### PR TITLE
fix: sync CRDs subchart with latest generated CRDs

### DIFF
--- a/charts/aerospike-ce-operator-crds/templates/aerospikecluster-crd.yaml
+++ b/charts/aerospike-ce-operator-crds/templates/aerospikecluster-crd.yaml
@@ -30,6 +30,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    - jsonPath: .status.conditions[?(@.type=='Available')].status
+      name: Available
+      type: string
     - jsonPath: .spec.image
       name: Image
       priority: 1
@@ -42,6 +45,10 @@ spec:
       name: PhaseReason
       priority: 1
       type: string
+    - jsonPath: .status.aerospikeClusterSize
+      name: AS-Size
+      priority: 1
+      type: integer
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -252,6 +259,7 @@ spec:
                 description: |-
                   Image is the Aerospike CE server container image.
                   Must be a community edition image (e.g., aerospike:ce-8.1.1.1).
+                  When spec.templateRef is set, image may be omitted and the template's default will be used.
                 type: string
               k8sNodeBlockList:
                 description: K8sNodeBlockList contains Kubernetes node names that
@@ -650,6 +658,359 @@ spec:
                           Uses the same format as aerospikeConfig.service.
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                  aerospikeNetworkPolicy:
+                    description: |-
+                      AerospikeNetworkPolicy defines the default network access configuration.
+                      Clusters that explicitly set spec.aerospikeNetworkPolicy will override this entirely.
+                    properties:
+                      accessType:
+                        default: pod
+                        description: AccessType determines how clients access the
+                          Aerospike service port.
+                        enum:
+                        - pod
+                        - hostInternal
+                        - hostExternal
+                        - configuredIP
+                        type: string
+                      alternateAccessType:
+                        default: pod
+                        description: |-
+                          AlternateAccessType determines how clients from alternate networks
+                          access the Aerospike service port.
+                        enum:
+                        - pod
+                        - hostInternal
+                        - hostExternal
+                        - configuredIP
+                        type: string
+                      customAccessNetworkNames:
+                        description: CustomAccessNetworkNames specifies network names
+                          for configuredIP access type.
+                        items:
+                          type: string
+                        type: array
+                      customAlternateAccessNetworkNames:
+                        description: |-
+                          CustomAlternateAccessNetworkNames specifies network names for
+                          configuredIP alternate access type.
+                        items:
+                          type: string
+                        type: array
+                      customFabricNetworkNames:
+                        description: |-
+                          CustomFabricNetworkNames specifies network names for
+                          configuredIP fabric type.
+                        items:
+                          type: string
+                        type: array
+                      fabricType:
+                        default: pod
+                        description: FabricType determines the network type for fabric
+                          (inter-node) communication.
+                        enum:
+                        - pod
+                        - hostInternal
+                        - hostExternal
+                        - configuredIP
+                        type: string
+                    type: object
+                  image:
+                    description: |-
+                      Image is the default Aerospike CE container image for clusters using this template.
+                      Must be a community edition image (e.g., aerospike:ce-8.1.1.1).
+                      Clusters can override this by explicitly setting spec.image.
+                    type: string
+                  monitoring:
+                    description: |-
+                      Monitoring configures default Prometheus monitoring via an exporter sidecar.
+                      Clusters that explicitly set spec.monitoring will override this entirely.
+                    properties:
+                      enabled:
+                        description: Enabled enables the Prometheus exporter sidecar.
+                        type: boolean
+                      env:
+                        description: |-
+                          Env specifies additional environment variables for the exporter container.
+                          These can be used for metric filtering, custom configuration, etc.
+                          User-provided env vars are appended last, allowing intentional overrides.
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: |-
+                                Name of the environment variable.
+                                May consist of any printable ASCII characters except '='.
+                              type: string
+                            value:
+                              description: |-
+                                Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables in the container and
+                                any service environment variables. If a variable cannot be resolved,
+                                the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                Escaped references will never be expanded, regardless of whether the variable
+                                exists or not.
+                                Defaults to "".
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  description: |-
+                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fileKeyRef:
+                                  description: |-
+                                    FileKeyRef selects a key of the env file.
+                                    Requires the EnvFiles feature gate to be enabled.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        The key within the env file. An invalid key will prevent the pod from starting.
+                                        The keys defined within a source may consist of any printable ASCII characters except '='.
+                                        During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                      type: string
+                                    optional:
+                                      default: false
+                                      description: |-
+                                        Specify whether the file or its key must be defined. If the file or key
+                                        does not exist, then the env var is not published.
+                                        If optional is set to true and the specified key does not exist,
+                                        the environment variable will not be set in the Pod's containers.
+
+                                        If optional is set to false and the specified key does not exist,
+                                        an error will be returned during Pod creation.
+                                      type: boolean
+                                    path:
+                                      description: |-
+                                        The path within the volume from which to select the file.
+                                        Must be relative and may not contain the '..' path or start with '..'.
+                                      type: string
+                                    volumeName:
+                                      description: The name of the volume mount containing
+                                        the env file.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  - volumeName
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  description: |-
+                                    Selects a resource of the container: only resources limits and requests
+                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      exporterImage:
+                        description: |-
+                          ExporterImage is the Aerospike Prometheus exporter container image.
+                          Defaults to "aerospike/aerospike-prometheus-exporter:v1.16.1".
+                        type: string
+                      metricLabels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          MetricLabels specifies custom labels to add to all exported metrics.
+                          These are passed to the exporter via the METRIC_LABELS environment variable
+                          as sorted key=value pairs.
+                        type: object
+                      port:
+                        description: Port is the metrics port for the exporter. Defaults
+                          to 9145.
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
+                      prometheusRule:
+                        description: PrometheusRule configures automatic PrometheusRule
+                          creation for Aerospike cluster alerts.
+                        properties:
+                          customRules:
+                            description: |-
+                              CustomRules completely replaces the default alert rules when provided.
+                              When set, the built-in alerts (NodeDown, StopWrites, HighDiskUsage, HighMemoryUsage)
+                              are NOT generated. Each entry must be a complete Prometheus rule group object.
+                            items:
+                              x-kubernetes-preserve-unknown-fields: true
+                            type: array
+                          enabled:
+                            description: Enabled enables PrometheusRule creation.
+                            type: boolean
+                          labels:
+                            additionalProperties:
+                              type: string
+                            description: Labels are additional labels to add to the
+                              PrometheusRule for discovery.
+                            type: object
+                        type: object
+                      resources:
+                        description: Resources defines CPU and memory resource requests/limits
+                          for the exporter.
+                        properties:
+                          claims:
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+
+                              This field depends on the
+                              DynamicResourceAllocation feature gate.
+
+                              This field is immutable. It can only be set for containers.
+                            items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
+                                    inside a container.
+                                  type: string
+                                request:
+                                  description: |-
+                                    Request is the name chosen for a request in the referenced claim.
+                                    If empty, everything from the claim is made available, otherwise
+                                    only the result of this request.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                        type: object
+                      serviceMonitor:
+                        description: ServiceMonitor configures automatic ServiceMonitor
+                          creation for Prometheus Operator.
+                        properties:
+                          enabled:
+                            description: Enabled enables ServiceMonitor creation.
+                            type: boolean
+                          interval:
+                            description: Interval is the Prometheus scrape interval.
+                              Defaults to "30s".
+                            type: string
+                          labels:
+                            additionalProperties:
+                              type: string
+                            description: Labels are additional labels to add to the
+                              ServiceMonitor for discovery.
+                            type: object
+                        type: object
                     type: object
                   rackConfig:
                     description: RackConfig defines rack-level configuration defaults.
