### PR TITLE
improve: fix service port comparison, PVC error aggregation, and add tests

### DIFF
--- a/internal/controller/reconciler_acl.go
+++ b/internal/controller/reconciler_acl.go
@@ -207,7 +207,7 @@ func (r *AerospikeCEClusterReconciler) reconcileUsers(
 		// has changed (guarded by the generation check above), so it won't
 		// run every reconcile cycle. The server is idempotent for same-value changes.
 		if err := aeroClient.ChangePassword(adminPolicy, userSpec.Name, password); err != nil {
-			log.V(1).Info("Password change failed (non-fatal)", "user", userSpec.Name, "error", err)
+			log.Error(err, "Password change failed (non-fatal, continuing)", "user", userSpec.Name)
 		}
 	}
 

--- a/internal/controller/reconciler_cleanup.go
+++ b/internal/controller/reconciler_cleanup.go
@@ -2,10 +2,11 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -32,7 +33,7 @@ func (r *AerospikeCEClusterReconciler) handleDeletion(
 
 	// Set Deleting phase so observers know the cluster is being removed.
 	if err := r.setPhase(ctx, cluster, asdbcev1alpha1.AerospikePhaseDeleting, "Cluster is being deleted"); err != nil {
-		if !errors.IsConflict(err) {
+		if !k8serrors.IsConflict(err) {
 			return ctrl.Result{}, err
 		}
 		// Conflict is non-fatal here; the deletion will proceed regardless.
@@ -48,14 +49,15 @@ func (r *AerospikeCEClusterReconciler) handleDeletion(
 		var pvcErrors []error
 		for _, sts := range stsList.Items {
 			if err := storage.DeleteCascadeDeletePVCs(ctx, r.Client, cluster.Namespace, sts.Name, cluster.Spec.Storage); err != nil {
-				if !errors.IsNotFound(err) {
+				if !k8serrors.IsNotFound(err) {
 					log.Error(err, "Failed to delete cascade PVCs for StatefulSet", "statefulset", sts.Name)
 					pvcErrors = append(pvcErrors, fmt.Errorf("statefulset %s: %w", sts.Name, err))
 				}
 			}
 		}
 		if len(pvcErrors) > 0 {
-			return ctrl.Result{}, fmt.Errorf("failed to delete cascade PVCs for %d StatefulSet(s): %w", len(pvcErrors), pvcErrors[0])
+			return ctrl.Result{}, fmt.Errorf("failed to delete cascade PVCs for %d StatefulSet(s): %w",
+				len(pvcErrors), errors.Join(pvcErrors...))
 		}
 	}
 
@@ -67,7 +69,7 @@ func (r *AerospikeCEClusterReconciler) handleDeletion(
 
 	controllerutil.RemoveFinalizer(latest, utils.StorageFinalizer)
 	if err := r.Update(ctx, latest); err != nil {
-		if errors.IsConflict(err) {
+		if k8serrors.IsConflict(err) {
 			log.V(1).Info("Conflict removing finalizer, will requeue")
 			return ctrl.Result{Requeue: true}, nil
 		}

--- a/internal/controller/reconciler_monitoring_unit_test.go
+++ b/internal/controller/reconciler_monitoring_unit_test.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -60,5 +61,90 @@ func TestToStringMap(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestDefaultAlertRules(t *testing.T) {
+	rules := defaultAlertRules("my-cluster", "aerospike")
+	if len(rules) != 1 {
+		t.Fatalf("expected 1 rule group, got %d", len(rules))
+	}
+
+	group, ok := rules[0].(map[string]any)
+	if !ok {
+		t.Fatal("rule group is not map[string]any")
+	}
+
+	groupName, ok := group["name"].(string)
+	if !ok || groupName != "my-cluster.rules" {
+		t.Errorf("group name = %q, want %q", groupName, "my-cluster.rules")
+	}
+
+	ruleList, ok := group["rules"].([]any)
+	if !ok {
+		t.Fatal("rules is not []any")
+	}
+
+	expectedAlerts := []string{
+		"AerospikeNodeDown",
+		"AerospikeNamespaceStopWrites",
+		"AerospikeHighDiskUsage",
+		"AerospikeHighMemoryUsage",
+		"AerospikeReconcileStale",
+		"AerospikeClusterSizeMismatch",
+	}
+
+	if len(ruleList) != len(expectedAlerts) {
+		t.Fatalf("expected %d alert rules, got %d", len(expectedAlerts), len(ruleList))
+	}
+
+	for i, expected := range expectedAlerts {
+		rule, ok := ruleList[i].(map[string]any)
+		if !ok {
+			t.Fatalf("rule[%d] is not map[string]any", i)
+		}
+		alertName, ok := rule["alert"].(string)
+		if !ok || alertName != expected {
+			t.Errorf("rule[%d].alert = %q, want %q", i, alertName, expected)
+		}
+
+		// Verify expressions reference the cluster/namespace context
+		expr, ok := rule["expr"].(string)
+		if !ok {
+			t.Errorf("rule[%d].expr is not string", i)
+			continue
+		}
+		if !strings.Contains(expr, "aerospike") {
+			t.Errorf("rule[%d].expr = %q, expected to contain namespace reference", i, expr)
+		}
+		if !strings.Contains(expr, "my-cluster") {
+			t.Errorf("rule[%d].expr = %q, expected to contain cluster name reference", i, expr)
+		}
+	}
+}
+
+func TestDefaultAlertRules_LabelSeverity(t *testing.T) {
+	rules := defaultAlertRules("test", "ns")
+	group := rules[0].(map[string]any)
+	ruleList := group["rules"].([]any)
+
+	criticalCount := 0
+	warningCount := 0
+	for _, r := range ruleList {
+		rule := r.(map[string]any)
+		labels := rule["labels"].(map[string]any)
+		switch labels["severity"].(string) {
+		case "critical":
+			criticalCount++
+		case "warning":
+			warningCount++
+		}
+	}
+
+	if criticalCount != 2 {
+		t.Errorf("expected 2 critical alerts, got %d", criticalCount)
+	}
+	if warningCount != 4 {
+		t.Errorf("expected 4 warning alerts, got %d", warningCount)
 	}
 }

--- a/internal/controller/reconciler_services.go
+++ b/internal/controller/reconciler_services.go
@@ -104,7 +104,9 @@ func servicePortsChanged(existing, desired []corev1.ServicePort) bool {
 		return true
 	}
 	for i, p := range existing {
-		if p.Name != desired[i].Name || p.Port != desired[i].Port {
+		d := desired[i]
+		if p.Name != d.Name || p.Port != d.Port ||
+			p.TargetPort != d.TargetPort || p.Protocol != d.Protocol {
 			return true
 		}
 	}

--- a/internal/controller/reconciler_services_test.go
+++ b/internal/controller/reconciler_services_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 func TestServicePortsChanged(t *testing.T) {
@@ -56,6 +57,36 @@ func TestServicePortsChanged(t *testing.T) {
 			desired: []corev1.ServicePort{
 				{Name: "service", Port: 3000},
 				{Name: "fabric", Port: 3001},
+			},
+			want: false,
+		},
+		{
+			name: "different TargetPort",
+			existing: []corev1.ServicePort{
+				{Name: "service", Port: 3000, TargetPort: intstr.FromInt32(3000), Protocol: corev1.ProtocolTCP},
+			},
+			desired: []corev1.ServicePort{
+				{Name: "service", Port: 3000, TargetPort: intstr.FromInt32(4000), Protocol: corev1.ProtocolTCP},
+			},
+			want: true,
+		},
+		{
+			name: "different Protocol",
+			existing: []corev1.ServicePort{
+				{Name: "service", Port: 3000, TargetPort: intstr.FromInt32(3000), Protocol: corev1.ProtocolTCP},
+			},
+			desired: []corev1.ServicePort{
+				{Name: "service", Port: 3000, TargetPort: intstr.FromInt32(3000), Protocol: corev1.ProtocolUDP},
+			},
+			want: true,
+		},
+		{
+			name: "same ports with all fields",
+			existing: []corev1.ServicePort{
+				{Name: "service", Port: 3000, TargetPort: intstr.FromInt32(3000), Protocol: corev1.ProtocolTCP},
+			},
+			desired: []corev1.ServicePort{
+				{Name: "service", Port: 3000, TargetPort: intstr.FromInt32(3000), Protocol: corev1.ProtocolTCP},
 			},
 			want: false,
 		},


### PR DESCRIPTION
## Summary
- **Fix `servicePortsChanged`**: Previously only compared `Name` and `Port` fields, missing `TargetPort` and `Protocol` changes. This could cause the operator to skip service updates when only TargetPort or Protocol changed.
- **Fix PVC error aggregation**: Use `errors.Join` in `handleDeletion` to aggregate all PVC cleanup errors instead of only wrapping the first error. Provides complete diagnostic context when multiple StatefulSets fail during cluster deletion.
- **Improve ACL logging**: Elevate password change failure from `V(1).Info` to `Error` level for better operational visibility — password failures are non-fatal but should be visible to operators.
- **Add monitoring tests**: Tests for `defaultAlertRules` verifying alert structure (6 rules), severity distribution (2 critical, 4 warning), and PromQL expression references.
- **Add service port tests**: Tests for TargetPort and Protocol comparison in `servicePortsChanged`.

## Test plan
- [x] `make lint` — 0 issues
- [x] `make test` — all tests pass (unit + integration)
- [x] New tests: `TestDefaultAlertRules`, `TestDefaultAlertRules_LabelSeverity`, `TestServicePortsChanged` (TargetPort/Protocol cases)