### PR TITLE
Fix cert-manager subchart schema validation error on helm install

### DIFF
--- a/charts/aerospike-ce-operator/Chart.yaml
+++ b/charts/aerospike-ce-operator/Chart.yaml
@@ -26,4 +26,4 @@ dependencies:
   - name: cert-manager
     version: 1.17.2
     repository: https://charts.jetstack.io
-    condition: cert-manager.install
+    condition: certManagerSubchart.enabled

--- a/charts/aerospike-ce-operator/values.yaml
+++ b/charts/aerospike-ce-operator/values.yaml
@@ -505,12 +505,21 @@ ui:
 # =============================================================================
 # cert-manager subchart (optional bundled install)
 # =============================================================================
-cert-manager:
-  # -- Install cert-manager as a subchart alongside the operator.
-  # When true, cert-manager v1.17.2 is deployed automatically.
+
+# -- Controls whether cert-manager is installed as a subchart.
+# Kept separate from the `cert-manager:` key to avoid passing unknown properties
+# to cert-manager's strict values schema, which causes schema validation errors.
+# Usage: --set certManagerSubchart.enabled=true
+certManagerSubchart:
+  # -- Install cert-manager v1.17.2 as a subchart alongside the operator.
   # Recommended for quick-start and single-command installs.
   # Set to false (default) if cert-manager is already installed in the cluster.
-  install: false
+  enabled: false
+
+# -- cert-manager subchart values (passed directly to the cert-manager chart).
+# Do NOT add custom keys here — cert-manager enforces a strict JSON schema.
+# See: https://cert-manager.io/docs/installation/helm/#customizing-the-chart-before-installing
+cert-manager:
   crds:
     enabled: true
 

--- a/docs/content/guide/cluster-templates.md
+++ b/docs/content/guide/cluster-templates.md
@@ -221,7 +221,7 @@ Use the `defaultTemplates.enabled=true` option to automatically create all three
 ```bash
 helm install aerospike-ce-operator oci://ghcr.io/kimsoungryoul/charts/aerospike-ce-operator \
   -n aerospike-operator --create-namespace \
-  --set cert-manager.install=true \
+  --set certManagerSubchart.enabled=true \
   --set defaultTemplates.enabled=true
 ```
 

--- a/docs/content/guide/install.md
+++ b/docs/content/guide/install.md
@@ -20,7 +20,7 @@ This guide covers two methods to install the ACKO operator.
 
 cert-manager is required for webhook TLS. Choose one of the following installation methods:
 