@@ -1154,6 +1515,15 @@ spec:
                           type: object
                         type: array
                     type: object
+                  size:
+                    description: |-
+                      Size is the default number of Aerospike nodes for clusters using this template.
+                      CE limits this to a maximum of 8.
+                      Clusters that explicitly set spec.size (non-zero) will override this value.
+                    format: int32
+                    maximum: 8
+                    minimum: 1
+                    type: integer
                   storage:
                     description: Storage defines the default data volume configuration.
                     properties:
@@ -4009,6 +4379,15 @@ spec:
                     - OrderedReady
                     - Parallel
                     type: string
+                  readinessGateEnabled:
+                    description: |-
+                      ReadinessGateEnabled enables the custom Pod Readiness Gate "acko.io/aerospike-ready".
+                      When true, the operator injects the gate into each pod's spec and patches
+                      pod.Status.Conditions to True only after Aerospike has joined the cluster mesh
+                      and finished all data migrations. Pods are excluded from Service endpoints
+                      until the gate is satisfied.
+                      Defaults to false for backward compatibility.
+                    type: boolean
                   securityContext:
                     description: SecurityContext defines pod-level security attributes.
                     properties:
@@ -7652,9 +8031,10 @@ spec:
                 description: |-
                   Size is the number of Aerospike nodes (pods) in the cluster.
                   CE limits this to a maximum of 8.
