### PR TITLE
Add P0 feature documentation and GitHub Pages deployment

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,56 @@
+name: Deploy Docs to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: docs
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: docs/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build (EN + KO)
+        run: |
+          npm run build
+          npm run build -- --locale ko --out-dir build/ko
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/build
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/content/api-reference/aerospikececluster.md
+++ b/docs/content/api-reference/aerospikececluster.md
@@ -52,6 +52,11 @@ Defines the desired state of an Aerospike CE cluster.
 | `paused` | *bool | No | `false` | Stop reconciliation when true. |
 | `seedsFinderServices` | [SeedsFinderServices](#seedsfinderservices) | No | — | LoadBalancer service for seed discovery. |
 | `k8sNodeBlockList` | []string | No | — | Node names to exclude from scheduling. |
+| `operations` | [][OperationSpec](#operationspec) | No | — | On-demand operations (WarmRestart, PodRestart). Max 1 at a time. |
+| `validationPolicy` | [ValidationPolicySpec](#validationpolicyspec) | No | — | Controls webhook validation behavior. |
+| `headlessService` | [AerospikeServiceSpec](#aerospikeservicespec) | No | — | Custom metadata for the headless service. |
+| `podService` | [AerospikeServiceSpec](#aerospikeservicespec) | No | — | Custom metadata for per-pod services. Creates individual Service per pod when set. |
+| `enableRackIDOverride` | *bool | No | `false` | Enable dynamic rack ID assignment via pod annotations. |
 
 ---
 
@@ -101,6 +106,7 @@ Observed state of the Aerospike CE cluster.
 | `observedGeneration` | int64 | Most recent generation observed by the controller. |
 | `selector` | string | Label selector string for HPA compatibility. |
 | `aerospikeConfig` | [AerospikeConfigSpec](#aerospikeconfigspec) | Last applied Aerospike configuration. |
+| `operationStatus` | [OperationStatus](#operationstatus) | Current on-demand operation status. |
 
 ---
 
@@ -293,6 +299,9 @@ Defines rack-aware deployment configuration.
 |---|---|---|---|
 | `racks` | [][Rack](#rack) | Yes | List of rack definitions (min 1). |
 | `namespaces` | []string | No | Aerospike namespace names that are rack-aware. |
+| `scaleDownBatchSize` | [IntOrString](https://pkg.go.dev/k8s.io/apimachinery/pkg/util/intstr#IntOrString) | No | Pods to scale down simultaneously per rack. Int or percent string (e.g., `"25%"`). Default: 1. |
+| `maxIgnorablePods` | [IntOrString](https://pkg.go.dev/k8s.io/apimachinery/pkg/util/intstr#IntOrString) | No | Max pending/failed pods to ignore during reconciliation. |
+| `rollingUpdateBatchSize` | [IntOrString](https://pkg.go.dev/k8s.io/apimachinery/pkg/util/intstr#IntOrString) | No | Pods to restart simultaneously per rack. Int or percent string. Takes precedence over `spec.rollingUpdateBatchSize`. |
 
 ---
 
@@ -306,6 +315,8 @@ Defines a single rack in the cluster topology.
 | `zone` | string | No | Zone label value (`topology.kubernetes.io/zone`). |
 | `region` | string | No | Region label value (`topology.kubernetes.io/region`). |
 | `nodeName` | string | No | Constrain to a specific node. |
+| `rackLabel` | string | No | Custom label for rack affinity. Schedules to nodes with `acko.io/rack=<rackLabel>`. Must be unique across racks. |
+| `revision` | string | No | Version identifier for controlled rack migrations. |
 | `aerospikeConfig` | [AerospikeConfigSpec](#aerospikeconfigspec) | No | Per-rack Aerospike config override. |
 | `storage` | [AerospikeStorageSpec](#aerospikestoragespec) | No | Per-rack storage override. |
 | `podSpec` | [RackPodSpec](#rackpodspec) | No | Per-rack pod scheduling override. |
@@ -415,3 +426,60 @@ Bandwidth annotations for CNI traffic shaping.
 |---|---|---|
 | `ingress` | string | Max ingress bandwidth (e.g., `1Gbps`, `500Mbps`). |
 | `egress` | string | Max egress bandwidth (e.g., `1Gbps`, `500Mbps`). |
+
+---
+
+## OperationSpec
+
+Defines an on-demand operation to trigger on cluster pods.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `kind` | string | Yes | Operation type: `WarmRestart` (SIGUSR1) or `PodRestart` (delete/recreate). |
+| `id` | string | Yes | Unique operation identifier (1-20 characters). |
+| `podList` | []string | No | Specific pod names to target. Empty means all pods. |
+
+---
+
+## OperationStatus
+
+Tracks the status of an on-demand operation.
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | string | Operation identifier. |
+| `kind` | string | Operation type: `WarmRestart` or `PodRestart`. |
+| `phase` | string | Operation phase: `InProgress`, `Completed`, or `Error`. |
+| `completedPods` | []string | Pods that have completed the operation. |
+| `failedPods` | []string | Pods where the operation failed. |
+
+---
+
+## ValidationPolicySpec
+
+Controls webhook validation behavior.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `skipWorkDirValidate` | bool | `false` | Skip validation that the Aerospike work directory is on persistent storage. |
+
+---
+
+## AerospikeServiceSpec
+
+Defines custom metadata for a Kubernetes Service.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `metadata` | [AerospikeObjectMeta](#aerospikeobjectmeta) | No | Custom annotations and labels for the service. |
+
+---
+
+## AerospikeObjectMeta
+
+Custom metadata for Kubernetes objects.
+
+| Field | Type | Description |
+|---|---|---|
+| `annotations` | map[string]string | Custom annotations. |
+| `labels` | map[string]string | Custom labels. |

--- a/docs/content/guide/create-cluster.md
+++ b/docs/content/guide/create-cluster.md
@@ -137,10 +137,19 @@ spec:
   rackConfig:
     namespaces:
       - testns              # Rack-aware namespace
+    rollingUpdateBatchSize: "50%"  # Restart 50% of pods per rack during rolling update
+    scaleDownBatchSize: 1          # Remove 1 pod per rack during scale-down
+    maxIgnorablePods: 1            # Continue reconciling if 1 pod is stuck
     racks:
       - id: 1
+        rackLabel: zone-a          # Schedule to nodes with acko.io/rack=zone-a
+        revision: "v1.0"
       - id: 2
+        rackLabel: zone-b
+        revision: "v1.0"
       - id: 3
+        rackLabel: zone-c
+        revision: "v1.0"
 
   podSpec:
     aerospikeContainer:
@@ -173,7 +182,7 @@ spec:
           filesize: 4294967296
 ```
 
-**Use case:** High availability across zones. Each rack ID creates a separate StatefulSet (`<name>-<rackID>`) and ConfigMap.
+**Use case:** High availability across zones with rack-label-based scheduling. Each rack ID creates a separate StatefulSet (`<name>-<rackID>`) and ConfigMap.
 
 ```bash
 kubectl apply -f config/samples/aerospike-ce-cluster-multirack.yaml
@@ -268,6 +277,13 @@ The validating webhook enforces Community Edition constraints:
 | Replication factor | must not exceed `spec.size` | `replication-factor N exceeds cluster size` |
 | Replication factor range | 1 to 4 | `must be between 1 and 4` |
 | Rack IDs | Must be unique | `duplicate rack ID` |
+| Rack labels | Must be unique across racks | `duplicate rackLabel` |
+| Operations | Max 1 active at a time | `only one operation allowed` |
+| Operation ID | 1-20 characters | `id must be between 1 and 20 characters` |
+| Operations (in-progress) | Cannot modify while InProgress | `cannot modify operations while InProgress` |
+| `scaleDownBatchSize` | Must be positive | `must be positive` |
+| `rollingUpdateBatchSize` (rackConfig) | Must be positive | `must be positive` |
+| `maxIgnorablePods` | Must be >= 0 | `must not be negative` |
 
 ### Enterprise-Only Namespace Keys
 

--- a/docs/content/guide/manage-cluster.md
+++ b/docs/content/guide/manage-cluster.md
@@ -43,6 +43,37 @@ spec:
   rollingUpdateBatchSize: 2   # Restart 2 pods at a time (default: 1)
 ```
 
+For rack-aware deployments, you can set batch size per rack in `rackConfig`. This takes precedence over `spec.rollingUpdateBatchSize`:
+
+```yaml
+spec:
+  rackConfig:
+    rollingUpdateBatchSize: "50%"   # Restart 50% of pods per rack simultaneously
+```
+
+### Scale Down Batch Size
+
+Control how many pods are removed simultaneously per rack during scale-down:
+
+```yaml
+spec:
+  rackConfig:
+    scaleDownBatchSize: 2            # Remove 2 pods per rack at a time
+    # scaleDownBatchSize: "25%"      # Or use percentage
+```
+
+### Max Ignorable Pods
+
+Allow reconciliation to continue even when some pods are in Pending/Failed state:
+
+```yaml
+spec:
+  rackConfig:
+    maxIgnorablePods: 1   # Ignore up to 1 stuck pod and continue reconciling
+```
+
+This is useful when pods are stuck due to scheduling issues and you don't want to block the entire reconciliation.
+
 ## Configuration Updates
 
 ### Static Configuration Changes
@@ -78,6 +109,111 @@ kubectl -n aerospike patch asce aerospike-ce-3node --type merge -p '{"spec":{"pa
 # Resume
 kubectl -n aerospike patch asce aerospike-ce-3node --type merge -p '{"spec":{"paused":null}}'
 ```
+
+## On-Demand Operations
+
+Trigger pod restarts declaratively via `spec.operations`. Only one operation can be active at a time.
+
+### WarmRestart
+
+Sends SIGUSR1 to the Aerospike process for a graceful restart without pod deletion:
+
+```yaml
+spec:
+  operations:
+    - kind: WarmRestart
+      id: "config-reload-v2"       # Unique ID (1-20 chars)
+      podList:                      # Optional: empty = all pods
+        - aerospike-ce-3node-0
+        - aerospike-ce-3node-1
+```
+
+### PodRestart
+
+Deletes and recreates pods (cold restart):
+
+```yaml
+spec:
+  operations:
+    - kind: PodRestart
+      id: "cold-restart-01"
+      podList:
+        - aerospike-ce-3node-2
+```
+
+### Checking Operation Status
+
+```bash
+kubectl -n aerospike get asce aerospike-ce-3node -o jsonpath='{.status.operationStatus}' | jq .
+```
+
+The status includes `phase` (`InProgress`, `Completed`, `Error`), `completedPods`, and `failedPods`.
+
+:::warning
+- Operations cannot be modified while InProgress
+- The operation `id` must be unique (1-20 characters)
+- Remove the operation from the spec after it completes
+:::
+
+## Service Customization
+
+### Headless Service Metadata
+
+Add custom annotations and labels to the headless service (used for pod discovery):
+
+```yaml
+spec:
+  headlessService:
+    metadata:
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8687"
+      labels:
+        monitoring: enabled
+```
+
+### Per-Pod Services
+
+When `podService` is set, the operator creates an individual ClusterIP Service for each pod, enabling direct pod-level access:
+
+```yaml
+spec:
+  podService:
+    metadata:
+      annotations:
+        external-dns.alpha.kubernetes.io/hostname: "aero.example.com"
+      labels:
+        service-type: pod-local
+```
+
+**Use case:** External DNS integration, pod-level load balancing, or direct client access to specific pods.
+
+## Validation Policy
+
+Control webhook validation behavior:
+
+```yaml
+spec:
+  validationPolicy:
+    skipWorkDirValidate: true   # Skip work directory PV validation
+```
+
+| Field | Default | Description |
+|---|---|---|
+| `skipWorkDirValidate` | `false` | Skip validation that work directory is on persistent storage |
+
+This is useful for development environments or in-memory deployments that don't require persistent work directories.
+
+## Rack ID Override
+
+Enable dynamic rack ID assignment via pod annotations:
+
+```yaml
+spec:
+  enableRackIDOverride: true
+```
+
+When enabled, the operator allows rack IDs to be overridden by pod annotations instead of being strictly managed by the operator. This is useful for manual rack management scenarios.
 
 ## Storage
 
@@ -210,6 +346,37 @@ spec:
     # Defaults applied automatically:
     #   multiPodPerHost: false
     #   dnsPolicy: ClusterFirstWithHostNet
+```
+
+## Rack Label Scheduling
+
+Use `rackLabel` to schedule pods to nodes with a specific label. The operator sets a node affinity for `acko.io/rack=<rackLabel>`:
+
+```yaml
+spec:
+  rackConfig:
+    racks:
+      - id: 1
+        rackLabel: zone-a    # Pods scheduled to nodes with acko.io/rack=zone-a
+      - id: 2
+        rackLabel: zone-b
+      - id: 3
+        rackLabel: zone-c
+```
+
+:::warning
+`rackLabel` values must be unique across racks.
+:::
+
+You can also attach a `revision` to each rack for controlled migrations:
+
+```yaml
+spec:
+  rackConfig:
+    racks:
+      - id: 1
+        rackLabel: zone-a
+        revision: "v1.0"     # Version identifier for migration tracking
 ```
 
 ## Node Scheduling

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/api-reference/aerospikececluster.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/api-reference/aerospikececluster.md
@@ -52,6 +52,11 @@ Aerospike CE 클러스터의 원하는 상태를 정의합니다.
 | `paused` | *bool | 아니요 | `false` | true이면 재조정 중지. |
 | `seedsFinderServices` | [SeedsFinderServices](#seedsfinderservices) | 아니요 | — | 시드 디스커버리용 LoadBalancer 서비스. |
 | `k8sNodeBlockList` | []string | 아니요 | — | 스케줄링에서 제외할 노드 이름. |
+| `operations` | [][OperationSpec](#operationspec) | 아니요 | — | 온디맨드 오퍼레이션 (WarmRestart, PodRestart). 동시에 최대 1개. |
+| `validationPolicy` | [ValidationPolicySpec](#validationpolicyspec) | 아니요 | — | 웹훅 검증 동작 제어. |
+| `headlessService` | [AerospikeServiceSpec](#aerospikeservicespec) | 아니요 | — | Headless 서비스 커스텀 메타데이터. |
+| `podService` | [AerospikeServiceSpec](#aerospikeservicespec) | 아니요 | — | Pod별 서비스 커스텀 메타데이터. 설정 시 파드마다 개별 Service 생성. |
+| `enableRackIDOverride` | *bool | 아니요 | `false` | 파드 어노테이션을 통한 동적 랙 ID 할당 활성화. |
 
 ---
 
@@ -101,6 +106,7 @@ Aerospike CE 클러스터의 관측된 상태입니다.
 | `observedGeneration` | int64 | 컨트롤러가 관측한 가장 최근 세대. |
 | `selector` | string | HPA 호환을 위한 레이블 셀렉터 문자열. |
 | `aerospikeConfig` | [AerospikeConfigSpec](#aerospikeconfigspec) | 마지막으로 적용된 Aerospike 설정. |
+| `operationStatus` | [OperationStatus](#operationstatus) | 현재 온디맨드 오퍼레이션 상태. |
 
 ---
 
@@ -293,6 +299,9 @@ Aerospike 서버 컨테이너를 커스터마이징합니다.
 |---|---|---|---|
 | `racks` | [][Rack](#rack) | 예 | 랙 정의 목록 (최소 1). |
 | `namespaces` | []string | 아니요 | 랙 인식 Aerospike 네임스페이스 이름. |
+| `scaleDownBatchSize` | [IntOrString](https://pkg.go.dev/k8s.io/apimachinery/pkg/util/intstr#IntOrString) | 아니요 | 랙당 동시 스케일 다운 파드 수. 정수 또는 퍼센트 문자열 (예: `"25%"`). 기본값: 1. |
+| `maxIgnorablePods` | [IntOrString](https://pkg.go.dev/k8s.io/apimachinery/pkg/util/intstr#IntOrString) | 아니요 | 재조정 중 무시할 수 있는 최대 Pending/Failed 파드 수. |
+| `rollingUpdateBatchSize` | [IntOrString](https://pkg.go.dev/k8s.io/apimachinery/pkg/util/intstr#IntOrString) | 아니요 | 랙당 동시 재시작 파드 수. 정수 또는 퍼센트 문자열. `spec.rollingUpdateBatchSize`보다 우선. |
 
 ---
 
@@ -306,6 +315,8 @@ Aerospike 서버 컨테이너를 커스터마이징합니다.
 | `zone` | string | 아니요 | 존 레이블 값 (`topology.kubernetes.io/zone`). |
 | `region` | string | 아니요 | 리전 레이블 값 (`topology.kubernetes.io/region`). |
 | `nodeName` | string | 아니요 | 특정 노드로 제한. |
+| `rackLabel` | string | 아니요 | 랙 어피니티용 커스텀 라벨. `acko.io/rack=<rackLabel>` 노드에 스케줄링. 랙 간 고유해야 함. |
+| `revision` | string | 아니요 | 제어된 랙 마이그레이션용 버전 식별자. |
 | `aerospikeConfig` | [AerospikeConfigSpec](#aerospikeconfigspec) | 아니요 | 랙별 Aerospike 설정 오버라이드. |
 | `storage` | [AerospikeStorageSpec](#aerospikestoragespec) | 아니요 | 랙별 스토리지 오버라이드. |
 | `podSpec` | [RackPodSpec](#rackpodspec) | 아니요 | 랙별 파드 스케줄링 오버라이드. |
@@ -415,3 +426,60 @@ CNI 트래픽 셰이핑을 위한 대역폭 어노테이션입니다.
 |---|---|---|
 | `ingress` | string | 최대 인그레스 대역폭 (예: `1Gbps`, `500Mbps`). |
 | `egress` | string | 최대 이그레스 대역폭 (예: `1Gbps`, `500Mbps`). |
+
+---
+
+## OperationSpec
+
+클러스터 파드에 대한 온디맨드 오퍼레이션을 정의합니다.
+
+| 필드 | 타입 | 필수 | 설명 |
+|---|---|---|---|
+| `kind` | string | 예 | 오퍼레이션 타입: `WarmRestart` (SIGUSR1) 또는 `PodRestart` (삭제/재생성). |
+| `id` | string | 예 | 고유 오퍼레이션 식별자 (1-20자). |
+| `podList` | []string | 아니요 | 대상 파드 이름 목록. 비우면 전체 파드 대상. |
+
+---
+
+## OperationStatus
+
+온디맨드 오퍼레이션의 상태를 추적합니다.
+
+| 필드 | 타입 | 설명 |
+|---|---|---|
+| `id` | string | 오퍼레이션 식별자. |
+| `kind` | string | 오퍼레이션 타입: `WarmRestart` 또는 `PodRestart`. |
+| `phase` | string | 오퍼레이션 단계: `InProgress`, `Completed`, 또는 `Error`. |
+| `completedPods` | []string | 오퍼레이션이 완료된 파드 목록. |
+| `failedPods` | []string | 오퍼레이션이 실패한 파드 목록. |
+
+---
+
+## ValidationPolicySpec
+
+웹훅 검증 동작을 제어합니다.
+
+| 필드 | 타입 | 기본값 | 설명 |
+|---|---|---|---|
+| `skipWorkDirValidate` | bool | `false` | Aerospike 작업 디렉토리가 영구 스토리지에 있는지 검증을 건너뜁니다. |
+
+---
+
+## AerospikeServiceSpec
+
+Kubernetes Service의 커스텀 메타데이터를 정의합니다.
+
+| 필드 | 타입 | 필수 | 설명 |
+|---|---|---|---|
+| `metadata` | [AerospikeObjectMeta](#aerospikeobjectmeta) | 아니요 | 서비스의 커스텀 어노테이션 및 레이블. |
+
+---
+
+## AerospikeObjectMeta
+
+Kubernetes 객체의 커스텀 메타데이터입니다.
+
+| 필드 | 타입 | 설명 |
+|---|---|---|
+| `annotations` | map[string]string | 커스텀 어노테이션. |
+| `labels` | map[string]string | 커스텀 레이블. |

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/guide/create-cluster.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/guide/create-cluster.md
@@ -137,10 +137,19 @@ spec:
   rackConfig:
     namespaces:
       - testns              # 랙 인식 네임스페이스
+    rollingUpdateBatchSize: "50%"  # 롤링 업데이트 시 랙당 50% 파드 동시 재시작
+    scaleDownBatchSize: 1          # 스케일 다운 시 랙당 1개 파드 제거
+    maxIgnorablePods: 1            # 멈춘 파드 1개까지 무시하고 계속 진행
     racks:
       - id: 1
+        rackLabel: zone-a          # acko.io/rack=zone-a 노드에 스케줄링
+        revision: "v1.0"
       - id: 2
+        rackLabel: zone-b
+        revision: "v1.0"
       - id: 3
+        rackLabel: zone-c
+        revision: "v1.0"
 
   podSpec:
     aerospikeContainer:
@@ -173,7 +182,7 @@ spec:
           filesize: 4294967296
 ```
 
-**사용 사례:** 존 간 고가용성. 각 랙 ID는 별도의 StatefulSet(`<이름>-<랙ID>`)과 ConfigMap을 생성합니다.
+**사용 사례:** 랙 라벨 기반 스케줄링을 활용한 존 간 고가용성. 각 랙 ID는 별도의 StatefulSet(`<이름>-<랙ID>`)과 ConfigMap을 생성합니다.
 
 ```bash
 kubectl apply -f config/samples/aerospike-ce-cluster-multirack.yaml
@@ -268,6 +277,13 @@ validating 웹훅은 Community Edition 제약 조건을 적용합니다:
 | 복제 팩터 | `spec.size` 이하 | `replication-factor N exceeds cluster size` |
 | 복제 팩터 범위 | 1~4 | `must be between 1 and 4` |
 | 랙 ID | 고유해야 함 | `duplicate rack ID` |
+| 랙 라벨 | 랙 간 고유해야 함 | `duplicate rackLabel` |
+| 오퍼레이션 | 동시에 최대 1개 | `only one operation allowed` |
+| 오퍼레이션 ID | 1-20자 | `id must be between 1 and 20 characters` |
+| 오퍼레이션 (진행 중) | InProgress 중 변경 불가 | `cannot modify operations while InProgress` |
+| `scaleDownBatchSize` | 양수여야 함 | `must be positive` |
+| `rollingUpdateBatchSize` (rackConfig) | 양수여야 함 | `must be positive` |
+| `maxIgnorablePods` | 0 이상이어야 함 | `must not be negative` |
 
 ### Enterprise 전용 네임스페이스 키
 

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/guide/manage-cluster.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/guide/manage-cluster.md
@@ -43,6 +43,37 @@ spec:
   rollingUpdateBatchSize: 2   # 한 번에 2개 파드 재시작 (기본값: 1)
 ```
 
+랙 인식 배포의 경우, `rackConfig`에서 랙별 배치 크기를 설정할 수 있습니다. 이 값은 `spec.rollingUpdateBatchSize`보다 우선합니다:
+
+```yaml
+spec:
+  rackConfig:
+    rollingUpdateBatchSize: "50%"   # 랙당 파드의 50%를 동시에 재시작
+```
+
+### 스케일 다운 배치 크기
+
+스케일 다운 시 랙당 동시에 제거하는 파드 수를 제어합니다:
+
+```yaml
+spec:
+  rackConfig:
+    scaleDownBatchSize: 2            # 랙당 한 번에 2개 파드 제거
+    # scaleDownBatchSize: "25%"      # 퍼센트도 사용 가능
+```
+
+### 무시 가능한 파드 수
+
+일부 파드가 Pending/Failed 상태일 때도 재조정을 계속 진행할 수 있습니다:
+
+```yaml
+spec:
+  rackConfig:
+    maxIgnorablePods: 1   # 멈춘 파드 1개까지 무시하고 재조정 계속
+```
+
+스케줄링 문제로 파드가 멈췄을 때 전체 재조정이 차단되지 않도록 하는 데 유용합니다.
+
 ## 설정 변경
 
 ### 정적 설정 변경
@@ -78,6 +109,111 @@ kubectl -n aerospike patch asce aerospike-ce-3node --type merge -p '{"spec":{"pa
 # 재개
 kubectl -n aerospike patch asce aerospike-ce-3node --type merge -p '{"spec":{"paused":null}}'
 ```
+
+## 온디맨드 오퍼레이션
+
+`spec.operations`를 통해 파드 재시작을 선언적으로 트리거합니다. 한 번에 하나의 오퍼레이션만 활성화할 수 있습니다.
+
+### WarmRestart
+
+Aerospike 프로세스에 SIGUSR1을 보내 파드 삭제 없이 graceful restart합니다:
+
+```yaml
+spec:
+  operations:
+    - kind: WarmRestart
+      id: "config-reload-v2"       # 고유 ID (1-20자)
+      podList:                      # 선택사항: 비우면 전체 파드 대상
+        - aerospike-ce-3node-0
+        - aerospike-ce-3node-1
+```
+
+### PodRestart
+
+파드를 삭제하고 재생성합니다 (cold restart):
+
+```yaml
+spec:
+  operations:
+    - kind: PodRestart
+      id: "cold-restart-01"
+      podList:
+        - aerospike-ce-3node-2
+```
+
+### 오퍼레이션 상태 확인
+
+```bash
+kubectl -n aerospike get asce aerospike-ce-3node -o jsonpath='{.status.operationStatus}' | jq .
+```
+
+상태에는 `phase` (`InProgress`, `Completed`, `Error`), `completedPods`, `failedPods`가 포함됩니다.
+
+:::warning
+- InProgress 중에는 오퍼레이션을 변경할 수 없습니다
+- 오퍼레이션 `id`는 고유해야 합니다 (1-20자)
+- 완료 후 spec에서 오퍼레이션을 제거하세요
+:::
+
+## 서비스 커스터마이징
+
+### Headless 서비스 메타데이터
+
+Headless 서비스(파드 디스커버리용)에 커스텀 어노테이션과 레이블을 추가합니다:
+
+```yaml
+spec:
+  headlessService:
+    metadata:
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8687"
+      labels:
+        monitoring: enabled
+```
+
+### Pod별 서비스
+
+`podService`를 설정하면 오퍼레이터가 각 파드에 대해 개별 ClusterIP Service를 생성하여 직접적인 파드 레벨 접근을 가능하게 합니다:
+
+```yaml
+spec:
+  podService:
+    metadata:
+      annotations:
+        external-dns.alpha.kubernetes.io/hostname: "aero.example.com"
+      labels:
+        service-type: pod-local
+```
+
+**사용 사례:** 외부 DNS 연동, 파드 레벨 로드밸런싱, 특정 파드에 대한 직접 클라이언트 접근.
+
+## 검증 정책
+
+웹훅 검증 동작을 제어합니다:
+
+```yaml
+spec:
+  validationPolicy:
+    skipWorkDirValidate: true   # 작업 디렉토리 PV 검증 건너뛰기
+```
+
+| 필드 | 기본값 | 설명 |
+|---|---|---|
+| `skipWorkDirValidate` | `false` | 작업 디렉토리가 영구 스토리지에 있는지 검증을 건너뜁니다 |
+
+개발 환경이나 영구 작업 디렉토리가 필요 없는 인메모리 배포에 유용합니다.
+
+## 랙 ID 오버라이드
+
+파드 어노테이션을 통한 동적 랙 ID 할당을 활성화합니다:
+
+```yaml
+spec:
+  enableRackIDOverride: true
+```
+
+활성화하면 오퍼레이터가 엄격하게 관리하는 대신 파드 어노테이션으로 랙 ID를 오버라이드할 수 있습니다. 수동 랙 관리 시나리오에 유용합니다.
 
 ## 스토리지
 
@@ -210,6 +346,37 @@ spec:
     # 자동으로 적용되는 기본값:
     #   multiPodPerHost: false
     #   dnsPolicy: ClusterFirstWithHostNet
+```
+
+## 랙 라벨 스케줄링
+
+`rackLabel`을 사용하여 특정 라벨이 있는 노드에 파드를 스케줄링합니다. 오퍼레이터가 `acko.io/rack=<rackLabel>`에 대한 노드 어피니티를 설정합니다:
+
+```yaml
+spec:
+  rackConfig:
+    racks:
+      - id: 1
+        rackLabel: zone-a    # acko.io/rack=zone-a 노드에 스케줄링
+      - id: 2
+        rackLabel: zone-b
+      - id: 3
+        rackLabel: zone-c
+```
+
+:::warning
+`rackLabel` 값은 랙 간에 고유해야 합니다.
+:::
+
+제어된 마이그레이션을 위해 각 랙에 `revision`을 부여할 수도 있습니다:
+
+```yaml
+spec:
+  rackConfig:
+    racks:
+      - id: 1
+        rackLabel: zone-a
+        revision: "v1.0"     # 마이그레이션 추적용 버전 식별자
 ```
 
 ## 노드 스케줄링


### PR DESCRIPTION
## Summary
- Document all P0 features from PR #7 in both EN and KO docs: on-demand operations (WarmRestart/PodRestart), RackConfig enhancements (scaleDownBatchSize, maxIgnorablePods, rollingUpdateBatchSize, rackLabel, revision), service customization (headlessService/podService), ValidationPolicy, and enableRackIDOverride
- Update API reference with 5 new types (OperationSpec, OperationStatus, ValidationPolicySpec, AerospikeServiceSpec, AerospikeObjectMeta) and new fields on existing types (RackConfig, Rack, AerospikeCEClusterSpec, AerospikeCEClusterStatus)
- Add new CE validation rules for operations, rackLabel, and batch size fields
- Add `docs.yaml` GitHub Action for automatic Docusaurus deployment to GitHub Pages on push to `main` (with `workflow_dispatch` support)

## Test plan
- [x] Docusaurus build passes for both EN and KO locales (no broken links)
- [ ] E2E tests pass (requires Kind cluster)