### PR TITLE
Fix TemplateApplied event duplication, missing PhaseToFloat phases, and ServicePort not set

### DIFF
--- a/internal/controller/reconciler.go
+++ b/internal/controller/reconciler.go
@@ -135,17 +135,12 @@ func (r *AerospikeCEClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 			// response refreshes the full cluster object (incl. Status) from the
 			// server, which would nil-out the in-memory snapshot if Status has
 			// not been saved yet.
-			snapshotRV := cluster.Status.TemplateSnapshot.ResourceVersion
 			if err := r.Status().Update(ctx, cluster); err != nil {
 				if errors.IsConflict(err) {
 					return ctrl.Result{Requeue: true}, nil
 				}
 				return ctrl.Result{}, err
 			}
-			r.Recorder.Eventf(cluster, corev1.EventTypeNormal, "TemplateApplied",
-				"Applied template %q (rv: %s)",
-				cluster.Spec.TemplateRef.Name,
-				snapshotRV)
 		}
 		// Remove the resync annotation from the API server now that the snapshot is persisted.
 		// This Patch runs after Status.Update so it does not overwrite the snapshot.

--- a/internal/controller/reconciler_status.go
+++ b/internal/controller/reconciler_status.go
@@ -184,6 +184,7 @@ func (r *AerospikeCEClusterReconciler) populateStatus(
 			HostIP:            pod.Status.HostIP,
 			Image:             podImage,
 			PodPort:           podutil.ServicePort,
+			ServicePort:       int32(getServicePort(cluster)),
 			Rack:              rackID,
 			IsRunningAndReady: isReady,
 			ConfigHash:        configHash,

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -106,6 +106,18 @@ func PhaseToFloat(phase string) float64 {
 		return 2
 	case "Error":
 		return 3
+	case "ScalingUp":
+		return 4
+	case "ScalingDown":
+		return 5
+	case "RollingRestart":
+		return 6
+	case "ACLSync":
+		return 7
+	case "Paused":
+		return 8
+	case "Deleting":
+		return 9
 	default:
 		return 0
 	}

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -15,6 +15,12 @@ func TestPhaseToFloat(t *testing.T) {
 		{"InProgress", 1},
 		{"Completed", 2},
 		{"Error", 3},
+		{"ScalingUp", 4},
+		{"ScalingDown", 5},
+		{"RollingRestart", 6},
+		{"ACLSync", 7},
+		{"Paused", 8},
+		{"Deleting", 9},
 		{"", 0},
 		{"Unknown", 0},
 	}


### PR DESCRIPTION
## Summary
- **Fix 1 (`reconciler.go`)**: Remove the duplicate `TemplateApplied` event emitted inside the `if resolveResult.SnapshotUpdated` block (before `Status.Update`). Only the post-update event at line 162 is kept, which carries the accurate `ResourceVersion` returned by the API server.
- **Fix 2 (`metrics.go`)**: Add 6 missing phase mappings to `PhaseToFloat` — `ScalingUp`→4, `ScalingDown`→5, `RollingRestart`→6, `ACLSync`→7, `Paused`→8, `Deleting`→9. Previously all 6 phases resolved to `0` (Unknown), making Grafana phase dashboards unusable.
- **Fix 3 (`reconciler_status.go`)**: Populate `AerospikePodStatus.ServicePort` via the existing `getServicePort(cluster)` helper. The field was always left at its zero-value despite being defined in the struct.
- **Tests (`metrics_test.go`)**: Add 6 test cases to `TestPhaseToFloat` covering each newly mapped phase.

Closes #101

## Test plan
- [x] Unit tests pass (`make test`)
- [x] Integration tests pass (`make test`)
- [x] Lint passes (`make lint`)
- [x] `TestPhaseToFloat` covers all 9 named phases + unknown/empty cases
- [ ] E2E tests pass (requires Kind cluster)