+                  When spec.templateRef is set, size may be omitted and the template's default will be used.
                 format: int32
                 maximum: 8
-                minimum: 1
+                minimum: 0
                 type: integer
               storage:
                 description: Storage defines volumes and volume mounts for Aerospike
@@ -8196,14 +8576,17 @@ spec:
                       is mounted on persistent storage.
                     type: boolean
                 type: object
-            required:
-            - image
-            - size
             type: object
           status:
             description: AerospikeClusterStatus defines the observed state of the
               Aerospike CE cluster.
             properties:
+              aerospikeClusterSize:
+                description: |-
+                  AerospikeClusterSize is the Aerospike cluster-size as reported by asinfo.
+                  This may differ from the number of ready K8s pods during split-brain or rolling restarts.
+                format: int32
+                type: integer
               aerospikeConfig:
                 description: AerospikeConfig is the last applied Aerospike configuration.
                 type: object
@@ -8397,6 +8780,7 @@ spec:
                     description: |-
                       Image is the Aerospike CE server container image.
                       Must be a community edition image (e.g., aerospike:ce-8.1.1.1).
+                      When spec.templateRef is set, image may be omitted and the template's default will be used.
                     type: string
                   k8sNodeBlockList:
                     description: K8sNodeBlockList contains Kubernetes node names that
