### PR TITLE
improve: fix shallow copy bugs and nil map access

### DIFF
--- a/internal/controller/reconciler_dynamic_config.go
+++ b/internal/controller/reconciler_dynamic_config.go
@@ -162,17 +162,16 @@ func (r *AerospikeCEClusterReconciler) updateDynamicConfigStatus(
 	}
 
 	if latest.Status.Pods == nil {
-		return
+		latest.Status.Pods = make(map[string]asdbcev1alpha1.AerospikePodStatus)
 	}
 
-	if podStatus, ok := latest.Status.Pods[podName]; ok {
-		base := latest.DeepCopy()
-		podStatus.DynamicConfigStatus = status
-		latest.Status.Pods[podName] = podStatus
-		if err := r.Status().Patch(ctx, latest, client.MergeFrom(base)); err != nil {
-			log.Error(err, "Failed to patch dynamic config status", "pod", podName)
-			r.Recorder.Eventf(cluster, corev1.EventTypeWarning, EventDynamicConfigFailed,
-				"Failed to update dynamic config status for pod %s: %v", podName, err)
-		}
+	base := latest.DeepCopy()
+	podStatus := latest.Status.Pods[podName]
+	podStatus.DynamicConfigStatus = status
+	latest.Status.Pods[podName] = podStatus
+	if err := r.Status().Patch(ctx, latest, client.MergeFrom(base)); err != nil {
+		log.Error(err, "Failed to patch dynamic config status", "pod", podName)
+		r.Recorder.Eventf(cluster, corev1.EventTypeWarning, EventDynamicConfigFailed,
+			"Failed to update dynamic config status for pod %s: %v", podName, err)
 	}
 }

--- a/internal/controller/reconciler_restart.go
+++ b/internal/controller/reconciler_restart.go
@@ -373,14 +373,10 @@ func (r *AerospikeCEClusterReconciler) markDirtyVolumes(
 	}
 
 	if latest.Status.Pods == nil {
-		return nil
+		latest.Status.Pods = make(map[string]asdbcev1alpha1.AerospikePodStatus)
 	}
 
-	podStatus, ok := latest.Status.Pods[podName]
-	if !ok {
-		return nil
-	}
-
+	podStatus := latest.Status.Pods[podName]
 	podStatus.DirtyVolumes = dirtyVols
 	latest.Status.Pods[podName] = podStatus
 	return r.Status().Update(ctx, latest)

--- a/internal/template/apply_cluster_test.go
+++ b/internal/template/apply_cluster_test.go
@@ -25,8 +25,10 @@ import (
 )
 
 const (
-	testImageCE8 = "aerospike:ce-8.1.1.1"
-	testImageCE7 = "aerospike:ce-7.2.0.6"
+	testImageCE8     = "aerospike:ce-8.1.1.1"
+	testImageCE7     = "aerospike:ce-7.2.0.6"
+	testTopologyZone = "zone"
+	testMutatedValue = "mutated"
 )
 
 // newCluster returns a minimal AerospikeCECluster for testing.

--- a/internal/template/merge.go
+++ b/internal/template/merge.go
@@ -17,6 +17,8 @@ limitations under the License.
 package template
 
 import (
+	corev1 "k8s.io/api/core/v1"
+
 	asdbcev1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
 )
 
@@ -190,14 +192,16 @@ func mergeTemplateScheduling(base, override *asdbcev1alpha1.TemplateScheduling) 
 		result.PodAntiAffinityLevel = override.PodAntiAffinityLevel
 	}
 	if override.NodeAffinity != nil {
-		result.NodeAffinity = override.NodeAffinity
+		result.NodeAffinity = override.NodeAffinity.DeepCopy()
 	}
