### PR TITLE
fix: correct UI ClusterRole apiGroup from wrong domain to acko.io

### DIFF
--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/clusterrole.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/clusterrole.yaml
@@ -6,10 +6,10 @@ metadata:
   labels:
     {{- include "aerospike-ce-kubernetes-operator.ui.labels" . | nindent 4 }}
 rules:
-  - apiGroups: ["aerospike-ce-kubernetes-operator.io"]
+  - apiGroups: ["acko.io"]
     resources: ["aerospikeclusters"]
     verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
-  - apiGroups: ["aerospike-ce-kubernetes-operator.io"]
+  - apiGroups: ["acko.io"]
     resources: ["aerospikeclusters/status"]
     verbs: ["get"]
   - apiGroups: [""]


### PR DESCRIPTION
## Summary

- `ui/clusterrole.yaml`의 `apiGroups` 값이 존재하지 않는 도메인(`aerospike-ce-kubernetes-operator.io`)으로 잘못 설정되어 있었음
- 실제 CRD group인 `acko.io`로 수정
- 이 버그로 인해 `ui.enabled=true`, `ui.k8s.enabled=true` 설정 시에도 UI에서 AerospikeCluster 생성이 RBAC 오류로 실패하던 문제 해결

## Test plan

- [ ] `helm template test charts/aerospike-ce-kubernetes-operator --set ui.enabled=true --set ui.k8s.enabled=true | grep -A 10 "kind: ClusterRole"` 실행 후 `apiGroups: ["acko.io"]` 확인
- [ ] Kind 클러스터 배포 후 UI에서 AerospikeCluster 생성 정상 동작 확인