### PR TITLE
improve: webhook validation hardening and QA tests

### DIFF
--- a/api/v1alpha1/aerospikececluster_webhook.go
+++ b/api/v1alpha1/aerospikececluster_webhook.go
@@ -472,6 +472,15 @@ var aerospikeCEBuiltinRoles = map[string]bool{
 func (v *AerospikeCEClusterValidator) validateAccessControl(acl *AerospikeAccessControlSpec) []string {
 	var errors []string
 
+	// Check for duplicate user names
+	seenUsers := make(map[string]bool)
+	for _, user := range acl.Users {
+		if seenUsers[user.Name] {
+			errors = append(errors, fmt.Sprintf("accessControl.users: duplicate user name %q", user.Name))
+		}
+		seenUsers[user.Name] = true
+	}
+
 	hasAdmin := false
 	for _, user := range acl.Users {
 		if user.SecretName == "" {
@@ -494,6 +503,15 @@ func (v *AerospikeCEClusterValidator) validateAccessControl(acl *AerospikeAccess
 
 	if !hasAdmin {
 		errors = append(errors, "aerospikeAccessControl must have at least one user with both 'sys-admin' and 'user-admin' roles (required for operator-managed cluster administration)")
+	}
+
+	// Check for duplicate role names
+	seenRoles := make(map[string]bool)
+	for _, role := range acl.Roles {
+		if seenRoles[role.Name] {
+			errors = append(errors, fmt.Sprintf("accessControl.roles: duplicate role name %q", role.Name))
+		}
+		seenRoles[role.Name] = true
 	}
 
 	// Validate that users reference only built-in or explicitly defined roles
@@ -913,6 +931,11 @@ var aerospikeReservedPorts = map[int32]string{
 func (v *AerospikeCEClusterValidator) validateMonitoring(m *AerospikeMonitoringSpec) ([]string, admission.Warnings) {
 	var errors []string
 	var warnings admission.Warnings
+
+	// Validate port is in valid TCP range.
+	if m.Port < 1 || m.Port > 65535 {
+		errors = append(errors, fmt.Sprintf("monitoring.port must be in range 1-65535 (got %d)", m.Port))
+	}
 
 	// Port conflict check with Aerospike reserved ports.
 	if portName, ok := aerospikeReservedPorts[m.Port]; ok {

--- a/api/v1alpha1/webhook_test.go
+++ b/api/v1alpha1/webhook_test.go
@@ -3377,3 +3377,170 @@ func TestValidate_ImageEnterpriseEETag(t *testing.T) {
 		t.Errorf("expected enterprise image error, got: %v", err)
 	}
 }
+
+func TestValidate_DuplicateUserNames(t *testing.T) {
+	v := &AerospikeCEClusterValidator{}
+	cluster := &AerospikeCECluster{
+		Spec: AerospikeCEClusterSpec{
+			Size:  3,
+			Image: "aerospike:ce-8.1.1.1",
+			AerospikeAccessControl: &AerospikeAccessControlSpec{
+				Users: []AerospikeUserSpec{
+					{
+						Name:       "admin",
+						SecretName: "admin-secret",
+						Roles:      []string{"sys-admin", "user-admin"},
+					},
+					{
+						Name:       "admin",
+						SecretName: "admin-secret-2",
+						Roles:      []string{"read"},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := v.validate(cluster)
+	if err == nil {
+		t.Fatal("expected error for duplicate user names")
+	}
+	if !strings.Contains(err.Error(), "duplicate user name") {
+		t.Errorf("error should mention 'duplicate user name', got: %v", err)
+	}
+}
+
+func TestValidate_DuplicateRoleNames(t *testing.T) {
+	v := &AerospikeCEClusterValidator{}
+	cluster := &AerospikeCECluster{
+		Spec: AerospikeCEClusterSpec{
+			Size:  3,
+			Image: "aerospike:ce-8.1.1.1",
+			AerospikeAccessControl: &AerospikeAccessControlSpec{
+				Users: []AerospikeUserSpec{
+					{
+						Name:       "admin",
+						SecretName: "admin-secret",
+						Roles:      []string{"sys-admin", "user-admin"},
+					},
+				},
+				Roles: []AerospikeRoleSpec{
+					{
+						Name:       "custom-role",
+						Privileges: []string{"read"},
+					},
+					{
+						Name:       "custom-role",
+						Privileges: []string{"write"},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := v.validate(cluster)
+	if err == nil {
+		t.Fatal("expected error for duplicate role names")
+	}
+	if !strings.Contains(err.Error(), "duplicate role name") {
+		t.Errorf("error should mention 'duplicate role name', got: %v", err)
+	}
+}
+
+func TestValidate_UniqueUserNames(t *testing.T) {
+	v := &AerospikeCEClusterValidator{}
+	cluster := &AerospikeCECluster{
+		Spec: AerospikeCEClusterSpec{
+			Size:  3,
+			Image: "aerospike:ce-8.1.1.1",
+			AerospikeAccessControl: &AerospikeAccessControlSpec{
+				Users: []AerospikeUserSpec{
+					{
+						Name:       "admin",
+						SecretName: "admin-secret",
+						Roles:      []string{"sys-admin", "user-admin"},
+					},
+					{
+						Name:       "reader",
+						SecretName: "reader-secret",
+						Roles:      []string{"read"},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := v.validate(cluster)
+	if err != nil {
+		t.Errorf("unexpected error for unique user names: %v", err)
+	}
+}
+
+func TestValidate_MonitoringPortOutOfRange_Negative(t *testing.T) {
+	v := &AerospikeCEClusterValidator{}
+	cluster := &AerospikeCECluster{
+		Spec: AerospikeCEClusterSpec{
+			Size:  3,
+			Image: "aerospike:ce-8.1.1.1",
+			Monitoring: &AerospikeMonitoringSpec{
+				Enabled:       true,
+				ExporterImage: "exporter:v1",
+				Port:          -1,
+			},
+		},
+	}
+
+	_, err := v.validate(cluster)
+	if err == nil {
+		t.Fatal("expected error for negative monitoring port")
+	}
+	if !strings.Contains(err.Error(), "must be in range 1-65535") {
+		t.Errorf("error should mention port range, got: %v", err)
+	}
+}
+
+func TestValidate_MonitoringPortOutOfRange_Zero(t *testing.T) {
+	v := &AerospikeCEClusterValidator{}
+	cluster := &AerospikeCECluster{
+		Spec: AerospikeCEClusterSpec{
+			Size:  3,
+			Image: "aerospike:ce-8.1.1.1",
+			Monitoring: &AerospikeMonitoringSpec{
+				Enabled:       true,
+				ExporterImage: "exporter:v1",
+				Port:          0,
+			},
+		},
+	}
+
+	_, err := v.validate(cluster)
+	if err == nil {
+		t.Fatal("expected error for zero monitoring port")
+	}
+	if !strings.Contains(err.Error(), "must be in range 1-65535") {
+		t.Errorf("error should mention port range, got: %v", err)
+	}
+}
+
+func TestValidate_MonitoringPortOutOfRange_TooHigh(t *testing.T) {
+	v := &AerospikeCEClusterValidator{}
+	cluster := &AerospikeCECluster{
+		Spec: AerospikeCEClusterSpec{
+			Size:  3,
+			Image: "aerospike:ce-8.1.1.1",
+			Monitoring: &AerospikeMonitoringSpec{
+				Enabled:       true,
+				ExporterImage: "exporter:v1",
+				Port:          70000,
+			},
+		},
+	}
+
+	_, err := v.validate(cluster)
+	if err == nil {
+		t.Fatal("expected error for port > 65535")
+	}
+	if !strings.Contains(err.Error(), "must be in range 1-65535") {
+		t.Errorf("error should mention port range, got: %v", err)
+	}
+}

--- a/internal/controller/reconciler_monitoring_unit_test.go
+++ b/internal/controller/reconciler_monitoring_unit_test.go
@@ -1,0 +1,64 @@
+package controller
+
+import (
+	"testing"
+)
+
+func TestToStringMap(t *testing.T) {
+	tests := []struct {
+		name string
+		in   map[string]string
+		want map[string]any
+	}{
+		{
+			name: "nil map returns empty map (not nil)",
+			in:   nil,
+			want: map[string]any{},
+		},
+		{
+			name: "empty map returns empty map",
+			in:   map[string]string{},
+			want: map[string]any{},
+		},
+		{
+			name: "single entry is converted",
+			in:   map[string]string{"app": "aerospike"},
+			want: map[string]any{"app": "aerospike"},
+		},
+		{
+			name: "multiple entries are all converted",
+			in: map[string]string{
+				"app":  "aerospike",
+				"team": "platform",
+				"env":  "prod",
+			},
+			want: map[string]any{
+				"app":  "aerospike",
+				"team": "platform",
+				"env":  "prod",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := toStringMap(tc.in)
+			if got == nil {
+				t.Fatal("toStringMap() returned nil, want non-nil map")
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("toStringMap() returned %d entries, want %d", len(got), len(tc.want))
+			}
+			for k, wantVal := range tc.want {
+				gotVal, ok := got[k]
+				if !ok {
+					t.Errorf("toStringMap() missing key %q", k)
+					continue
+				}
+				if gotVal != wantVal {
+					t.Errorf("toStringMap()[%q] = %v, want %v", k, gotVal, wantVal)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- **Webhook: 중복 사용자/역할 이름 검증** — `accessControl.users`에서 중복 사용자 이름, `accessControl.roles`에서 중복 역할 이름을 감지하여 validation error 반환. 기존 `validateRackConfig`의 중복 rack ID 검증 패턴을 따름.
- **Webhook: monitoring 포트 범위 검증** — monitoring 포트가 유효한 TCP 범위(1-65535)를 벗어나면 validation error 반환. 기존 reserved port 충돌 검증 앞에 추가.
- **QA: `toStringMap` unit test** — 기존에는 `//go:build integration` 태그 뒤에만 테스트되던 `toStringMap` 함수에 대해 일반 unit test 추가. `make test`에서 항상 실행됨.

## Test plan

- [x] `TestValidate_DuplicateUserNames` — 동일 이름의 사용자 2명 → validation error 확인
- [x] `TestValidate_DuplicateRoleNames` — 동일 이름의 역할 2개 → validation error 확인
- [x] `TestValidate_UniqueUserNames` — 고유 이름의 사용자들 → 에러 없음 확인
- [x] `TestValidate_MonitoringPortOutOfRange_Negative` — 포트 -1 → validation error 확인
- [x] `TestValidate_MonitoringPortOutOfRange_Zero` — 포트 0 → validation error 확인
- [x] `TestValidate_MonitoringPortOutOfRange_TooHigh` — 포트 70000 → validation error 확인
- [x] `TestToStringMap` — nil/empty/single/multiple 케이스 테스트
- [x] `make lint` 통과 (0 issues)
- [x] `make test` 전체 통과