-	// Arrays: override replaces entirely.
+	// Arrays: override replaces entirely (deep copy to avoid shared backing array).
 	if len(override.Tolerations) > 0 {
-		result.Tolerations = override.Tolerations
+		result.Tolerations = make([]corev1.Toleration, len(override.Tolerations))
+		copy(result.Tolerations, override.Tolerations)
 	}
 	if len(override.TopologySpreadConstraints) > 0 {
-		result.TopologySpreadConstraints = override.TopologySpreadConstraints
+		result.TopologySpreadConstraints = make([]corev1.TopologySpreadConstraint, len(override.TopologySpreadConstraints))
+		copy(result.TopologySpreadConstraints, override.TopologySpreadConstraints)
 	}
 	if override.PodManagementPolicy != "" {
 		result.PodManagementPolicy = override.PodManagementPolicy

--- a/internal/template/resolver_test.go
+++ b/internal/template/resolver_test.go
@@ -354,7 +354,7 @@ func TestApplyScheduling_TopologySpreadConstraints(t *testing.T) {
 	cluster := &asdbcev1alpha1.AerospikeCECluster{}
 	scheduling := &asdbcev1alpha1.TemplateScheduling{
 		TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
-			{MaxSkew: 1, TopologyKey: "zone", WhenUnsatisfiable: corev1.DoNotSchedule},
+			{MaxSkew: 1, TopologyKey: testTopologyZone, WhenUnsatisfiable: corev1.DoNotSchedule},
 		},
 	}
 
@@ -363,7 +363,7 @@ func TestApplyScheduling_TopologySpreadConstraints(t *testing.T) {
 	if cluster.Spec.PodSpec == nil || len(cluster.Spec.PodSpec.TopologySpreadConstraints) == 0 {
 		t.Fatal("expected TopologySpreadConstraints to be applied")
 	}
-	if cluster.Spec.PodSpec.TopologySpreadConstraints[0].TopologyKey != "zone" {
+	if cluster.Spec.PodSpec.TopologySpreadConstraints[0].TopologyKey != testTopologyZone {
 		t.Errorf("expected topologyKey=zone, got %q", cluster.Spec.PodSpec.TopologySpreadConstraints[0].TopologyKey)
 	}
 }
@@ -503,9 +503,72 @@ func TestMergeTemplateSpec_SchedulingIsolatedFromBase(t *testing.T) {
 	result := MergeTemplateSpec(base, override)
 
 	// Mutating result's Tolerations must NOT affect base.
-	result.Scheduling.Tolerations[0].Key = "mutated"
+	result.Scheduling.Tolerations[0].Key = testMutatedValue
 	if base.Scheduling.Tolerations[0].Key != "base-key" {
 		t.Error("mutating merge result must not affect the original base (shallow copy bug)")
+	}
+}
+
+func TestMergeTemplateSpec_NodeAffinityIsolatedFromOverride(t *testing.T) {
+	base := &asdbcev1alpha1.AerospikeCEClusterTemplateSpec{
+		Scheduling: &asdbcev1alpha1.TemplateScheduling{
+			PodAntiAffinityLevel: asdbcev1alpha1.PodAntiAffinityPreferred,
+		},
+	}
+	override := &asdbcev1alpha1.AerospikeCEClusterTemplateSpec{
+		Scheduling: &asdbcev1alpha1.TemplateScheduling{
+			NodeAffinity: &corev1.NodeAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+					NodeSelectorTerms: []corev1.NodeSelectorTerm{
+						{MatchExpressions: []corev1.NodeSelectorRequirement{
+							{Key: "zone", Operator: corev1.NodeSelectorOpIn, Values: []string{"us-east-1a"}},
+						}},
+					},
+				},
+			},
+		},
+	}
+	result := MergeTemplateSpec(base, override)
+
+	result.Scheduling.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.
+		NodeSelectorTerms[0].MatchExpressions[0].Values[0] = testMutatedValue
+	if override.Scheduling.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.
+		NodeSelectorTerms[0].MatchExpressions[0].Values[0] != "us-east-1a" {
+		t.Error("mutating merge result must not affect the override (shallow copy bug in NodeAffinity)")
+	}
+}
+
+func TestMergeTemplateSpec_TolerationsIsolatedFromOverride(t *testing.T) {
+	base := &asdbcev1alpha1.AerospikeCEClusterTemplateSpec{}
+	override := &asdbcev1alpha1.AerospikeCEClusterTemplateSpec{
+		Scheduling: &asdbcev1alpha1.TemplateScheduling{
+			Tolerations: []corev1.Toleration{
+				{Key: "original", Operator: corev1.TolerationOpExists},
+			},
+		},
+	}
+	result := MergeTemplateSpec(base, override)
+
+	result.Scheduling.Tolerations[0].Key = testMutatedValue
+	if override.Scheduling.Tolerations[0].Key != "original" {
+		t.Error("mutating merge result must not affect the override (shallow copy bug in Tolerations)")
+	}
+}
+
+func TestMergeTemplateSpec_TopologySpreadConstraintsIsolatedFromOverride(t *testing.T) {
+	base := &asdbcev1alpha1.AerospikeCEClusterTemplateSpec{}
+	override := &asdbcev1alpha1.AerospikeCEClusterTemplateSpec{
+		Scheduling: &asdbcev1alpha1.TemplateScheduling{
+			TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+				{MaxSkew: 1, TopologyKey: testTopologyZone, WhenUnsatisfiable: corev1.DoNotSchedule},
+			},
+		},
+	}
+	result := MergeTemplateSpec(base, override)
+
+	result.Scheduling.TopologySpreadConstraints[0].TopologyKey = testMutatedValue
+	if override.Scheduling.TopologySpreadConstraints[0].TopologyKey != testTopologyZone {
+		t.Error("mutating merge result must not affect the override (shallow copy bug in TopologySpreadConstraints)")
 	}
 }
 

