### PR TITLE
improve: fix Helm chart QA issues (security, TLS, PrometheusRule, PDB, NetworkPolicy)

### DIFF
--- a/charts/aerospike-operator/templates/_helpers.tpl
+++ b/charts/aerospike-operator/templates/_helpers.tpl
@@ -177,5 +177,5 @@ UI service account name.
 UI container image with tag.
 */}}
 {{- define "aerospike-operator.ui.image" -}}
-{{- printf "%s:%s" .Values.ui.image.repository (default "latest" .Values.ui.image.tag) }}
+{{- printf "%s:%s" .Values.ui.image.repository (default .Chart.AppVersion .Values.ui.image.tag) }}
 {{- end }}

--- a/charts/aerospike-operator/templates/networkpolicy.yaml
+++ b/charts/aerospike-operator/templates/networkpolicy.yaml
@@ -12,6 +12,7 @@ spec:
       {{- include "aerospike-operator.selectorLabels" . | nindent 6 }}
   policyTypes:
     - Ingress
+    - Egress
   ingress:
     - from:
         - namespaceSelector:
@@ -29,4 +30,21 @@ spec:
         - port: {{ .Values.webhook.port }}
           protocol: TCP
     {{- end }}
+  egress:
+    # DNS resolution
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    # Kubernetes API server
+    - ports:
+        - port: 443
+          protocol: TCP
+        - port: 6443
+          protocol: TCP
 {{- end }}

--- a/charts/aerospike-operator/templates/prometheusrule.yaml
+++ b/charts/aerospike-operator/templates/prometheusrule.yaml
@@ -59,7 +59,7 @@ spec:
         # -- Operator high memory usage
         - alert: AerospikeOperatorHighMemory
           expr: |
-            container_memory_working_set_bytes{container="manager", pod=~".*aerospike-operator.*"} > 256 * 1024 * 1024
+            container_memory_working_set_bytes{container="manager", pod=~"{{ include "aerospike-operator.fullname" . }}.*"} > 256 * 1024 * 1024
           for: 10m
           labels:
             severity: warning
@@ -69,7 +69,7 @@ spec:
         # -- Operator pod restarts
         - alert: AerospikeOperatorPodRestarts
           expr: |
-            increase(kube_pod_container_status_restarts_total{container="manager", pod=~".*aerospike-operator.*"}[1h]) > 3
+            increase(kube_pod_container_status_restarts_total{container="manager", pod=~"{{ include "aerospike-operator.fullname" . }}.*"}[1h]) > 3
           for: 5m
           labels:
             severity: warning

--- a/charts/aerospike-operator/templates/service-webhook.yaml
+++ b/charts/aerospike-operator/templates/service-webhook.yaml
@@ -8,7 +8,8 @@ metadata:
     {{- include "aerospike-operator.labels" . | nindent 4 }}
 spec:
   ports:
-    - port: 443
+    - name: webhook
+      port: 443
       protocol: TCP
       targetPort: {{ .Values.webhook.port }}
   selector:

