### PR TITLE
fix: enable defaultTemplates by default in Helm chart

### DIFF
--- a/charts/aerospike-ce-operator/values.yaml
+++ b/charts/aerospike-ce-operator/values.yaml
@@ -512,7 +512,7 @@ defaultTemplates:
   # NOTE: AerospikeClusterTemplate is namespace-scoped. Templates created here are
   # only accessible to AerospikeCluster resources in the same namespace (Release.Namespace).
   # For cross-namespace use, apply templates manually: kubectl apply -f config/samples/acko_v1alpha1_template_*.yaml -n <namespace>
-  enabled: false
+  enabled: true
 
   templates:
     minimal:


### PR DESCRIPTION
## Summary
- `defaultTemplates.enabled`를 `false` → `true`로 변경
- `helm install` 시 minimal, soft-rack, hard-rack AerospikeClusterTemplate 3개가 자동 생성됨

## Test plan
- [x] `helm upgrade`로 로컬 Kind 클러스터에서 검증 완료
- [x] `kubectl get aerospikeclustertemplates -A`로 3개 템플릿 생성 확인