@@ -8798,6 +9182,361 @@ spec:
                               Uses the same format as aerospikeConfig.service.
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      aerospikeNetworkPolicy:
+                        description: |-
+                          AerospikeNetworkPolicy defines the default network access configuration.
+                          Clusters that explicitly set spec.aerospikeNetworkPolicy will override this entirely.
+                        properties:
+                          accessType:
+                            default: pod
+                            description: AccessType determines how clients access
+                              the Aerospike service port.
+                            enum:
+                            - pod
+                            - hostInternal
+                            - hostExternal
+                            - configuredIP
+                            type: string
+                          alternateAccessType:
+                            default: pod
+                            description: |-
+                              AlternateAccessType determines how clients from alternate networks
+                              access the Aerospike service port.
+                            enum:
+                            - pod
+                            - hostInternal
+                            - hostExternal
+                            - configuredIP
+                            type: string
+                          customAccessNetworkNames:
+                            description: CustomAccessNetworkNames specifies network
+                              names for configuredIP access type.
+                            items:
+                              type: string
+                            type: array
+                          customAlternateAccessNetworkNames:
+                            description: |-
+                              CustomAlternateAccessNetworkNames specifies network names for
+                              configuredIP alternate access type.
+                            items:
+                              type: string
+                            type: array
+                          customFabricNetworkNames:
+                            description: |-
+                              CustomFabricNetworkNames specifies network names for
+                              configuredIP fabric type.
+                            items:
+                              type: string
+                            type: array
+                          fabricType:
+                            default: pod
+                            description: FabricType determines the network type for
+                              fabric (inter-node) communication.
+                            enum:
+                            - pod
+                            - hostInternal
+                            - hostExternal
+                            - configuredIP
+                            type: string
+                        type: object
+                      image:
+                        description: |-
+                          Image is the default Aerospike CE container image for clusters using this template.
+                          Must be a community edition image (e.g., aerospike:ce-8.1.1.1).
+                          Clusters can override this by explicitly setting spec.image.
+                        type: string
+                      monitoring:
+                        description: |-
+                          Monitoring configures default Prometheus monitoring via an exporter sidecar.
+                          Clusters that explicitly set spec.monitoring will override this entirely.
+                        properties:
+                          enabled:
+                            description: Enabled enables the Prometheus exporter sidecar.
+                            type: boolean
+                          env:
+                            description: |-
+                              Env specifies additional environment variables for the exporter container.
+                              These can be used for metric filtering, custom configuration, etc.
+                              User-provided env vars are appended last, allowing intentional overrides.
+                            items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name of the environment variable.
+                                    May consist of any printable ASCII characters except '='.
+                                  type: string
+                                value:
+                                  description: |-
+                                    Variable references $(VAR_NAME) are expanded
+                                    using the previously defined environment variables in the container and
+                                    any service environment variables. If a variable cannot be resolved,
+                                    the reference in the input string will be unchanged. Double $$ are reduced
+                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                    "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                    Escaped references will never be expanded, regardless of whether the variable
+                                    exists or not.
+                                    Defaults to "".
+                                  type: string
+                                valueFrom:
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    fieldRef:
+                                      description: |-
+                                        Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                        spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    fileKeyRef:
+                                      description: |-
+                                        FileKeyRef selects a key of the env file.
+                                        Requires the EnvFiles feature gate to be enabled.
+                                      properties:
+                                        key:
+                                          description: |-
+                                            The key within the env file. An invalid key will prevent the pod from starting.
+                                            The keys defined within a source may consist of any printable ASCII characters except '='.
+                                            During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                          type: string
+                                        optional:
+                                          default: false
+                                          description: |-
+                                            Specify whether the file or its key must be defined. If the file or key
+                                            does not exist, then the env var is not published.
+                                            If optional is set to true and the specified key does not exist,
+                                            the environment variable will not be set in the Pod's containers.
+
+                                            If optional is set to false and the specified key does not exist,
+                                            an error will be returned during Pod creation.
+                                          type: boolean
+                                        path:
+                                          description: |-
+                                            The path within the volume from which to select the file.
+                                            Must be relative and may not contain the '..' path or start with '..'.
+                                          type: string
+                                        volumeName:
+                                          description: The name of the volume mount
+                                            containing the env file.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      - volumeName
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    resourceFieldRef:
+                                      description: |-
+                                        Selects a resource of the container: only resources limits and requests
+                                        (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          exporterImage:
+                            description: |-
+                              ExporterImage is the Aerospike Prometheus exporter container image.
+                              Defaults to "aerospike/aerospike-prometheus-exporter:v1.16.1".
+                            type: string
+                          metricLabels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              MetricLabels specifies custom labels to add to all exported metrics.
+                              These are passed to the exporter via the METRIC_LABELS environment variable
+                              as sorted key=value pairs.
+                            type: object
+                          port:
+                            description: Port is the metrics port for the exporter.
+                              Defaults to 9145.
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          prometheusRule:
+                            description: PrometheusRule configures automatic PrometheusRule
+                              creation for Aerospike cluster alerts.
+                            properties:
+                              customRules:
+                                description: |-
+                                  CustomRules completely replaces the default alert rules when provided.
+                                  When set, the built-in alerts (NodeDown, StopWrites, HighDiskUsage, HighMemoryUsage)
+                                  are NOT generated. Each entry must be a complete Prometheus rule group object.
+                                items:
+                                  x-kubernetes-preserve-unknown-fields: true
+                                type: array
+                              enabled:
+                                description: Enabled enables PrometheusRule creation.
+                                type: boolean
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                description: Labels are additional labels to add to
+                                  the PrometheusRule for discovery.
+                                type: object
+                            type: object
+                          resources:
+                            description: Resources defines CPU and memory resource
+                              requests/limits for the exporter.
+                            properties:
+                              claims:
+                                description: |-
+                                  Claims lists the names of resources, defined in spec.resourceClaims,
+                                  that are used by this container.
+
+                                  This field depends on the
+                                  DynamicResourceAllocation feature gate.
+
+                                  This field is immutable. It can only be set for containers.
+                                items:
+                                  description: ResourceClaim references one entry
+                                    in PodSpec.ResourceClaims.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name must match the name of one entry in pod.spec.resourceClaims of
+                                        the Pod where this field is used. It makes that resource available
+                                        inside a container.
+                                      type: string
+                                    request:
+                                      description: |-
+                                        Request is the name chosen for a request in the referenced claim.
+                                        If empty, everything from the claim is made available, otherwise
+                                        only the result of this request.
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: |-
+                                  Limits describes the maximum amount of compute resources allowed.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: |-
+                                  Requests describes the minimum amount of compute resources required.
+                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                            type: object
+                          serviceMonitor:
+                            description: ServiceMonitor configures automatic ServiceMonitor
+                              creation for Prometheus Operator.
+                            properties:
+                              enabled:
+                                description: Enabled enables ServiceMonitor creation.
+                                type: boolean
+                              interval:
+                                description: Interval is the Prometheus scrape interval.
+                                  Defaults to "30s".
+                                type: string
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                description: Labels are additional labels to add to
+                                  the ServiceMonitor for discovery.
+                                type: object
+                            type: object
                         type: object
                       rackConfig:
                         description: RackConfig defines rack-level configuration defaults.
@@ -9304,6 +10043,15 @@ spec:
                               type: object
                             type: array
                         type: object
+                      size:
+                        description: |-
+                          Size is the default number of Aerospike nodes for clusters using this template.
+                          CE limits this to a maximum of 8.
+                          Clusters that explicitly set spec.size (non-zero) will override this value.
+                        format: int32
+                        maximum: 8
+                        minimum: 1
+                        type: integer
                       storage:
                         description: Storage defines the default data volume configuration.
                         properties:
@@ -12173,6 +12921,15 @@ spec:
                         - OrderedReady
                         - Parallel
                         type: string
+                      readinessGateEnabled:
+                        description: |-
+                          ReadinessGateEnabled enables the custom Pod Readiness Gate "acko.io/aerospike-ready".
+                          When true, the operator injects the gate into each pod's spec and patches
+                          pod.Status.Conditions to True only after Aerospike has joined the cluster mesh
+                          and finished all data migrations. Pods are excluded from Service endpoints
+                          until the gate is satisfied.
+                          Defaults to false for backward compatibility.
+                        type: boolean
                       securityContext:
                         description: SecurityContext defines pod-level security attributes.
                         properties:
@@ -15847,9 +16604,10 @@ spec:
                     description: |-
                       Size is the number of Aerospike nodes (pods) in the cluster.
                       CE limits this to a maximum of 8.
+                      When spec.templateRef is set, size may be omitted and the template's default will be used.
                     format: int32
                     maximum: 8
-                    minimum: 1
+                    minimum: 0
                     type: integer
                   storage:
                     description: Storage defines volumes and volume mounts for Aerospike
@@ -16392,9 +17150,6 @@ spec:
                           is mounted on persistent storage.
                         type: boolean
                     type: object
-                required:
-                - image
-                - size
                 type: object
               conditions:
                 description: Conditions represent the latest observations of the cluster
@@ -16470,6 +17225,11 @@ spec:
                   LastReconcileError is the error message from the most recent failed reconciliation.
                   Cleared on successful reconciliation.
                 type: string
+              lastReconcileTime:
+                description: LastReconcileTime is the timestamp of the last successful
+                  reconciliation.
+                format: date-time
+                type: string
               observedGeneration:
                 description: ObservedGeneration is the most recent generation observed
                   by the controller.
@@ -16514,6 +17274,18 @@ spec:
                     - Deleting
                     type: string
                 type: object
+              operatorVersion:
+                description: |-
+                  OperatorVersion is the version of the operator that last reconciled this cluster.
+                  Injected via ldflags at build time.
+                type: string
+              pendingRestartPods:
+                description: |-
+                  PendingRestartPods lists pods that are queued for restart in the current rolling restart.
+                  Cleared when the rolling restart completes.
+                items:
+                  type: string
+                type: array
               phase:
                 description: Phase indicates the overall cluster phase.
                 enum:
@@ -16578,6 +17350,21 @@ spec:
                       description: IsRunningAndReady indicates whether the pod is
                         running and ready.
                       type: boolean
+                    lastRestartReason:
+                      description: LastRestartReason is the reason the pod was last
+                        restarted by the operator.
+                      enum:
+                      - ConfigChanged
+                      - ImageChanged
+                      - PodSpecChanged
+                      - ManualRestart
+                      - WarmRestart
+                      type: string
+                    lastRestartTime:
+                      description: LastRestartTime is the timestamp when the pod was
+                        last restarted by the operator.
+                      format: date-time
+                      type: string
                     nodeID:
                       description: |-
                         NodeID is the Aerospike-assigned node identifier (e.g. "BB9020012AC4202").
@@ -16597,11 +17384,23 @@ spec:
                     rack:
                       description: Rack is the rack ID assigned to this pod.
                       type: integer
+                    readinessGateSatisfied:
+                      description: |-
+                        ReadinessGateSatisfied reflects whether the "acko.io/aerospike-ready" readiness gate
+                        condition is currently True for this pod. Only meaningful when
+                        spec.podSpec.readinessGateEnabled=true.
+                      type: boolean
                     servicePort:
                       description: ServicePort is the Aerospike service port exposed
                         via node/LB.
                       format: int32
                       type: integer
+                    unstableSince:
+                      description: |-
+                        UnstableSince records the first time this pod became NotReady.
+                        Reset to nil when the pod returns to Ready. Useful for alerting on long-running instability.
+                      format: date-time
+                      type: string
                   type: object
                 description: Pods contains status information for each pod in the
                   cluster.
@@ -16671,6 +17470,361 @@ spec:
                               Uses the same format as aerospikeConfig.service.
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      aerospikeNetworkPolicy:
+                        description: |-
+                          AerospikeNetworkPolicy defines the default network access configuration.
+                          Clusters that explicitly set spec.aerospikeNetworkPolicy will override this entirely.
+                        properties:
+                          accessType:
+                            default: pod
+                            description: AccessType determines how clients access
+                              the Aerospike service port.
+                            enum:
+                            - pod
+                            - hostInternal
+                            - hostExternal
+                            - configuredIP
+                            type: string
+                          alternateAccessType:
+                            default: pod
+                            description: |-
+                              AlternateAccessType determines how clients from alternate networks
+                              access the Aerospike service port.
+                            enum:
+                            - pod
+                            - hostInternal
+                            - hostExternal
+                            - configuredIP
+                            type: string
+                          customAccessNetworkNames:
+                            description: CustomAccessNetworkNames specifies network
+                              names for configuredIP access type.
+                            items:
+                              type: string
+                            type: array
+                          customAlternateAccessNetworkNames:
+                            description: |-
+                              CustomAlternateAccessNetworkNames specifies network names for
+                              configuredIP alternate access type.
+                            items:
+                              type: string
+                            type: array
+                          customFabricNetworkNames:
+                            description: |-
+                              CustomFabricNetworkNames specifies network names for
+                              configuredIP fabric type.
+                            items:
+                              type: string
+                            type: array
+                          fabricType:
+                            default: pod
+                            description: FabricType determines the network type for
+                              fabric (inter-node) communication.
+                            enum:
+                            - pod
+                            - hostInternal
+                            - hostExternal
+                            - configuredIP
+                            type: string
+                        type: object
+                      image:
+                        description: |-
+                          Image is the default Aerospike CE container image for clusters using this template.
+                          Must be a community edition image (e.g., aerospike:ce-8.1.1.1).
+                          Clusters can override this by explicitly setting spec.image.
+                        type: string
+                      monitoring:
+                        description: |-
+                          Monitoring configures default Prometheus monitoring via an exporter sidecar.
+                          Clusters that explicitly set spec.monitoring will override this entirely.
+                        properties:
+                          enabled:
+                            description: Enabled enables the Prometheus exporter sidecar.
+                            type: boolean
+                          env:
+                            description: |-
+                              Env specifies additional environment variables for the exporter container.
+                              These can be used for metric filtering, custom configuration, etc.
+                              User-provided env vars are appended last, allowing intentional overrides.
+                            items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name of the environment variable.
+                                    May consist of any printable ASCII characters except '='.
+                                  type: string
+                                value:
+                                  description: |-
+                                    Variable references $(VAR_NAME) are expanded
+                                    using the previously defined environment variables in the container and
+                                    any service environment variables. If a variable cannot be resolved,
+                                    the reference in the input string will be unchanged. Double $$ are reduced
+                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                    "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                    Escaped references will never be expanded, regardless of whether the variable
+                                    exists or not.
+                                    Defaults to "".
+                                  type: string
+                                valueFrom:
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    fieldRef:
+                                      description: |-
+                                        Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                        spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    fileKeyRef:
+                                      description: |-
+                                        FileKeyRef selects a key of the env file.
+                                        Requires the EnvFiles feature gate to be enabled.
+                                      properties:
+                                        key:
+                                          description: |-
+                                            The key within the env file. An invalid key will prevent the pod from starting.
+                                            The keys defined within a source may consist of any printable ASCII characters except '='.
+                                            During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                          type: string
+                                        optional:
+                                          default: false
+                                          description: |-
+                                            Specify whether the file or its key must be defined. If the file or key
+                                            does not exist, then the env var is not published.
+                                            If optional is set to true and the specified key does not exist,
+                                            the environment variable will not be set in the Pod's containers.
+
+                                            If optional is set to false and the specified key does not exist,
+                                            an error will be returned during Pod creation.
+                                          type: boolean
+                                        path:
+                                          description: |-
+                                            The path within the volume from which to select the file.
+                                            Must be relative and may not contain the '..' path or start with '..'.
+                                          type: string
+                                        volumeName:
+                                          description: The name of the volume mount
+                                            containing the env file.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      - volumeName
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    resourceFieldRef:
+                                      description: |-
+                                        Selects a resource of the container: only resources limits and requests
+                                        (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          exporterImage:
+                            description: |-
+                              ExporterImage is the Aerospike Prometheus exporter container image.
+                              Defaults to "aerospike/aerospike-prometheus-exporter:v1.16.1".
+                            type: string
+                          metricLabels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              MetricLabels specifies custom labels to add to all exported metrics.
+                              These are passed to the exporter via the METRIC_LABELS environment variable
+                              as sorted key=value pairs.
+                            type: object
+                          port:
+                            description: Port is the metrics port for the exporter.
+                              Defaults to 9145.
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          prometheusRule:
+                            description: PrometheusRule configures automatic PrometheusRule
+                              creation for Aerospike cluster alerts.
+                            properties:
+                              customRules:
+                                description: |-
+                                  CustomRules completely replaces the default alert rules when provided.
+                                  When set, the built-in alerts (NodeDown, StopWrites, HighDiskUsage, HighMemoryUsage)
+                                  are NOT generated. Each entry must be a complete Prometheus rule group object.
+                                items:
+                                  x-kubernetes-preserve-unknown-fields: true
+                                type: array
+                              enabled:
+                                description: Enabled enables PrometheusRule creation.
+                                type: boolean
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                description: Labels are additional labels to add to
+                                  the PrometheusRule for discovery.
+                                type: object
+                            type: object
+                          resources:
+                            description: Resources defines CPU and memory resource
+                              requests/limits for the exporter.
+                            properties:
+                              claims:
+                                description: |-
+                                  Claims lists the names of resources, defined in spec.resourceClaims,
+                                  that are used by this container.
+
+                                  This field depends on the
+                                  DynamicResourceAllocation feature gate.
+
+                                  This field is immutable. It can only be set for containers.
+                                items:
+                                  description: ResourceClaim references one entry
+                                    in PodSpec.ResourceClaims.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name must match the name of one entry in pod.spec.resourceClaims of
+                                        the Pod where this field is used. It makes that resource available
+                                        inside a container.
+                                      type: string
+                                    request:
+                                      description: |-
+                                        Request is the name chosen for a request in the referenced claim.
+                                        If empty, everything from the claim is made available, otherwise
+                                        only the result of this request.
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: |-
+                                  Limits describes the maximum amount of compute resources allowed.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: |-
+                                  Requests describes the minimum amount of compute resources required.
+                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                            type: object
+                          serviceMonitor:
+                            description: ServiceMonitor configures automatic ServiceMonitor
+                              creation for Prometheus Operator.
+                            properties:
+                              enabled:
+                                description: Enabled enables ServiceMonitor creation.
+                                type: boolean
+                              interval:
+                                description: Interval is the Prometheus scrape interval.
+                                  Defaults to "30s".
+                                type: string
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                description: Labels are additional labels to add to
+                                  the ServiceMonitor for discovery.
+                                type: object
+                            type: object
                         type: object
                       rackConfig:
                         description: RackConfig defines rack-level configuration defaults.
@@ -17177,6 +18331,15 @@ spec:
                               type: object
                             type: array
                         type: object
+                      size:
+                        description: |-
+                          Size is the default number of Aerospike nodes for clusters using this template.
+                          CE limits this to a maximum of 8.
+                          Clusters that explicitly set spec.size (non-zero) will override this value.
+                        format: int32
+                        maximum: 8
+                        minimum: 1
+                        type: integer
                       storage:
                         description: Storage defines the default data volume configuration.
                         properties:

--- a/charts/aerospike-ce-operator-crds/templates/aerospikeclustertemplate-crd.yaml
+++ b/charts/aerospike-ce-operator-crds/templates/aerospikeclustertemplate-crd.yaml
@@ -93,6 +93,359 @@ spec:
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                 type: object
+              aerospikeNetworkPolicy:
+                description: |-
+                  AerospikeNetworkPolicy defines the default network access configuration.
+                  Clusters that explicitly set spec.aerospikeNetworkPolicy will override this entirely.
+                properties:
+                  accessType:
+                    default: pod
+                    description: AccessType determines how clients access the Aerospike
+                      service port.
+                    enum:
+                    - pod
+                    - hostInternal
+                    - hostExternal
+                    - configuredIP
+                    type: string
+                  alternateAccessType:
+                    default: pod
+                    description: |-
+                      AlternateAccessType determines how clients from alternate networks
+                      access the Aerospike service port.
+                    enum:
+                    - pod
+                    - hostInternal
+                    - hostExternal
+                    - configuredIP
+                    type: string
+                  customAccessNetworkNames:
+                    description: CustomAccessNetworkNames specifies network names
+                      for configuredIP access type.
+                    items:
+                      type: string
+                    type: array
+                  customAlternateAccessNetworkNames:
+                    description: |-
+                      CustomAlternateAccessNetworkNames specifies network names for
+                      configuredIP alternate access type.
+                    items:
+                      type: string
+                    type: array
+                  customFabricNetworkNames:
+                    description: |-
+                      CustomFabricNetworkNames specifies network names for
+                      configuredIP fabric type.
+                    items:
+                      type: string
+                    type: array
+                  fabricType:
+                    default: pod
+                    description: FabricType determines the network type for fabric
+                      (inter-node) communication.
+                    enum:
+                    - pod
+                    - hostInternal
+                    - hostExternal
+                    - configuredIP
+                    type: string
+                type: object
+              image:
+                description: |-
+                  Image is the default Aerospike CE container image for clusters using this template.
+                  Must be a community edition image (e.g., aerospike:ce-8.1.1.1).
+                  Clusters can override this by explicitly setting spec.image.
+                type: string
+              monitoring:
+                description: |-
+                  Monitoring configures default Prometheus monitoring via an exporter sidecar.
+                  Clusters that explicitly set spec.monitoring will override this entirely.
+                properties:
+                  enabled:
+                    description: Enabled enables the Prometheus exporter sidecar.
+                    type: boolean
+                  env:
+                    description: |-
+                      Env specifies additional environment variables for the exporter container.
+                      These can be used for metric filtering, custom configuration, etc.
+                      User-provided env vars are appended last, allowing intentional overrides.
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
+                          type: string
+                        value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any service environment variables. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless of whether the variable
+                            exists or not.
+                            Defaults to "".
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: |-
+                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  exporterImage:
+                    description: |-
+                      ExporterImage is the Aerospike Prometheus exporter container image.
+                      Defaults to "aerospike/aerospike-prometheus-exporter:v1.16.1".
+                    type: string
+                  metricLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      MetricLabels specifies custom labels to add to all exported metrics.
+                      These are passed to the exporter via the METRIC_LABELS environment variable
+                      as sorted key=value pairs.
+                    type: object
+                  port:
+                    description: Port is the metrics port for the exporter. Defaults
+                      to 9145.
+                    format: int32
+                    maximum: 65535
+                    minimum: 1
+                    type: integer
+                  prometheusRule:
+                    description: PrometheusRule configures automatic PrometheusRule
+                      creation for Aerospike cluster alerts.
+                    properties:
+                      customRules:
+                        description: |-
+                          CustomRules completely replaces the default alert rules when provided.
+                          When set, the built-in alerts (NodeDown, StopWrites, HighDiskUsage, HighMemoryUsage)
+                          are NOT generated. Each entry must be a complete Prometheus rule group object.
+                        items:
+                          x-kubernetes-preserve-unknown-fields: true
+                        type: array
+                      enabled:
+                        description: Enabled enables PrometheusRule creation.
+                        type: boolean
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: Labels are additional labels to add to the PrometheusRule
+                          for discovery.
+                        type: object
+                    type: object
+                  resources:
+                    description: Resources defines CPU and memory resource requests/limits
+                      for the exporter.
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This field depends on the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                  serviceMonitor:
+                    description: ServiceMonitor configures automatic ServiceMonitor
+                      creation for Prometheus Operator.
+                    properties:
+                      enabled:
+                        description: Enabled enables ServiceMonitor creation.
+                        type: boolean
+                      interval:
+                        description: Interval is the Prometheus scrape interval. Defaults
+                          to "30s".
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: Labels are additional labels to add to the ServiceMonitor
+                          for discovery.
+                        type: object
+                    type: object
+                type: object
               rackConfig:
                 description: RackConfig defines rack-level configuration defaults.
                 properties:
@@ -596,6 +949,15 @@ spec:
                       type: object
                     type: array
                 type: object
+              size:
+                description: |-
+                  Size is the default number of Aerospike nodes for clusters using this template.
+                  CE limits this to a maximum of 8.
+                  Clusters that explicitly set spec.size (non-zero) will override this value.
+                format: int32
+                maximum: 8
+                minimum: 1
+                type: integer
               storage:
                 description: Storage defines the default data volume configuration.
                 properties:


### PR DESCRIPTION
## Summary
- CRDs subchart (`charts/aerospike-ce-operator-crds/templates/`)가 `config/crd/bases/`의 최신 CRD와 동기화되지 않아 Helm 설치 시 `unknown field` 경고 발생 (`spec.image`, `spec.monitoring`, `spec.size` 등)
- 최신 생성된 CRD로 동기화하고 `helm.sh/resource-policy: keep` annotation 유지

## Test plan
- [x] `helm install`시 `unknown field` 경고 없음 확인
- [x] AerospikeClusterTemplate CR 생성 시 `spec.image`, `spec.monitoring`, `spec.size` 필드 정상 인식