--- a/charts/aerospike-operator/templates/ui/deployment.yaml
+++ b/charts/aerospike-operator/templates/ui/deployment.yaml
@@ -36,17 +36,9 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.ui.postgresql.enabled }}
-      securityContext:
-        {{- with .Values.ui.podSecurityContext.seccompProfile }}
-        seccompProfile:
-          {{- toYaml . | nindent 10 }}
-        {{- end }}
-      {{- else }}
       {{- with .Values.ui.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
-      {{- end }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.ui.terminationGracePeriodSeconds | default 45 }}
       containers:

--- a/charts/aerospike-operator/templates/ui/ingress.yaml
+++ b/charts/aerospike-operator/templates/ui/ingress.yaml
@@ -14,9 +14,9 @@ spec:
   {{- if .Values.ui.ingress.className }}
   ingressClassName: {{ .Values.ui.ingress.className }}
   {{- end }}
-  {{- if .Values.ui.ingress.tls }}
+  {{- with .Values.ui.ingress.tls }}
   tls:
-    {{- range .Values.ui.ingress.tls }}
+    {{- range . }}
     - hosts:
         {{- range .hosts }}
         - {{ . | quote }}

--- a/charts/aerospike-operator/templates/ui/pdb.yaml
+++ b/charts/aerospike-operator/templates/ui/pdb.yaml
@@ -1,5 +1,4 @@
 {{- if and .Values.ui.enabled .Values.ui.podDisruptionBudget.enabled }}
-{{- if or .Values.ui.podDisruptionBudget.minAvailable .Values.ui.podDisruptionBudget.maxUnavailable }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -8,14 +7,12 @@ metadata:
   labels:
     {{- include "aerospike-operator.ui.labels" . | nindent 4 }}
 spec:
-  {{- if .Values.ui.podDisruptionBudget.minAvailable }}
-  minAvailable: {{ .Values.ui.podDisruptionBudget.minAvailable }}
-  {{- end }}
   {{- if .Values.ui.podDisruptionBudget.maxUnavailable }}
   maxUnavailable: {{ .Values.ui.podDisruptionBudget.maxUnavailable }}
+  {{- else }}
+  minAvailable: {{ .Values.ui.podDisruptionBudget.minAvailable }}
   {{- end }}
   selector:
     matchLabels:
       {{- include "aerospike-operator.ui.selectorLabels" . | nindent 6 }}
-{{- end }}
 {{- end }}

--- a/charts/aerospike-operator/values.yaml
+++ b/charts/aerospike-operator/values.yaml
@@ -241,8 +241,8 @@ ui:
   image:
     # -- Container image repository
     repository: ghcr.io/kimsoungryoul/aerospike-cluster-manager
-    # -- Container image tag
-    tag: latest
+    # -- Container image tag; defaults to Chart.appVersion when empty
+    tag: ""
     # -- Image pull policy
     pullPolicy: IfNotPresent
 
@@ -453,8 +453,9 @@ ui:
     # -- Enable PodDisruptionBudget for UI pods
     enabled: false
     # -- Minimum number of pods that must remain available (mutually exclusive with maxUnavailable)
-    # minAvailable: 1
-    # -- Maximum number of pods that can be unavailable (mutually exclusive with minAvailable)
+    minAvailable: 1
+    # -- Maximum number of pods that can be unavailable (mutually exclusive with minAvailable).
+    # Uncomment and remove minAvailable to use.
     # maxUnavailable: 1
 
   # =============================================================================


### PR DESCRIPTION
## Summary

QA 에이전트 팀을 통해 Helm 차트(`charts/aerospike-operator/`)의 버그 및 개선점을 탐색하고 수정했습니다.

### CRITICAL Fixes
- **UI deployment podSecurityContext 복원**: PostgreSQL 사이드카 활성화 시 `runAsNonRoot`, `runAsUser`, `fsGroup`이 누락되던 보안 버그 수정
  
### HIGH Priority Fixes
- **Ingress TLS 렌더링 버그**: 빈 배열 `tls: []`이 Go 템플릿에서 truthy로 평가되어 빈 `tls:` 블록이 생성되던 문제 수정 (`if` → `with`)
- **PrometheusRule pod 이름 패턴**: 하드코딩된 `pod=~".*aerospike-operator.*"`를 `{{ include "aerospike-operator.fullname" . }}.*`로 변경하여 `fullnameOverride` 지원
- **UI image tag default**: `"latest"` → `Chart.AppVersion`으로 변경하여 프로덕션 안정성 확보
- **Webhook service port name**: `name: webhook` 추가 (서비스 메시 호환성)
- **UI PDB 템플릿 단순화**: double-guard 제거, `minAvailable: 1` 기본값 추가

### MEDIUM Priority Fixes
- **Operator NetworkPolicy egress 규칙**: DNS 및 kube-apiserver 접근을 위한 egress 규칙 추가 (CiliumNetworkPolicy와 기능 동등성 확보)

### False Positive (수정하지 않음)
- CiliumNetworkPolicy `k8s:io.kubernetes.pod.namespace` 라벨: Cilium 공식 문서에 따르면 올바른 문법

## 변경 파일
- `charts/aerospike-operator/templates/ui/deployment.yaml` — podSecurityContext 복원
- `charts/aerospike-operator/templates/ui/ingress.yaml` — TLS 조건 수정
- `charts/aerospike-operator/templates/ui/pdb.yaml` — 템플릿 단순화
- `charts/aerospike-operator/templates/prometheusrule.yaml` — pod 이름 패턴 템플릿화
- `charts/aerospike-operator/templates/service-webhook.yaml` — port name 추가
- `charts/aerospike-operator/templates/networkpolicy.yaml` — egress 규칙 추가
- `charts/aerospike-operator/templates/_helpers.tpl` — UI image tag default 변경
- `charts/aerospike-operator/values.yaml` — UI image tag, PDB minAvailable 기본값

## Test plan
- [x] `helm lint charts/aerospike-operator/` — 통과
- [x] `helm lint charts/aerospike-operator/ --set ui.enabled=true` — 통과
- [x] `helm template` with `ui.enabled=true` 렌더링 검증
- [x] `fullnameOverride=custom-operator`로 PrometheusRule 패턴 검증
- [x] 빈 `tls: []`에서 TLS 블록 미렌더링 확인
- [x] PDB `minAvailable: 1` 기본 렌더링 확인