### PR TITLE
improve: fix CI dependency version pattern and stale chart name references

### DIFF
--- a/.github/workflows/publish-chart.yml
+++ b/.github/workflows/publish-chart.yml
@@ -33,7 +33,8 @@ jobs:
           sed -i "s/^version:.*/version: ${TAG}/" charts/acko/Chart.yaml
           sed -i "s/^appVersion:.*/appVersion: \"${TAG}\"/" charts/acko/Chart.yaml
           # Update the acko-crds dependency version reference in acko/Chart.yaml
-          sed -i "s/version: \"0\.1\.0\"/version: \"${TAG}\"/" charts/acko/Chart.yaml
+          # Use a pattern that matches any version string so this works after version bumps.
+          sed -i '/name: acko-crds/{n;s/version: ".*"/version: "'"${TAG}"'"/}' charts/acko/Chart.yaml
 
       - name: Login to GHCR
         run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin

--- a/charts/acko/values.yaml
+++ b/charts/acko/values.yaml
@@ -222,7 +222,7 @@ affinity: {}
 #       whenUnsatisfiable: DoNotSchedule
 #       labelSelector:
 #         matchLabels:
-#           app.kubernetes.io/name: aerospike-operator
+#           app.kubernetes.io/name: acko
 topologySpreadConstraints: []
 
 # -- Priority class name for operator pod
@@ -244,7 +244,7 @@ podLabels: {}
 ui:
   # -- Enable the Aerospike Cluster Manager web UI.
   # Deploys a full-stack management dashboard alongside the operator.
-  # Access via: kubectl port-forward svc/<release>-aerospike-operator-ui 3000:3000
+  # Access via: kubectl port-forward svc/<release>-acko-ui 3000:3000
   enabled: false
 
   # -- Number of UI replicas


### PR DESCRIPTION
## Summary
- Fix hardcoded `0.1.0` version pattern in `publish-chart.yml` that would silently fail after version bumps — replaced with a general regex matching any version string after `name: acko-crds`
- Fix stale `aerospike-operator` references in `values.yaml` comments (topology label selector and UI service name)

Follow-up to #119.

## Test plan
- [x] CI workflow sed pattern verified: `/name: acko-crds/{n;s/version: ".*"/version: "TAG"/}` correctly targets only the dependency version line
- [x] `helm lint charts/acko --set crds.install=false` passes (values.yaml comment-only changes)