--- a/internal/template/scheduling.go
+++ b/internal/template/scheduling.go
@@ -86,18 +86,20 @@ func applyScheduling(scheduling *asdbcev1alpha1.TemplateScheduling, cluster *asd
 			ps.Affinity = &corev1.Affinity{}
 		}
 		if ps.Affinity.NodeAffinity == nil {
-			ps.Affinity.NodeAffinity = scheduling.NodeAffinity
+			ps.Affinity.NodeAffinity = scheduling.NodeAffinity.DeepCopy()
 		}
 	}
 
 	// Apply tolerations if not already set.
 	if len(scheduling.Tolerations) > 0 && len(ps.Tolerations) == 0 {
-		ps.Tolerations = scheduling.Tolerations
+		ps.Tolerations = make([]corev1.Toleration, len(scheduling.Tolerations))
+		copy(ps.Tolerations, scheduling.Tolerations)
 	}
 
 	// Apply topology spread constraints if not already set.
 	if len(scheduling.TopologySpreadConstraints) > 0 && len(ps.TopologySpreadConstraints) == 0 {
-		ps.TopologySpreadConstraints = scheduling.TopologySpreadConstraints
+		ps.TopologySpreadConstraints = make([]corev1.TopologySpreadConstraint, len(scheduling.TopologySpreadConstraints))
+		copy(ps.TopologySpreadConstraints, scheduling.TopologySpreadConstraints)
 	}
 
 	// Apply pod management policy if not already set.

--- a/internal/template/scheduling_test.go
+++ b/internal/template/scheduling_test.go
@@ -19,6 +19,8 @@ package template
 import (
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
+
 	asdbcev1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
 )
 
@@ -93,5 +95,63 @@ func TestTranslatePodAntiAffinity(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestApplyScheduling_NodeAffinityDeepCopied(t *testing.T) {
+	nodeAffinity := &corev1.NodeAffinity{
+		RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+			NodeSelectorTerms: []corev1.NodeSelectorTerm{
+				{MatchExpressions: []corev1.NodeSelectorRequirement{
+					{Key: "zone", Operator: corev1.NodeSelectorOpIn, Values: []string{"us-east-1a"}},
+				}},
+			},
+		},
+	}
+	scheduling := &asdbcev1alpha1.TemplateScheduling{NodeAffinity: nodeAffinity}
+	cluster := &asdbcev1alpha1.AerospikeCECluster{}
+
+	applyScheduling(scheduling, cluster)
+
+	// Mutating the cluster's NodeAffinity must not affect the template's original.
+	cluster.Spec.PodSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.
+		NodeSelectorTerms[0].MatchExpressions[0].Values[0] = testMutatedValue
+	if nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.
+		NodeSelectorTerms[0].MatchExpressions[0].Values[0] != "us-east-1a" {
+		t.Error("applyScheduling must deep copy NodeAffinity to avoid shared pointers")
+	}
+}
+
+func TestApplyScheduling_TolerationsDeepCopied(t *testing.T) {
+	scheduling := &asdbcev1alpha1.TemplateScheduling{
+		Tolerations: []corev1.Toleration{
+			{Key: "original", Operator: corev1.TolerationOpExists},
+		},
+	}
+	cluster := &asdbcev1alpha1.AerospikeCECluster{}
+
+	applyScheduling(scheduling, cluster)
+
+	// Mutating the cluster's Tolerations slice must not affect the template.
+	cluster.Spec.PodSpec.Tolerations[0].Key = testMutatedValue
+	if scheduling.Tolerations[0].Key != "original" {
+		t.Error("applyScheduling must deep copy Tolerations to avoid shared backing array")
+	}
+}
+
+func TestApplyScheduling_TopologySpreadConstraintsDeepCopied(t *testing.T) {
+	scheduling := &asdbcev1alpha1.TemplateScheduling{
+		TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+			{MaxSkew: 1, TopologyKey: testTopologyZone, WhenUnsatisfiable: corev1.DoNotSchedule},
+		},
+	}
+	cluster := &asdbcev1alpha1.AerospikeCECluster{}
+
+	applyScheduling(scheduling, cluster)
+
+	// Mutating the cluster's TopologySpreadConstraints must not affect the template.
+	cluster.Spec.PodSpec.TopologySpreadConstraints[0].TopologyKey = testMutatedValue
+	if scheduling.TopologySpreadConstraints[0].TopologyKey != testTopologyZone {
+		t.Error("applyScheduling must deep copy TopologySpreadConstraints to avoid shared backing array")
 	}
 }


### PR DESCRIPTION
## Summary
- **Fix shallow copy bugs in template scheduling/merge**: `applyScheduling()` and `mergeTemplateScheduling()` were assigning `NodeAffinity`, `Tolerations`, `TopologySpreadConstraints` by reference, causing shared mutable state between template and cluster objects. Now uses `DeepCopy()` and explicit slice copying.
- **Fix nil map access in `markDirtyVolumes()`**: Previously returned `nil` silently when `Status.Pods` map was uninitialized or pod entry was missing, causing dirty volume tracking to fail. Now initializes the map when nil.
- **Fix nil map skip in `updateDynamicConfigStatus()`**: Previously skipped the dynamic config status update entirely when `Status.Pods` was nil. Now initializes the map to ensure status is always recorded.
- **Add 6 deep copy isolation tests**: Verify that mutating merged/applied results does not affect the original template or override objects.

## Test plan
- [x] `make lint` — 0 issues
- [x] `make test` — all unit + envtest integration tests pass
- [x] `make build` — compiles successfully
- [x] Deep copy isolation tests verify mutation independence for NodeAffinity, Tolerations, TopologySpreadConstraints in both `applyScheduling` and `mergeTemplateScheduling`