### PR TITLE
improve: fix nil pointer dereferences and enhance validation safety

### DIFF
--- a/api/v1alpha1/types_rack.go
+++ b/api/v1alpha1/types_rack.go
@@ -128,6 +128,7 @@ type AerospikeAccessControlSpec struct {
 type AerospikeRoleSpec struct {
 	// Name is the role name.
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MinLength=1
 	Name string `json:"name"`
 
 	// Privileges is a list of privilege strings (e.g., "read-write", "sys-admin").
@@ -143,11 +144,13 @@ type AerospikeRoleSpec struct {
 type AerospikeUserSpec struct {
 	// Name is the username.
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MinLength=1
 	Name string `json:"name"`
 
 	// SecretName is the Kubernetes Secret containing the user's password.
 	// The secret must have a "password" key.
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MinLength=1
 	SecretName string `json:"secretName"`
 
 	// Roles is a list of role names assigned to this user.

--- a/config/crd/bases/acko.io_aerospikececlusters.yaml
+++ b/config/crd/bases/acko.io_aerospikececlusters.yaml
@@ -91,6 +91,7 @@ spec:
                       properties:
                         name:
                           description: Name is the role name.
+                          minLength: 1
                           type: string
                         privileges:
                           description: Privileges is a list of privilege strings (e.g.,
@@ -117,6 +118,7 @@ spec:
                       properties:
                         name:
                           description: Name is the username.
+                          minLength: 1
                           type: string
                         roles:
                           description: Roles is a list of role names assigned to this
@@ -129,6 +131,7 @@ spec:
                           description: |-
                             SecretName is the Kubernetes Secret containing the user's password.
                             The secret must have a "password" key.
+                          minLength: 1
                           type: string
                       required:
                       - name
@@ -8231,6 +8234,7 @@ spec:
                           properties:
                             name:
                               description: Name is the role name.
+                              minLength: 1
                               type: string
                             privileges:
                               description: Privileges is a list of privilege strings
@@ -8257,6 +8261,7 @@ spec:
                           properties:
                             name:
                               description: Name is the username.
+                              minLength: 1
                               type: string
                             roles:
                               description: Roles is a list of role names assigned
@@ -8269,6 +8274,7 @@ spec:
                               description: |-
                                 SecretName is the Kubernetes Secret containing the user's password.
                                 The secret must have a "password" key.
+                              minLength: 1
                               type: string
                           required:
                           - name

--- a/internal/controller/reconciler_operations.go
+++ b/internal/controller/reconciler_operations.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -115,6 +116,10 @@ func (r *AerospikeCEClusterReconciler) reconcileOperations(
 	}
 	latest.Status.OperationStatus = opStatus
 	if err := r.Status().Update(ctx, latest); err != nil {
+		if errors.IsConflict(err) {
+			log.V(1).Info("Conflict updating operation status, will requeue", "operation", op.ID)
+			return true, nil
+		}
 		return !allDone, err
 	}
 

--- a/internal/controller/reconciler_pod_service.go
+++ b/internal/controller/reconciler_pod_service.go
@@ -145,7 +145,13 @@ func (r *AerospikeCEClusterReconciler) cleanupStalePodServices(
 
 	for i := range svcList.Items {
 		svc := &svcList.Items[i]
+		if svc.Labels == nil {
+			continue
+		}
 		podName := svc.Labels[podServiceLabel]
+		if podName == "" {
+			continue
+		}
 		if _, active := activePodNames[podName]; !active {
 			log.Info("Deleting stale pod service", "name", svc.Name, "pod", podName)
 			if err := r.Delete(ctx, svc); err != nil && !errors.IsNotFound(err) {

--- a/internal/controller/reconciler_statefulset.go
+++ b/internal/controller/reconciler_statefulset.go
@@ -82,11 +82,14 @@ func (r *AerospikeCEClusterReconciler) reconcileStatefulSet(
 		oldReplicas = *existing.Spec.Replicas
 	}
 	needsUpdate := oldReplicas != rackSize
-	existingHash := existing.Spec.Template.Annotations[utils.ConfigHashAnnotation]
+	var existingHash, existingPodSpecHash string
+	if existing.Spec.Template.Annotations != nil {
+		existingHash = existing.Spec.Template.Annotations[utils.ConfigHashAnnotation]
+		existingPodSpecHash = existing.Spec.Template.Annotations[utils.PodSpecHashAnnotation]
+	}
 	if existingHash != hash {
 		needsUpdate = true
 	}
-	existingPodSpecHash := existing.Spec.Template.Annotations[utils.PodSpecHashAnnotation]
 	if existingPodSpecHash != podSpecHash {
 		needsUpdate = true
 	}
@@ -239,7 +242,7 @@ func (r *AerospikeCEClusterReconciler) detectScaling(
 	rackSizes []int32,
 ) (scalingUp bool, scalingDown bool, err error) {
 	for i, rack := range racks {
-		stsName := cluster.Name + "-" + fmt.Sprintf("%d", rack.ID)
+		stsName := utils.StatefulSetName(cluster.Name, rack.ID)
 		existing := &appsv1.StatefulSet{}
 		if err := r.Get(ctx, types.NamespacedName{Name: stsName, Namespace: cluster.Namespace}, existing); err != nil {
 			if errors.IsNotFound(err) {

--- a/internal/template/resolver.go
+++ b/internal/template/resolver.go
@@ -162,6 +162,9 @@ func Resolve(
 	}
 
 	// Build effective template spec: snapshot base + overrides.
+	if cluster.Status.TemplateSnapshot == nil || cluster.Status.TemplateSnapshot.Spec == nil {
+		return result, fmt.Errorf("template snapshot is missing or has no spec; cannot resolve template %q", cluster.Spec.TemplateRef.Name)
+	}
 	snapshotSpec := cluster.Status.TemplateSnapshot.Spec
 	effectiveSpec := MergeTemplateSpec(snapshotSpec, cluster.Spec.Overrides)
 


### PR DESCRIPTION
## Summary

- **Fix potential nil dereference in StatefulSet annotation access** (`reconciler_statefulset.go:85,89`): `existing.Spec.Template.Annotations` 접근 시 nil 체크 추가. 외부에서 생성되거나 annotations가 제거된 StatefulSet에서 panic 방지
- **Fix potential nil dereference in template snapshot resolution** (`resolver.go:165`): `TemplateSnapshot` 또는 `TemplateSnapshot.Spec`가 nil일 때 crash 대신 명확한 에러 반환
- **Add defensive nil/empty checks in pod service cleanup** (`reconciler_pod_service.go:148`): labels가 없거나 pod service label이 비어있는 Service 안전하게 skip
- **Add IsConflict handling in operation status update** (`reconciler_operations.go:117`): 다른 status update 패턴과 일관되게 conflict 에러 시 requeue 처리
- **Use `utils.StatefulSetName()` consistently** (`reconciler_statefulset.go:242`): `detectScaling`에서 수동 문자열 조합 대신 유틸리티 함수 사용
- **Add MinLength=1 validation markers** (`types_rack.go`): `AerospikeRoleSpec.Name`, `AerospikeUserSpec.Name`, `AerospikeUserSpec.SecretName`에 빈 문자열 검증 추가

## Test plan
- [x] `make manifests` — CRD 재생성 확인 (minLength: 1 반영)
- [x] `make build` — 컴파일 성공
- [x] `make test` — 전체 unit + integration 테스트 통과