### PR TITLE
fix: correct three event-recording issues found in PR #112 review

### DIFF
--- a/internal/controller/events.go
+++ b/internal/controller/events.go
@@ -12,10 +12,10 @@ const (
 	EventLocalPVCDeleteFailed    = "LocalPVCDeleteFailed"
 
 	// Config management
-	EventConfigMapCreated     = "ConfigMapCreated"
-	EventConfigMapUpdated     = "ConfigMapUpdated"
-	EventDynamicConfigApplied = "DynamicConfigApplied"
-	EventDynamicConfigFailed  = "DynamicConfigStatusFailed"
+	EventConfigMapCreated          = "ConfigMapCreated"
+	EventConfigMapUpdated          = "ConfigMapUpdated"
+	EventDynamicConfigApplied      = "DynamicConfigApplied"
+	EventDynamicConfigStatusFailed = "DynamicConfigStatusFailed"
 
 	// StatefulSet / Rack management
 	EventStatefulSetCreated = "StatefulSetCreated"

--- a/internal/controller/reconciler_cleanup.go
+++ b/internal/controller/reconciler_cleanup.go
@@ -68,6 +68,11 @@ func (r *AerospikeCEClusterReconciler) handleDeletion(
 	}
 
 	controllerutil.RemoveFinalizer(latest, utils.StorageFinalizer)
+	// Emit event before Update: once the finalizer is removed the object is
+	// immediately eligible for garbage collection, so the event must be
+	// recorded while the object still exists in the API server.
+	r.Recorder.Eventf(latest, corev1.EventTypeNormal, EventFinalizerRemoved,
+		"Storage finalizer removed, cluster deletion proceeding")
 	if err := r.Update(ctx, latest); err != nil {
 		if k8serrors.IsConflict(err) {
 			log.V(1).Info("Conflict removing finalizer, will requeue")
@@ -75,8 +80,6 @@ func (r *AerospikeCEClusterReconciler) handleDeletion(
 		}
 		return ctrl.Result{}, err
 	}
-	r.Recorder.Eventf(latest, corev1.EventTypeNormal, EventFinalizerRemoved,
-		"Storage finalizer removed, cluster deletion proceeding")
 
 	log.Info("Cluster deletion handled successfully")
 	return ctrl.Result{}, nil

--- a/internal/controller/reconciler_dynamic_config.go
+++ b/internal/controller/reconciler_dynamic_config.go
@@ -156,7 +156,7 @@ func (r *AerospikeCEClusterReconciler) updateDynamicConfigStatus(
 	latest := &asdbcev1alpha1.AerospikeCECluster{}
 	if err := r.Get(ctx, types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}, latest); err != nil {
 		log.Error(err, "Failed to re-fetch cluster for dynamic config status update", "pod", podName)
-		r.Recorder.Eventf(cluster, corev1.EventTypeWarning, EventDynamicConfigFailed,
+		r.Recorder.Eventf(cluster, corev1.EventTypeWarning, EventDynamicConfigStatusFailed,
 			"Failed to update dynamic config status for pod %s: %v", podName, err)
 		return
 	}
@@ -171,7 +171,7 @@ func (r *AerospikeCEClusterReconciler) updateDynamicConfigStatus(
 	latest.Status.Pods[podName] = podStatus
 	if err := r.Status().Patch(ctx, latest, client.MergeFrom(base)); err != nil {
 		log.Error(err, "Failed to patch dynamic config status", "pod", podName)
-		r.Recorder.Eventf(cluster, corev1.EventTypeWarning, EventDynamicConfigFailed,
+		r.Recorder.Eventf(cluster, corev1.EventTypeWarning, EventDynamicConfigStatusFailed,
 			"Failed to update dynamic config status for pod %s: %v", podName, err)
 	}
 }

--- a/internal/controller/reconciler_events_test.go
+++ b/internal/controller/reconciler_events_test.go
@@ -22,7 +22,7 @@ func TestEventConstants(t *testing.T) {
 		{"ConfigMapCreated", EventConfigMapCreated, "ConfigMapCreated"},
 		{"ConfigMapUpdated", EventConfigMapUpdated, "ConfigMapUpdated"},
 		{"DynamicConfigApplied", EventDynamicConfigApplied, "DynamicConfigApplied"},
-		{"DynamicConfigFailed", EventDynamicConfigFailed, "DynamicConfigStatusFailed"},
+		{"DynamicConfigStatusFailed", EventDynamicConfigStatusFailed, "DynamicConfigStatusFailed"},
 		// StatefulSet / Rack management
 		{"StatefulSetCreated", EventStatefulSetCreated, "StatefulSetCreated"},
 		{"StatefulSetUpdated", EventStatefulSetUpdated, "StatefulSetUpdated"},

--- a/internal/controller/reconciler_restart.go
+++ b/internal/controller/reconciler_restart.go
@@ -172,9 +172,12 @@ func (r *AerospikeCEClusterReconciler) reconcileRollingRestart(
 		restarted++
 	}
 
-	if restarted > 0 {
+	// Emit RollingRestartCompleted only when the batch covered all remaining pods.
+	// In batch-mode restarts this fires on the last batch; intermediate batches skip it.
+	// len(podsToRestart) > 0 is guaranteed by the early-return above.
+	if restarted >= int32(len(podsToRestart)) {
 		r.Recorder.Eventf(cluster, corev1.EventTypeNormal, EventRollingRestartCompleted,
-			"Rolling restart completed for rack %d", rack.ID)
+			"Rolling restart completed for rack %d: all %d pods restarted", rack.ID, restarted)
 	}
 
 	return restarted > 0, nil


### PR DESCRIPTION
Follow-up to #112 (PR review findings).

## Summary

### 1. `EventDynamicConfigFailed` → `EventDynamicConfigStatusFailed` (이름/값 일치화)
- 기존: `EventDynamicConfigFailed = "DynamicConfigStatusFailed"` — 상수 이름과 값이 불일치
- 수정: `EventDynamicConfigStatusFailed = "DynamicConfigStatusFailed"` — 이름과 값 일치
- 영향 파일: `events.go`, `reconciler_dynamic_config.go`, `reconciler_events_test.go`

### 2. `RollingRestartCompleted` 조건 수정 (배치 처리 정확성)
- 기존: `restarted > 0` — 중간 배치에서도 "Completed" 이벤트 emit됨
- 수정: `restarted >= int32(len(podsToRestart))` — 마지막 배치에서만 emit
- 배치 크기 2, 10개 pod 예시: 이전에는 매 배치마다 Completed, 이제 마지막 배치(2/2)에서만 emit
- `len(podsToRestart) > 0`은 이미 앞의 early-return에서 보장되므로 조건 단순화

### 3. `FinalizerRemoved` 이벤트를 `Update` 전으로 이동
- 기존: `RemoveFinalizer` → `Update` → `Eventf` — object 삭제 후 이벤트 기록 시도
- 수정: `RemoveFinalizer` → `Eventf` → `Update` — object가 살아 있을 때 이벤트 기록
- finalizer 제거 후 `Update` 완료 시 Kubernetes가 즉시 object를 GC하므로 이벤트가 유실될 수 있음

## Test plan
- [x] Unit tests pass (`make test`)
- [x] Lint passes (`make lint`) — cyclomatic complexity 유지 (`restarted > 0 &&` 제거로 complexity +0)
- [x] `TestEventConstants` — `EventDynamicConfigStatusFailed` 값 검증 통과