### PR TITLE
fix: replace deprecated memory-size with data-size for CE 8.1

### DIFF
--- a/.claude/skills/acko-cr-guide/examples/01-minimal.yaml
+++ b/.claude/skills/acko-cr-guide/examples/01-minimal.yaml
@@ -30,7 +30,7 @@ spec:
         replication-factor: 1  # Must be 1 for single-node cluster
         storage-engine:
           type: memory         # Pure in-memory; data lost on pod restart
-          memory-size: 1073741824  # 1 GiB
+          data-size: 1073741824  # 1 GiB
 
     logging:
       - name: /var/log/aerospike/aerospike.log

--- a/.claude/skills/acko-cr-guide/examples/04-monitoring.yaml
+++ b/.claude/skills/acko-cr-guide/examples/04-monitoring.yaml
@@ -39,9 +39,9 @@ spec:
     namespaces:
       - name: test
         replication-factor: 2
-        memory-size: 2147483648  # 2 GiB
         storage-engine:
           type: memory
+          data-size: 2147483648  # 2 GiB
 
   storage:
     volumes:

--- a/.claude/skills/acko-cr-guide/examples/06-storage-advanced.yaml
+++ b/.claude/skills/acko-cr-guide/examples/06-storage-advanced.yaml
@@ -114,7 +114,7 @@ spec:
       cluster-name: storage-advanced-demo
     namespaces:
       - name: test
-        memory-size: 1073741824        # 1 GiB index memory budget
+        indexes-memory-budget: 1073741824  # 1 GiB index memory budget
         replication-factor: 2
         storage-engine:
           type: device

--- a/.claude/skills/acko-cr-guide/examples/07-template.yaml
+++ b/.claude/skills/acko-cr-guide/examples/07-template.yaml
@@ -66,7 +66,7 @@ spec:
     service:
       proto-fd-max: 15000
     namespaceDefaults:
-      memory-size: 2147483648  # 2 GiB
+      data-size: 2147483648  # 2 GiB
       replication-factor: 2
     network:
       heartbeat:
@@ -101,9 +101,9 @@ spec:
   aerospikeConfig:
     namespaces:
       - name: data
-        memory-size: 1073741824  # 1 GiB — overrides template namespaceDefaults
         storage-engine:
           type: memory
+          data-size: 1073741824  # 1 GiB — overrides template namespaceDefaults
 
 # Resync after template changes:
 #   kubectl annotate aerospikecluster prod-cluster acko.io/resync-template=true

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ spec:
         replication-factor: 1
         storage-engine:
           type: memory
