### PR TITLE
fix: use post-install hook for default AerospikeClusterTemplate resources

### DIFF
--- a/charts/aerospike-ce-operator/templates/default-templates.yaml
+++ b/charts/aerospike-ce-operator/templates/default-templates.yaml
@@ -9,6 +9,9 @@ metadata:
   labels:
     {{- include "aerospike-ce-operator.labels" $ | nindent 4 }}
     app.kubernetes.io/component: cluster-template
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "10"
 spec:
   {{- toYaml $spec | nindent 2 }}
 {{- end }}


### PR DESCRIPTION
## Summary
- `default-templates.yaml`에 `helm.sh/hook: post-install,post-upgrade` 추가
- CRD subchart가 templates/로 CRD를 설치하므로, Helm이 CR보다 CRD를 먼저 적용하는 것을 보장할 수 없음
- hook으로 CRD 적용 후 default template이 생성되도록 수정

## Test plan
- [x] CRD 없는 fresh Kind 클러스터에서 `helm install` 성공 확인
- [x] `kubectl get aerospikeclustertemplates -A`로 3개 템플릿 정상 생성 확인