### PR TITLE
improve: ACL error handling, event recording, docs fixes, and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ spec:
         replication-factor: 1
         storage-engine:
           type: memory
-          data-size: 1073741824
+          memory-size: 1073741824
 ```
 
 ### Step 5: Verify

--- a/api/v1alpha1/aerospikececlustertemplate_webhook_test.go
+++ b/api/v1alpha1/aerospikececlustertemplate_webhook_test.go
@@ -1,0 +1,691 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// --- Defaulter tests ---
+
+func TestAerospikeCEClusterTemplateDefault(t *testing.T) {
+	tests := []struct {
+		name   string
+		tmpl   *AerospikeCEClusterTemplate
+		verify func(t *testing.T, tmpl *AerospikeCEClusterTemplate)
+	}{
+		{
+			name: "empty podAntiAffinityLevel defaults to preferred",
+			tmpl: &AerospikeCEClusterTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+				Spec: AerospikeCEClusterTemplateSpec{
+					Scheduling: &TemplateScheduling{
+						PodAntiAffinityLevel: "",
+					},
+				},
+			},
+			verify: func(t *testing.T, tmpl *AerospikeCEClusterTemplate) {
+				if tmpl.Spec.Scheduling.PodAntiAffinityLevel != PodAntiAffinityPreferred {
+					t.Errorf("PodAntiAffinityLevel = %q, want %q",
+						tmpl.Spec.Scheduling.PodAntiAffinityLevel, PodAntiAffinityPreferred)
+				}
+			},
+		},
+		{
+			name: "empty volumeMode defaults to Filesystem",
+			tmpl: &AerospikeCEClusterTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+				Spec: AerospikeCEClusterTemplateSpec{
+					Storage: &TemplateStorage{
+						StorageClassName: "standard",
+					},
+				},
+			},
+			verify: func(t *testing.T, tmpl *AerospikeCEClusterTemplate) {
+				if tmpl.Spec.Storage.VolumeMode != corev1.PersistentVolumeFilesystem {
+					t.Errorf("VolumeMode = %q, want %q",
+						tmpl.Spec.Storage.VolumeMode, corev1.PersistentVolumeFilesystem)
+				}
+			},
+		},
+		{
+			name: "empty accessModes defaults to ReadWriteOnce",
+			tmpl: &AerospikeCEClusterTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+				Spec: AerospikeCEClusterTemplateSpec{
+					Storage: &TemplateStorage{
+						StorageClassName: "standard",
+					},
+				},
+			},
+			verify: func(t *testing.T, tmpl *AerospikeCEClusterTemplate) {
+				if len(tmpl.Spec.Storage.AccessModes) != 1 {
+					t.Fatalf("AccessModes length = %d, want 1", len(tmpl.Spec.Storage.AccessModes))
+				}
+				if tmpl.Spec.Storage.AccessModes[0] != corev1.ReadWriteOnce {
+					t.Errorf("AccessModes[0] = %q, want %q",
+						tmpl.Spec.Storage.AccessModes[0], corev1.ReadWriteOnce)
+				}
+			},
+		},
+		{
+			name: "nil scheduling and nil storage does not panic",
+			tmpl: &AerospikeCEClusterTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+				Spec:       AerospikeCEClusterTemplateSpec{},
+			},
+			verify: func(t *testing.T, tmpl *AerospikeCEClusterTemplate) {
+				if tmpl.Spec.Scheduling != nil {
+					t.Error("Scheduling should remain nil")
+				}
+				if tmpl.Spec.Storage != nil {
+					t.Error("Storage should remain nil")
+				}
+			},
+		},
+		{
+			name: "pre-set podAntiAffinityLevel is not overwritten",
+			tmpl: &AerospikeCEClusterTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+				Spec: AerospikeCEClusterTemplateSpec{
+					Scheduling: &TemplateScheduling{
+						PodAntiAffinityLevel: PodAntiAffinityRequired,
+					},
+				},
+			},
+			verify: func(t *testing.T, tmpl *AerospikeCEClusterTemplate) {
+				if tmpl.Spec.Scheduling.PodAntiAffinityLevel != PodAntiAffinityRequired {
+					t.Errorf("PodAntiAffinityLevel = %q, want %q (should not be overwritten)",
+						tmpl.Spec.Scheduling.PodAntiAffinityLevel, PodAntiAffinityRequired)
+				}
+			},
+		},
+		{
+			name: "pre-set volumeMode is not overwritten",
+			tmpl: &AerospikeCEClusterTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+				Spec: AerospikeCEClusterTemplateSpec{
+					Storage: &TemplateStorage{
+						VolumeMode: corev1.PersistentVolumeBlock,
+					},
+				},
+			},
+			verify: func(t *testing.T, tmpl *AerospikeCEClusterTemplate) {
+				if tmpl.Spec.Storage.VolumeMode != corev1.PersistentVolumeBlock {
+					t.Errorf("VolumeMode = %q, want %q (should not be overwritten)",
+						tmpl.Spec.Storage.VolumeMode, corev1.PersistentVolumeBlock)
+				}
+			},
+		},
+		{
+			name: "pre-set accessModes are not overwritten",
+			tmpl: &AerospikeCEClusterTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+				Spec: AerospikeCEClusterTemplateSpec{
+					Storage: &TemplateStorage{
+						AccessModes: []corev1.PersistentVolumeAccessMode{
+							corev1.ReadWriteMany,
+						},
+					},
+				},
+			},
+			verify: func(t *testing.T, tmpl *AerospikeCEClusterTemplate) {
+				if len(tmpl.Spec.Storage.AccessModes) != 1 {
+					t.Fatalf("AccessModes length = %d, want 1", len(tmpl.Spec.Storage.AccessModes))
+				}
+				if tmpl.Spec.Storage.AccessModes[0] != corev1.ReadWriteMany {
+					t.Errorf("AccessModes[0] = %q, want %q (should not be overwritten)",
+						tmpl.Spec.Storage.AccessModes[0], corev1.ReadWriteMany)
+				}
+			},
+		},
+	}
+
+	d := &AerospikeCEClusterTemplateDefaulter{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := d.Default(context.Background(), tt.tmpl); err != nil {
+				t.Fatalf("Default() unexpected error: %v", err)
+			}
+			tt.verify(t, tt.tmpl)
+		})
+	}
+}
+
+// --- Validator tests ---
+
+func TestAerospikeCEClusterTemplateValidate(t *testing.T) {
+	tests := []struct {
+		name        string
+		tmpl        *AerospikeCEClusterTemplate
+		wantErr     bool
+		errContains string
+		wantWarning string
+	}{
+		{
+			name: "valid minimal template passes",
+			tmpl: &AerospikeCEClusterTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: "minimal", Namespace: "default"},
+				Spec:       AerospikeCEClusterTemplateSpec{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty spec passes (all optional)",
+			tmpl: &AerospikeCEClusterTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: "empty", Namespace: "default"},
+				Spec:       AerospikeCEClusterTemplateSpec{},
+			},
+			wantErr: false,
+		},
+		// V-T01: podAntiAffinityLevel validation
+		{
+			name: "V-T01: invalid podAntiAffinityLevel is rejected",
+			tmpl: &AerospikeCEClusterTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: "bad-level", Namespace: "default"},
+				Spec: AerospikeCEClusterTemplateSpec{
+					Scheduling: &TemplateScheduling{
+						PodAntiAffinityLevel: "hard",
+					},
+				},
+			},
+			wantErr:     true,
+			errContains: "podAntiAffinityLevel",
+		},
+		{
+			name: "V-T01: podAntiAffinityLevel=none passes",
+			tmpl: &AerospikeCEClusterTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: "level-none", Namespace: "default"},
+				Spec: AerospikeCEClusterTemplateSpec{
+					Scheduling: &TemplateScheduling{
+						PodAntiAffinityLevel: PodAntiAffinityNone,
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "V-T01: podAntiAffinityLevel=preferred passes",
+			tmpl: &AerospikeCEClusterTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: "level-preferred", Namespace: "default"},
+				Spec: AerospikeCEClusterTemplateSpec{
+					Scheduling: &TemplateScheduling{
+						PodAntiAffinityLevel: PodAntiAffinityPreferred,
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "V-T01: podAntiAffinityLevel=required passes",
+			tmpl: &AerospikeCEClusterTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: "level-required", Namespace: "default"},
+				Spec: AerospikeCEClusterTemplateSpec{
+					Scheduling: &TemplateScheduling{
+						PodAntiAffinityLevel: PodAntiAffinityRequired,
+					},
+				},
+			},
+			wantErr: false,
+		},
+		// V-T05: podManagementPolicy validation
+		{
+			name: "V-T05: invalid podManagementPolicy is rejected",
+			tmpl: &AerospikeCEClusterTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: "bad-policy", Namespace: "default"},
+				Spec: AerospikeCEClusterTemplateSpec{
+					Scheduling: &TemplateScheduling{
+						PodManagementPolicy: appsv1.PodManagementPolicyType("Immediate"),
+					},
+				},
+			},
+			wantErr:     true,
+			errContains: "podManagementPolicy",
+		},
+		{
+			name: "V-T05: podManagementPolicy=OrderedReady passes",
+			tmpl: &AerospikeCEClusterTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: "ordered", Namespace: "default"},
+				Spec: AerospikeCEClusterTemplateSpec{
+					Scheduling: &TemplateScheduling{
+						PodManagementPolicy: appsv1.OrderedReadyPodManagement,
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "V-T05: podManagementPolicy=Parallel passes",
+			tmpl: &AerospikeCEClusterTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: "parallel", Namespace: "default"},
+				Spec: AerospikeCEClusterTemplateSpec{
+					Scheduling: &TemplateScheduling{
+						PodManagementPolicy: appsv1.ParallelPodManagement,
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "V-T05: empty podManagementPolicy passes (optional)",
+			tmpl: &AerospikeCEClusterTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: "empty-policy", Namespace: "default"},
+				Spec: AerospikeCEClusterTemplateSpec{
+					Scheduling: &TemplateScheduling{},
+				},
+			},
+			wantErr: false,
+		},
+		// V-T02: maxRacksPerNode validation
+		{
+			name: "V-T02: negative maxRacksPerNode is rejected",
+			tmpl: &AerospikeCEClusterTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: "neg-racks", Namespace: "default"},
+				Spec: AerospikeCEClusterTemplateSpec{
+					RackConfig: &TemplateRackConfig{
+						MaxRacksPerNode: -1,
+					},
+				},
+			},
+			wantErr:     true,
+			errContains: "maxRacksPerNode",
+		},
+		{
+			name: "V-T02: zero maxRacksPerNode passes",
+			tmpl: &AerospikeCEClusterTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: "zero-racks", Namespace: "default"},
+				Spec: AerospikeCEClusterTemplateSpec{
+					RackConfig: &TemplateRackConfig{
+						MaxRacksPerNode: 0,
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "V-T02: positive maxRacksPerNode passes",
+			tmpl: &AerospikeCEClusterTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: "pos-racks", Namespace: "default"},
+				Spec: AerospikeCEClusterTemplateSpec{
+					RackConfig: &TemplateRackConfig{
+						MaxRacksPerNode: 3,
+					},
+				},
+			},
+			wantErr: false,
+		},
+		// V-T03: localPVRequired warning
+		{
+			name: "V-T03: localPVRequired=true with empty storageClassName produces warning",
+			tmpl: &AerospikeCEClusterTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: "localpv-warn", Namespace: "default"},
+				Spec: AerospikeCEClusterTemplateSpec{
+					Storage: &TemplateStorage{
+						LocalPVRequired:  true,
+						StorageClassName: "",
+					},
+				},
+			},
+			wantErr:     false,
+			wantWarning: "localPVRequired=true",
+		},
+		{
+			name: "V-T03: localPVRequired=true with storageClassName set produces no warning",
+			tmpl: &AerospikeCEClusterTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: "localpv-ok", Namespace: "default"},
+				Spec: AerospikeCEClusterTemplateSpec{
+					Storage: &TemplateStorage{
+						LocalPVRequired:  true,
+						StorageClassName: "local-storage",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		// V-T04: resources requests != limits warning
+		{
+			name: "V-T04: resources where requests != limits produces warning",
+			tmpl: &AerospikeCEClusterTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: "resources-warn", Namespace: "default"},
+				Spec: AerospikeCEClusterTemplateSpec{
+					Resources: &corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("500m"),
+							corev1.ResourceMemory: resource.MustParse("1Gi"),
+						},
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("1000m"),
+							corev1.ResourceMemory: resource.MustParse("2Gi"),
+						},
+					},
+				},
+			},
+			wantErr:     false,
+			wantWarning: "Guaranteed QoS",
+		},
+		{
+			name: "V-T04: resources where requests == limits produces no warning",
+			tmpl: &AerospikeCEClusterTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: "resources-ok", Namespace: "default"},
+				Spec: AerospikeCEClusterTemplateSpec{
+					Resources: &corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("1"),
+							corev1.ResourceMemory: resource.MustParse("2Gi"),
+						},
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("1"),
+							corev1.ResourceMemory: resource.MustParse("2Gi"),
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		// Heartbeat mode validation
+		{
+			name: "heartbeat mode=multicast is rejected for CE",
+			tmpl: &AerospikeCEClusterTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: "hb-multicast", Namespace: "default"},
+				Spec: AerospikeCEClusterTemplateSpec{
+					AerospikeConfig: &TemplateAerospikeConfig{
+						Network: &TemplateNetworkConfig{
+							Heartbeat: &TemplateHeartbeatConfig{
+								Mode: "multicast",
+							},
+						},
+					},
+				},
+			},
+			wantErr:     true,
+			errContains: "heartbeat.mode",
+		},
+		{
+			name: "heartbeat mode=mesh passes",
+			tmpl: &AerospikeCEClusterTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: "hb-mesh", Namespace: "default"},
+				Spec: AerospikeCEClusterTemplateSpec{
+					AerospikeConfig: &TemplateAerospikeConfig{
+						Network: &TemplateNetworkConfig{
+							Heartbeat: &TemplateHeartbeatConfig{
+								Mode: "mesh",
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "heartbeat mode empty passes (optional)",
+			tmpl: &AerospikeCEClusterTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: "hb-empty", Namespace: "default"},
+				Spec: AerospikeCEClusterTemplateSpec{
+					AerospikeConfig: &TemplateAerospikeConfig{
+						Network: &TemplateNetworkConfig{
+							Heartbeat: &TemplateHeartbeatConfig{
+								Mode: "",
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "nil aerospikeConfig passes",
+			tmpl: &AerospikeCEClusterTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: "no-config", Namespace: "default"},
+				Spec: AerospikeCEClusterTemplateSpec{
+					AerospikeConfig: nil,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "multiple errors are all reported",
+			tmpl: &AerospikeCEClusterTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: "multi-err", Namespace: "default"},
+				Spec: AerospikeCEClusterTemplateSpec{
+					Scheduling: &TemplateScheduling{
+						PodAntiAffinityLevel: "invalid",
+						PodManagementPolicy:  appsv1.PodManagementPolicyType("BadPolicy"),
+					},
+					RackConfig: &TemplateRackConfig{
+						MaxRacksPerNode: -5,
+					},
+					AerospikeConfig: &TemplateAerospikeConfig{
+						Network: &TemplateNetworkConfig{
+							Heartbeat: &TemplateHeartbeatConfig{
+								Mode: "multicast",
+							},
+						},
+					},
+				},
+			},
+			wantErr:     true,
+			errContains: "podAntiAffinityLevel",
+		},
+	}
+
+	v := &AerospikeCEClusterTemplateValidator{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test ValidateCreate
+			warnings, err := v.ValidateCreate(context.Background(), tt.tmpl)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("ValidateCreate() expected error, got nil")
+				}
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("ValidateCreate() error = %q, want it to contain %q",
+						err.Error(), tt.errContains)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("ValidateCreate() unexpected error: %v", err)
+				}
+			}
+
+			if tt.wantWarning != "" {
+				found := false
+				for _, w := range warnings {
+					if strings.Contains(w, tt.wantWarning) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("ValidateCreate() warnings = %v, want warning containing %q",
+						warnings, tt.wantWarning)
+				}
+			}
+
+			// Test ValidateUpdate uses the same validate() logic
+			warningsUpdate, errUpdate := v.ValidateUpdate(context.Background(), tt.tmpl, tt.tmpl)
+			if tt.wantErr {
+				if errUpdate == nil {
+					t.Fatal("ValidateUpdate() expected error, got nil")
+				}
+			} else {
+				if errUpdate != nil {
+					t.Fatalf("ValidateUpdate() unexpected error: %v", errUpdate)
+				}
+			}
+
+			if tt.wantWarning != "" {
+				found := false
+				for _, w := range warningsUpdate {
+					if strings.Contains(w, tt.wantWarning) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("ValidateUpdate() warnings = %v, want warning containing %q",
+						warningsUpdate, tt.wantWarning)
+				}
+			}
+		})
+	}
+}
+
+func TestAerospikeCEClusterTemplateValidateDelete(t *testing.T) {
+	v := &AerospikeCEClusterTemplateValidator{}
+	tmpl := &AerospikeCEClusterTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "delete-test", Namespace: "default"},
+	}
+
+	warnings, err := v.ValidateDelete(context.Background(), tmpl)
+	if err != nil {
+		t.Fatalf("ValidateDelete() unexpected error: %v", err)
+	}
+	if len(warnings) > 0 {
+		t.Errorf("ValidateDelete() unexpected warnings: %v", warnings)
+	}
+}
+
+// --- templateResourcesEqualRequestsLimits tests ---
+
+func TestTemplateResourcesEqualRequestsLimits(t *testing.T) {
+	tests := []struct {
+		name      string
+		resources *corev1.ResourceRequirements
+		want      bool
+	}{
+		{
+			name: "both requests and limits nil returns true",
+			resources: &corev1.ResourceRequirements{
+				Requests: nil,
+				Limits:   nil,
+			},
+			want: true,
+		},
+		{
+			name: "CPU equal and memory equal returns true",
+			resources: &corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("500m"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("500m"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+			},
+			want: true,
+		},
+		{
+			name: "CPU equal returns true when no memory specified",
+			resources: &corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("1"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("1"),
+				},
+			},
+			want: true,
+		},
+		{
+			name: "memory unequal returns false",
+			resources: &corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("2Gi"),
+				},
+			},
+			want: false,
+		},
+		{
+			name: "CPU unequal returns false",
+			resources: &corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("500m"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+			},
+			want: false,
+		},
+		{
+			name: "request CPU present but limit CPU missing returns false",
+			resources: &corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("500m"),
+				},
+				Limits: corev1.ResourceList{},
+			},
+			want: false,
+		},
+		{
+			name: "limit memory present but request memory missing returns false",
+			resources: &corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{},
+				Limits: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+			},
+			want: false,
+		},
+		{
+			name: "empty resource lists returns true",
+			resources: &corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{},
+				Limits:   corev1.ResourceList{},
+			},
+			want: true,
+		},
+		{
+			name: "equivalent quantities in different units returns true",
+			resources: &corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1000m"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("1073741824"), // 1Gi in bytes
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := templateResourcesEqualRequestsLimits(tt.resources)
+			if got != tt.want {
+				t.Errorf("templateResourcesEqualRequestsLimits() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/config/samples/acko_v1alpha1_aerospikececluster.yaml
+++ b/config/samples/acko_v1alpha1_aerospikececluster.yaml
@@ -35,7 +35,7 @@ spec:
         replication-factor: 1  # Single node, so replication-factor must be 1
         storage-engine:
           type: memory  # Pure in-memory storage (data lost on pod restart)
-          data-size: 1073741824  # 1 GiB of memory allocated for this namespace
+          memory-size: 1073741824  # 1 GiB of memory allocated for this namespace
 
     # Logging configuration.
     logging:

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -4,4 +4,10 @@ resources:
 - acko_v1alpha1_template_dev.yaml
 - acko_v1alpha1_template_stage.yaml
 - acko_v1alpha1_template_prod.yaml
+- aerospike-ce-cluster-3node.yaml
+- aerospike-ce-cluster-acl.yaml
+- aerospike-ce-cluster-multirack.yaml
+- aerospike-ce-cluster-monitoring.yaml
+- aerospike-ce-cluster-storage-advanced.yaml
+- aerospike-ce-cluster-with-template.yaml
 # +kubebuilder:scaffold:manifestskustomizesamples

--- a/internal/configdiff/dynamic_params_test.go
+++ b/internal/configdiff/dynamic_params_test.go
@@ -1,0 +1,68 @@
+package configdiff
+
+import "testing"
+
+func TestIsDynamic_Comprehensive(t *testing.T) {
+	tests := []struct {
+		name      string
+		paramPath string
+		want      bool
+	}{
+		// Service context — dynamic params
+		{"service proto-fd-max", "service.proto-fd-max", true},
+		{"service transaction-queues", "service.transaction-queues", true},
+		{"service migrate-threads", "service.migrate-threads", true},
+		{"service ticker-interval", "service.ticker-interval", true},
+
+		// Network context — dynamic params
+		{"network heartbeat interval", "network.heartbeat.interval", true},
+		{"network heartbeat timeout", "network.heartbeat.timeout", true},
+		{"network fabric send-threads", "network.fabric.send-threads", true},
+
+		// Namespace context — dynamic params
+		{"namespace memory-size", "namespace.memory-size", true},
+		{"namespace default-ttl", "namespace.default-ttl", true},
+		{"namespace high-water-disk-pct", "namespace.high-water-disk-pct", true},
+		{"namespace stop-writes-pct", "namespace.stop-writes-pct", true},
+		{"namespace replication-factor", "namespace.replication-factor", true},
+		{"namespace rack-id", "namespace.rack-id", true},
+
+		// Logging context — dynamic params
+		{"logging any", "logging.any", true},
+		{"logging namespace", "logging.namespace", true},
+		{"logging network", "logging.network", true},
+
+		// Security context — dynamic params
+		{"security report-authentication", "security.log.report-authentication", true},
+		{"security report-violation", "security.log.report-violation", true},
+
+		// Static / non-dynamic params (should return false)
+		{"service cluster-name is static", "service.cluster-name", false},
+		{"network service port is static", "network.service.port", false},
+		{"network service address is static", "network.service.address", false},
+		{"network heartbeat mode is static", "network.heartbeat.mode", false},
+		{"namespace name is static", "namespace.name", false},
+		{"namespace storage-engine is static", "namespace.storage-engine", false},
+
+		// Edge cases
+		{"empty string", "", false},
+		{"bare context without param", "service", false},
+		{"bare param without context", "proto-fd-max", false},
+		{"wrong case", "Service.proto-fd-max", false},
+		{"uppercase", "SERVICE.PROTO-FD-MAX", false},
+		{"trailing dot", "service.proto-fd-max.", false},
+		{"leading dot", ".service.proto-fd-max", false},
+		{"non-existent namespace param", "namespace.xdr-enabled", false},
+		{"non-existent top-level", "xdr.enabled", false},
+		{"spaces", " service.proto-fd-max", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsDynamic(tt.paramPath)
+			if got != tt.want {
+				t.Errorf("IsDynamic(%q) = %v, want %v", tt.paramPath, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/controller/reconciler_acl.go
+++ b/internal/controller/reconciler_acl.go
@@ -43,17 +43,18 @@ func (r *AerospikeCEClusterReconciler) reconcileACL(
 		return nil
 	}
 
-	// Check if any pod is ready before attempting ACL sync
+	// Check if any pod is ready before attempting ACL sync.
+	podList, err := r.listClusterPods(ctx, cluster)
+	if err != nil {
+		return fmt.Errorf("listing pods for ACL sync: %w", err)
+	}
+
 	podReady := false
-	if podList, err := r.listClusterPods(ctx, cluster); err == nil {
-		for i := range podList.Items {
-			if isPodReady(&podList.Items[i]) {
-				podReady = true
-				break
-			}
+	for i := range podList.Items {
+		if isPodReady(&podList.Items[i]) {
+			podReady = true
+			break
 		}
-	} else {
-		log.Info("Failed to list cluster pods for ACL sync, will retry", "error", err)
 	}
 	if !podReady {
 		log.Info("No ready pods, skipping ACL sync")

--- a/internal/controller/reconciler_config.go
+++ b/internal/controller/reconciler_config.go
@@ -136,6 +136,8 @@ func (r *AerospikeCEClusterReconciler) reconcileConfigMap(
 	if err := r.Update(ctx, existing); err != nil {
 		return fmt.Errorf("updating ConfigMap %s: %w", cmName, err)
 	}
+	r.Recorder.Eventf(cluster, corev1.EventTypeNormal, "ConfigMapUpdated",
+		"ConfigMap %s updated with new configuration", cmName)
 	return nil
 }
 

--- a/internal/controller/reconciler_restart.go
+++ b/internal/controller/reconciler_restart.go
@@ -139,6 +139,8 @@ func (r *AerospikeCEClusterReconciler) reconcileRollingRestart(
 
 		// 2. Restart pod (warm or cold)
 		if err := r.restartPod(ctx, cluster, pod, sts, desiredHash); err != nil {
+			r.Recorder.Eventf(cluster, corev1.EventTypeWarning, "RestartFailed",
+				"Failed to restart pod %s: %v", pod.Name, err)
 			return false, err
 		}
 
@@ -174,6 +176,8 @@ func (r *AerospikeCEClusterReconciler) restartPod(
 		log.Error(err, "Failed to update pod config hash after warm restart", "pod", pod.Name)
 	}
 	metrics.WarmRestartsTotal.WithLabelValues(cluster.Namespace, cluster.Name).Inc()
+	r.Recorder.Eventf(cluster, corev1.EventTypeNormal, "PodWarmRestarted",
+		"Pod %s warm-restarted (SIGUSR1)", pod.Name)
 	return nil
 }
 
@@ -228,6 +232,8 @@ func (r *AerospikeCEClusterReconciler) coldRestartPod(
 		return err
 	}
 	metrics.ColdRestartsTotal.WithLabelValues(cluster.Namespace, cluster.Name).Inc()
+	r.Recorder.Eventf(cluster, corev1.EventTypeNormal, "PodColdRestarted",
+		"Pod %s deleted for cold restart", pod.Name)
 	return nil
 }
 

--- a/internal/controller/reconciler_statefulset.go
+++ b/internal/controller/reconciler_statefulset.go
@@ -71,6 +71,8 @@ func (r *AerospikeCEClusterReconciler) reconcileStatefulSet(
 		if err := r.Create(ctx, sts); err != nil {
 			return fmt.Errorf("creating StatefulSet %s: %w", stsName, err)
 		}
+		r.Recorder.Eventf(cluster, corev1.EventTypeNormal, "StatefulSetCreated",
+			"StatefulSet %s created: replicas=%d", stsName, rackSize)
 		return nil
 	} else if err != nil {
 		return fmt.Errorf("getting StatefulSet %s: %w", stsName, err)
@@ -110,6 +112,8 @@ func (r *AerospikeCEClusterReconciler) reconcileStatefulSet(
 	if err := r.Update(ctx, existing); err != nil {
 		return fmt.Errorf("updating StatefulSet %s: %w", stsName, err)
 	}
+	r.Recorder.Eventf(cluster, corev1.EventTypeNormal, "StatefulSetUpdated",
+		"StatefulSet %s updated: replicas=%d", stsName, targetReplicas)
 
 	// Cleanup orphaned PVCs after StatefulSet update so pods terminate first.
 	if scaleDown {


### PR DESCRIPTION
## Summary

- **Bug Fix**: ACL reconciliation now properly propagates `listClusterPods` errors instead of silently treating them as "no ready pods"
- **Observability**: Added Kubernetes events for StatefulSet create/update, ConfigMap update, warm/cold restart, and restart failures — visible via `kubectl describe asce`
- **Docs**: Fixed `data-size` → `memory-size` in sample CR and README (Aerospike CE 8.1 parameter name), added 6 missing sample files to `kustomization.yaml`
- **Tests**: Added `dynamic_params_test.go` (34 cases) and `aerospikececlustertemplate_webhook_test.go` (33 cases)

## Test plan
- [x] `make test` passes (unit + integration)
- [x] `go build ./...` compiles cleanly
- [x] All new tests pass
- [ ] Manual verification of events with `kubectl describe asce` on a running cluster