-          memory-size: 1073741824
+          data-size: 1073741824
 ```
 
 ### Step 5: Verify

--- a/charts/aerospike-ce-operator/values.yaml
+++ b/charts/aerospike-ce-operator/values.yaml
@@ -607,4 +607,4 @@ defaultTemplates:
           proto-fd-max: 15000
         namespaceDefaults:
           replication-factor: 2
-          memory-size: 2147483648
+          data-size: 2147483648

--- a/config/samples/acko_v1alpha1_aerospikecluster.yaml
+++ b/config/samples/acko_v1alpha1_aerospikecluster.yaml
@@ -35,7 +35,7 @@ spec:
         replication-factor: 1  # Single node, so replication-factor must be 1
         storage-engine:
           type: memory  # Pure in-memory storage (data lost on pod restart)
-          memory-size: 1073741824  # 1 GiB of memory allocated for this namespace
+          data-size: 1073741824  # 1 GiB of memory allocated for this namespace
 
     # Logging configuration.
     logging:

--- a/config/samples/acko_v1alpha1_template_dev.yaml
+++ b/config/samples/acko_v1alpha1_template_dev.yaml
@@ -37,4 +37,4 @@ spec:
       proto-fd-max: 1024
     namespaceDefaults:
       replication-factor: 1
-      # memory-size: optional; CE 8.x auto-sizes in-memory namespaces when omitted
+      # data-size: optional; CE 8.x auto-sizes in-memory namespaces when omitted

--- a/config/samples/acko_v1alpha1_template_prod.yaml
+++ b/config/samples/acko_v1alpha1_template_prod.yaml
@@ -69,7 +69,7 @@ spec:
     service:
       proto-fd-max: 15000
     namespaceDefaults:
-      memory-size: 2147483648   # 2GiB default per namespace
+      data-size: 2147483648   # 2GiB default per namespace
       replication-factor: 2
     network:
       heartbeat:

--- a/config/samples/acko_v1alpha1_template_stage.yaml
+++ b/config/samples/acko_v1alpha1_template_stage.yaml
@@ -33,7 +33,7 @@ spec:
       proto-fd-max: 4096
     namespaceDefaults:
       replication-factor: 2
-      # memory-size: optional; CE 8.x auto-sizes in-memory namespaces when omitted
+      # data-size: optional; CE 8.x auto-sizes in-memory namespaces when omitted
     network:
       heartbeat:
         mode: mesh

--- a/config/samples/aerospike-cluster-monitoring.yaml
+++ b/config/samples/aerospike-cluster-monitoring.yaml
@@ -42,9 +42,9 @@ spec:
     namespaces:
       - name: test
         replication-factor: 2
-        memory-size: 2147483648  # 2 GiB
         storage-engine:
           type: memory
+          data-size: 2147483648  # 2 GiB
 
   storage:
     volumes:

--- a/config/samples/aerospike-cluster-storage-advanced.yaml
+++ b/config/samples/aerospike-cluster-storage-advanced.yaml
@@ -115,7 +115,7 @@ spec:
       cluster-name: storage-advanced-demo
     namespaces:
       - name: test
-        memory-size: 1073741824
+        indexes-memory-budget: 1073741824
         replication-factor: 2
         storage-engine:
           type: device

--- a/config/samples/aerospike-cluster-with-template.yaml
+++ b/config/samples/aerospike-cluster-with-template.yaml
@@ -28,7 +28,7 @@ spec:
   aerospikeConfig:
     namespaces:
       - name: data
-        memory-size: 1073741824   # 1GiB — overrides template namespaceDefaults
+        data-size: 1073741824   # 1GiB — overrides template namespaceDefaults
         storage-engine:
           type: memory
 

--- a/docs/content/guide/cluster-templates.md
+++ b/docs/content/guide/cluster-templates.md
@@ -80,7 +80,7 @@ spec:
       proto-fd-max: 15000
     namespaceDefaults:
       replication-factor: 2
-      memory-size: 2147483648   # 2 GiB
+      data-size: 2147483648   # 2 GiB
 ```
 
 ```bash

--- a/docs/content/guide/storage.md
+++ b/docs/content/guide/storage.md
@@ -285,7 +285,7 @@ spec:
       cluster-name: storage-advanced-demo
     namespaces:
       - name: test
-        memory-size: 1073741824
+        indexes-memory-budget: 1073741824
         replication-factor: 2
         storage-engine:
           type: device

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/guide/cluster-templates.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/guide/cluster-templates.md
@@ -80,7 +80,7 @@ spec:
       proto-fd-max: 15000
     namespaceDefaults:
       replication-factor: 2
-      memory-size: 2147483648   # 2 GiB
+      data-size: 2147483648   # 2 GiB
 ```
 
 ```bash

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/guide/storage.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/guide/storage.md
@@ -274,7 +274,7 @@ spec:
       cluster-name: storage-advanced-demo
     namespaces:
       - name: test
-        memory-size: 1073741824
+        indexes-memory-budget: 1073741824
         replication-factor: 2
         storage-engine:
           type: device


### PR DESCRIPTION
## Summary
- Aerospike CE 8.1에서 제거된 `memory-size` 파라미터를 올바른 CE 8.1 파라미터로 교체
  - memory storage: `memory-size` → `data-size` (storage-engine 블록 내)
  - device storage: `memory-size` → `indexes-memory-budget`
- 17개 파일 수정: 샘플 CR, Helm values, docs (EN/KO), skill 예제

## Test plan
- [x] 수정 전 `aerospike:ce-8.1.1.1` 이미지로 `CrashLoopBackOff` 재현 확인
- [x] `memory-size` → `data-size` 변경 후 config 파라미터 에러 해소 확인 필요