### PR TITLE
improve: fix race condition, error handling, and add initcontainer tests

### DIFF
--- a/internal/controller/reconciler.go
+++ b/internal/controller/reconciler.go
@@ -232,12 +232,20 @@ func (r *AerospikeCEClusterReconciler) reconcileCluster(
 		return ctrl.Result{}, err
 	}
 	if scalingUp {
-		if err := r.setPhase(ctx, cluster, asdbcev1alpha1.AerospikePhaseScalingUp, "Scaling up cluster"); err != nil && !errors.IsConflict(err) {
-			return ctrl.Result{}, err
+		if err := r.setPhase(ctx, cluster, asdbcev1alpha1.AerospikePhaseScalingUp, "Scaling up cluster"); err != nil {
+			if errors.IsConflict(err) {
+				log.V(1).Info("Conflict setting ScalingUp phase, continuing reconcile")
+			} else {
+				return ctrl.Result{}, err
+			}
 		}
 	} else if scalingDown {
-		if err := r.setPhase(ctx, cluster, asdbcev1alpha1.AerospikePhaseScalingDown, "Scaling down cluster"); err != nil && !errors.IsConflict(err) {
-			return ctrl.Result{}, err
+		if err := r.setPhase(ctx, cluster, asdbcev1alpha1.AerospikePhaseScalingDown, "Scaling down cluster"); err != nil {
+			if errors.IsConflict(err) {
+				log.V(1).Info("Conflict setting ScalingDown phase, continuing reconcile")
+			} else {
+				return ctrl.Result{}, err
+			}
 		}
 	}
 
@@ -300,8 +308,11 @@ func (r *AerospikeCEClusterReconciler) reconcileCluster(
 		}
 		if restarted {
 			if err := r.setPhase(ctx, cluster, asdbcev1alpha1.AerospikePhaseRollingRestart,
-				fmt.Sprintf("Rolling restart in progress for rack %d", rack.ID)); err != nil && !errors.IsConflict(err) {
-				return ctrl.Result{}, err
+				fmt.Sprintf("Rolling restart in progress for rack %d", rack.ID)); err != nil {
+				if !errors.IsConflict(err) {
+					return ctrl.Result{}, err
+				}
+				log.V(1).Info("Conflict setting RollingRestart phase, continuing reconcile", "rack", rack.ID)
 			}
 			return ctrl.Result{RequeueAfter: defaultReconcileRetryInterval}, nil
 		}
@@ -311,8 +322,12 @@ func (r *AerospikeCEClusterReconciler) reconcileCluster(
 	var aclErr error
 	aclSynced := false
 	if cluster.Spec.AerospikeAccessControl != nil {
-		if err := r.setPhase(ctx, cluster, asdbcev1alpha1.AerospikePhaseACLSync, "Synchronizing ACL roles and users"); err != nil && !errors.IsConflict(err) {
-			return ctrl.Result{}, err
+		if err := r.setPhase(ctx, cluster, asdbcev1alpha1.AerospikePhaseACLSync, "Synchronizing ACL roles and users"); err != nil {
+			if errors.IsConflict(err) {
+				log.V(1).Info("Conflict setting ACLSync phase, continuing reconcile")
+			} else {
+				return ctrl.Result{}, err
+			}
 		}
 	}
 	if synced, err := r.reconcileACL(ctx, cluster); err != nil {

--- a/internal/controller/reconciler_acl.go
+++ b/internal/controller/reconciler_acl.go
@@ -140,7 +140,7 @@ func (r *AerospikeCEClusterReconciler) reconcileRoles(
 			return fmt.Errorf("parsing privileges for role %s: %w", roleSpec.Name, err)
 		}
 		if err := syncRolePrivileges(aeroClient, adminPolicy, roleSpec.Name, existing.Privileges, desiredPrivs, log); err != nil {
-			return err
+			return fmt.Errorf("syncing privileges for role %s: %w", roleSpec.Name, err)
 		}
 	}
 
@@ -200,7 +200,7 @@ func (r *AerospikeCEClusterReconciler) reconcileUsers(
 
 		// Sync roles
 		if err := syncUserRoles(aeroClient, adminPolicy, userSpec.Name, existing.Roles, userSpec.Roles, log); err != nil {
-			return err
+			return fmt.Errorf("syncing roles for user %s: %w", userSpec.Name, err)
 		}
 
 		// Attempt password change. This only runs when spec generation

--- a/internal/controller/reconciler_cleanup.go
+++ b/internal/controller/reconciler_cleanup.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -37,18 +38,24 @@ func (r *AerospikeCEClusterReconciler) handleDeletion(
 		// Conflict is non-fatal here; the deletion will proceed regardless.
 	}
 
-	// Selectively delete PVCs for volumes that have cascadeDelete enabled
+	// Selectively delete PVCs for volumes that have cascadeDelete enabled.
+	// Continue through all StatefulSets even if some fail, to clean up as much as possible.
 	if cluster.Spec.Storage != nil {
 		stsList, err := r.listClusterStatefulSets(ctx, cluster)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
+		var pvcErrors []error
 		for _, sts := range stsList.Items {
 			if err := storage.DeleteCascadeDeletePVCs(ctx, r.Client, cluster.Namespace, sts.Name, cluster.Spec.Storage); err != nil {
 				if !errors.IsNotFound(err) {
-					return ctrl.Result{}, err
+					log.Error(err, "Failed to delete cascade PVCs for StatefulSet", "statefulset", sts.Name)
+					pvcErrors = append(pvcErrors, fmt.Errorf("statefulset %s: %w", sts.Name, err))
 				}
 			}
+		}
+		if len(pvcErrors) > 0 {
+			return ctrl.Result{}, fmt.Errorf("failed to delete cascade PVCs for %d StatefulSet(s): %w", len(pvcErrors), pvcErrors[0])
 		}
 	}
 

--- a/internal/controller/reconciler_dynamic_config.go
+++ b/internal/controller/reconciler_dynamic_config.go
@@ -8,6 +8,7 @@ import (
 	aero "github.com/aerospike/aerospike-client-go/v8"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	asdbcev1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
@@ -123,13 +124,13 @@ func buildSetConfigCommand(change configdiff.Change) (string, error) {
 // findNodeForPod finds the Aerospike node that corresponds to a given pod by
 // matching the pod IP. Returns nil if no match is found (no single-node fallback
 // to avoid applying config to the wrong node).
-func findNodeForPod(client *aero.Client, pod *corev1.Pod) *aero.Node {
+func findNodeForPod(aeroClient *aero.Client, pod *corev1.Pod) *aero.Node {
 	podIP := pod.Status.PodIP
 	if podIP == "" {
 		return nil
 	}
 
-	for _, node := range client.GetNodes() {
+	for _, node := range aeroClient.GetNodes() {
 		host := node.GetHost()
 		if host != nil && host.Name == podIP {
 			return node
@@ -140,8 +141,10 @@ func findNodeForPod(client *aero.Client, pod *corev1.Pod) *aero.Node {
 }
 
 // updateDynamicConfigStatus updates the DynamicConfigStatus field in the pod's
-// status within the cluster CR. Failures are non-fatal: they are logged and
-// reported as warning Events since the caller cannot meaningfully retry.
+// status within the cluster CR. Uses Patch (MergeFrom) for atomic updates to
+// avoid race conditions with concurrent reconcile loops.
+// Failures are non-fatal: they are logged and reported as warning Events since
+// the caller cannot meaningfully retry.
 func (r *AerospikeCEClusterReconciler) updateDynamicConfigStatus(
 	ctx context.Context,
 	cluster *asdbcev1alpha1.AerospikeCECluster,
@@ -163,10 +166,11 @@ func (r *AerospikeCEClusterReconciler) updateDynamicConfigStatus(
 	}
 
 	if podStatus, ok := latest.Status.Pods[podName]; ok {
+		base := latest.DeepCopy()
 		podStatus.DynamicConfigStatus = status
 		latest.Status.Pods[podName] = podStatus
-		if err := r.Status().Update(ctx, latest); err != nil {
-			log.Error(err, "Failed to update dynamic config status", "pod", podName)
+		if err := r.Status().Patch(ctx, latest, client.MergeFrom(base)); err != nil {
+			log.Error(err, "Failed to patch dynamic config status", "pod", podName)
 			r.Recorder.Eventf(cluster, corev1.EventTypeWarning, EventDynamicConfigFailed,
 				"Failed to update dynamic config status for pod %s: %v", podName, err)
 		}

--- a/internal/initcontainer/scripts_test.go
+++ b/internal/initcontainer/scripts_test.go
@@ -1,0 +1,68 @@
+package initcontainer
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGetInitScript(t *testing.T) {
+	script := GetInitScript()
+
+	if script == "" {
+		t.Fatal("GetInitScript() returned empty string")
+	}
+
+	// Verify the script starts with a shebang
+	if !strings.HasPrefix(script, "#!/bin/bash") {
+		t.Error("init script does not start with #!/bin/bash shebang")
+	}
+
+	// Verify key operations are present
+	for _, expected := range []string{
+		"CONFIG_SRC",
+		"CONFIG_DST",
+		"aerospike.conf",
+		"MY_POD_IP",
+		"WIPE_VOLUMES",
+		"INIT_VOLUMES",
+	} {
+		if !strings.Contains(script, expected) {
+			t.Errorf("init script missing expected content: %q", expected)
+		}
+	}
+}
+
+func TestGetConfigMapData(t *testing.T) {
+	conf := "service { cluster-name test }"
+	data := GetConfigMapData(conf)
+
+	if len(data) != 2 {
+		t.Fatalf("GetConfigMapData() returned %d entries, want 2", len(data))
+	}
+
+	if got := data["aerospike.conf"]; got != conf {
+		t.Errorf("aerospike.conf = %q, want %q", got, conf)
+	}
+
+	initScript := data["aerospike-init.sh"]
+	if initScript == "" {
+		t.Fatal("aerospike-init.sh is empty")
+	}
+
+	// The init script in ConfigMap should match GetInitScript()
+	if initScript != GetInitScript() {
+		t.Error("aerospike-init.sh in ConfigMap data does not match GetInitScript()")
+	}
+}
+
+func TestGetConfigMapData_EmptyConf(t *testing.T) {
+	data := GetConfigMapData("")
+
+	if got := data["aerospike.conf"]; got != "" {
+		t.Errorf("aerospike.conf = %q, want empty string", got)
+	}
+
+	if data["aerospike-init.sh"] == "" {
+		t.Error("aerospike-init.sh should still contain the init script even with empty conf")
+	}
+}


### PR DESCRIPTION
## Summary
- **Race condition fix**: `updateDynamicConfigStatus`에서 `Status().Update` → `Status().Patch(MergeFrom)`로 변경하여 동시 reconcile loop 간 race condition 방지
- **Error wrapping**: `reconciler_acl.go`의 `syncRolePrivileges`/`syncUserRoles` 반환 에러에 컨텍스트 래핑 추가 (디버깅 용이)
- **Conflict logging**: `reconciler.go`에서 `setPhase` conflict 에러를 V(1) 로그로 기록 (기존에는 silent ignore)
- **Cascade delete resilience**: `reconciler_cleanup.go`에서 PVC 삭제 시 첫 번째 에러에서 중단하지 않고 모든 StatefulSet을 순회한 뒤 에러 수집
- **Import shadowing fix**: `findNodeForPod`의 `client` 파라미터명을 `aeroClient`로 변경하여 lint 경고 해결
- **New tests**: `initcontainer/scripts.go`에 대한 유닛 테스트 추가 (100% coverage)

## Test plan
- [x] `make build` — 빌드 성공
- [x] `make test` — 모든 유닛 + integration 테스트 통과
- [x] `make lint` — 0 issues
- [x] `initcontainer` 패키지 100% coverage 달성