-**Option A — Bundle with operator (Recommended):** Pass `--set cert-manager.install=true` when installing the operator. cert-manager is deployed automatically. Skip to [Install the Operator](#install-the-operator).
+**Option A — Bundle with operator (Recommended):** Pass `--set certManagerSubchart.enabled=true` when installing the operator. cert-manager is deployed automatically. Skip to [Install the Operator](#install-the-operator).
 
 **Option B — Install separately:** For GitOps environments or when cert-manager is already managed independently.
 
@@ -51,7 +51,7 @@ The simplest installation method using the published OCI Helm chart.
 # Bundled cert-manager install (recommended)
 helm install aerospike-ce-operator oci://ghcr.io/kimsoungryoul/charts/aerospike-ce-operator \
   -n aerospike-operator --create-namespace \
-  --set cert-manager.install=true
+  --set certManagerSubchart.enabled=true
 ```
 
 ### Customizing Helm Values
@@ -509,7 +509,7 @@ helm install prometheus prometheus-community/kube-prometheus-stack \
 # =============================================================================
 helm install aerospike-ce-operator oci://ghcr.io/kimsoungryoul/charts/aerospike-ce-operator \
   -n aerospike-operator --create-namespace \
-  --set cert-manager.install=true \
+  --set certManagerSubchart.enabled=true \
   --set serviceMonitor.enabled=true \
   --set serviceMonitor.additionalLabels.release=prometheus \
   --set prometheusRule.enabled=true \

--- a/docs/content/quickstart.md
+++ b/docs/content/quickstart.md
@@ -75,7 +75,7 @@ kubectl -n cert-manager wait --for=condition=Available deployment/cert-manager -
 # With bundled cert-manager (recommended if you skipped Step 2)
 helm install aerospike-ce-operator oci://ghcr.io/kimsoungryoul/charts/aerospike-ce-operator \
   -n aerospike-operator --create-namespace \
-  --set cert-manager.install=true
+  --set certManagerSubchart.enabled=true
 ```
 
 Verify the operator is running:

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/guide/cluster-templates.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/guide/cluster-templates.md
@@ -221,7 +221,7 @@ kubectl apply -f config/samples/aerospike-cluster-with-template.yaml
 ```bash
 helm install aerospike-ce-operator oci://ghcr.io/kimsoungryoul/charts/aerospike-ce-operator \
   -n aerospike-operator --create-namespace \
-  --set cert-manager.install=true \
+  --set certManagerSubchart.enabled=true \
   --set defaultTemplates.enabled=true
 ```
 

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/guide/install.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/guide/install.md
@@ -20,7 +20,7 @@ import TabItem from '@theme/TabItem';
 
 cert-manager는 웹훅 TLS에 필요합니다. 아래 두 가지 방법 중 하나를 선택하세요:
 
-**방법 A — 오퍼레이터와 함께 설치 (권장):** 오퍼레이터 설치 시 `--set cert-manager.install=true`를 전달합니다. cert-manager가 자동으로 함께 배포됩니다. [오퍼레이터 설치](#오퍼레이터-설치)로 바로 건너뛰세요.
+**방법 A — 오퍼레이터와 함께 설치 (권장):** 오퍼레이터 설치 시 `--set certManagerSubchart.enabled=true`를 전달합니다. cert-manager가 자동으로 함께 배포됩니다. [오퍼레이터 설치](#오퍼레이터-설치)로 바로 건너뛰세요.
 
 **방법 B — 별도 설치:** GitOps 환경이나 cert-manager를 독립적으로 관리하는 경우.
 
@@ -51,7 +51,7 @@ kubectl -n cert-manager wait --for=condition=Available deployment/cert-manager-w
 # cert-manager 번들 설치 포함 (권장)
 helm install aerospike-ce-operator oci://ghcr.io/kimsoungryoul/charts/aerospike-ce-operator \
   -n aerospike-operator --create-namespace \
-  --set cert-manager.install=true
+  --set certManagerSubchart.enabled=true
 ```
 
 ### Helm 값 커스터마이징
@@ -388,7 +388,7 @@ helm install prometheus prometheus-community/kube-prometheus-stack \
 # =============================================================================
 helm install aerospike-ce-operator oci://ghcr.io/kimsoungryoul/charts/aerospike-ce-operator \
   -n aerospike-operator --create-namespace \
-  --set cert-manager.install=true \
+  --set certManagerSubchart.enabled=true \
   --set serviceMonitor.enabled=true \
   --set serviceMonitor.additionalLabels.release=prometheus \
   --set prometheusRule.enabled=true \

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/quickstart.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/quickstart.md
@@ -75,7 +75,7 @@ kubectl -n cert-manager wait --for=condition=Available deployment/cert-manager -
 # cert-manager 번들 설치 포함 (Step 2를 건너뛴 경우 권장)
 helm install aerospike-ce-operator oci://ghcr.io/kimsoungryoul/charts/aerospike-ce-operator \
   -n aerospike-operator --create-namespace \
-  --set cert-manager.install=true
+  --set certManagerSubchart.enabled=true
 ```
 
 오퍼레이터가 실행 중인지 확인:


### PR DESCRIPTION
## Summary
- Rename Helm subchart condition key from `cert-manager.install` to `certManagerSubchart.enabled` to prevent the flag from being forwarded to the cert-manager subchart's strict JSON schema validator
- The root cause: Helm passes all values nested under `cert-manager:` directly to the cert-manager subchart; cert-manager's schema rejects any unknown property (including `install`), causing `INSTALLATION FAILED: additional properties 'install' not allowed`
- Update all documentation examples (EN + KO) to use `--set certManagerSubchart.enabled=true`

## Test plan
- [x] Unit tests pass (`make test`)
- [x] Lint passes (`make lint`)
- [x] `helm template --set certManagerSubchart.enabled=true` no longer triggers schema validation error
- [ ] E2E install test on Kind cluster (requires cluster)