### PR TITLE
feat: rename SIZE→RackSize and add Health column (1/3 format)

### DIFF
--- a/api/v1alpha1/aerospikecluster_types.go
+++ b/api/v1alpha1/aerospikecluster_types.go
@@ -383,9 +383,13 @@ type AerospikeClusterStatus struct {
 	// +optional
 	Phase AerospikePhase `json:"phase,omitempty"`
 
-	// Size is the current cluster size.
+	// Size is the current number of ready pods.
 	// +optional
 	Size int32 `json:"size,omitempty"`
+
+	// Health is a human-readable summary of pod readiness in "ready/total" format (e.g. "1/3").
+	// +optional
+	Health string `json:"health,omitempty"`
 
 	// Conditions represent the latest observations of the cluster state.
 	// +listType=map
@@ -528,8 +532,8 @@ type AerospikePodStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:subresource:scale:specpath=.spec.size,statuspath=.status.size,selectorpath=.status.selector
 // +kubebuilder:resource:shortName=asc
-// +kubebuilder:printcolumn:name="Size",type=integer,JSONPath=`.spec.size`
-// +kubebuilder:printcolumn:name="Ready",type=integer,JSONPath=`.status.size`
+// +kubebuilder:printcolumn:name="RackSize",type=integer,JSONPath=`.spec.size`
+// +kubebuilder:printcolumn:name="Health",type=string,JSONPath=`.status.health`
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 // +kubebuilder:printcolumn:name="Available",type=string,JSONPath=`.status.conditions[?(@.type=='Available')].status`

--- a/config/crd/bases/acko.io_aerospikeclusters.yaml
+++ b/config/crd/bases/acko.io_aerospikeclusters.yaml
@@ -18,11 +18,11 @@ spec:
   versions:
   - additionalPrinterColumns:
     - jsonPath: .spec.size
-      name: Size
+      name: RackSize
       type: integer
-    - jsonPath: .status.size
-      name: Ready
-      type: integer
+    - jsonPath: .status.health
+      name: Health
+      type: string
     - jsonPath: .status.phase
       name: Phase
       type: string
@@ -17219,6 +17219,10 @@ spec:
                   excessive retries on persistently failing clusters.
                 format: int32
                 type: integer
+              health:
+                description: Health is a human-readable summary of pod readiness in
+                  "ready/total" format (e.g. "1/3").
+                type: string
               lastReconcileError:
                 description: |-
                   LastReconcileError is the error message from the most recent failed reconciliation.
@@ -17410,7 +17414,7 @@ spec:
                 description: Selector is the label selector for HPA compatibility.
                 type: string
               size:
-                description: Size is the current cluster size.
+                description: Size is the current number of ready pods.
                 format: int32
                 type: integer
               templateSnapshot:

--- a/docs/content/quickstart.md
+++ b/docs/content/quickstart.md
@@ -138,8 +138,8 @@ kubectl -n aerospike get pods
 Expected output:
 
 ```
-NAME                 SIZE   PHASE       AGE
-aerospike-ce-basic   1      Completed   60s
+NAME                 RACKSIZE   HEALTH   PHASE       AGE
+aerospike-ce-basic   1          1/1      Completed   60s
 ```
 
 ## Step 6: Connect to Aerospike

--- a/internal/controller/reconciler_status.go
+++ b/internal/controller/reconciler_status.go
@@ -57,6 +57,7 @@ func (r *AerospikeClusterReconciler) updateStatusAndPhase(
 	prevPhase := latest.Status.Phase
 	prevPhaseReason := latest.Status.PhaseReason
 	prevSize := latest.Status.Size
+	prevHealth := latest.Status.Health
 	prevGeneration := latest.Status.ObservedGeneration
 	prevConditions := conditionsSnapshot(latest.Status.Conditions)
 
@@ -75,6 +76,7 @@ func (r *AerospikeClusterReconciler) updateStatusAndPhase(
 	if prevPhase == phase &&
 		prevPhaseReason == phaseReason &&
 		prevSize == readyCount &&
+		prevHealth == latest.Status.Health &&
 		prevGeneration == latest.Generation &&
 		!conditionsChanged(prevConditions, latest.Status.Conditions) {
 		log.V(1).Info("Status unchanged, skipping update",
@@ -259,6 +261,7 @@ func (r *AerospikeClusterReconciler) populateStatus(
 
 	cluster.Status.Pods = podStatuses
 	cluster.Status.Size = readyCount
+	cluster.Status.Health = fmt.Sprintf("%d/%d", readyCount, cluster.Spec.Size)
 	cluster.Status.ObservedGeneration = cluster.Generation
 	cluster.Status.AerospikeConfig = cluster.Spec.AerospikeConfig
 


### PR DESCRIPTION
## Summary

- `SIZE` 컬럼 이름을 `RackSize`로 변경 (`spec.size`)
- `READY` (integer) 컬럼을 `Health` (string) 컬럼으로 교체 — `readyPods/totalSize` 형식 (예: `1/3`)
- `AerospikeClusterStatus`에 `health` 필드 추가
- `populateStatus`에서 `Health` 계산 및 skip-update 비교에 포함
- `quickstart.md` 예시 출력 업데이트

## Before / After

**Before:**
```
NAME             SIZE   READY   PHASE       AGE     AVAILABLE
my-aerospike22   3      1       Completed   3m30s   True
```

**After:**
```
NAME             RACKSIZE   HEALTH   PHASE       AGE     AVAILABLE
my-aerospike22   3          1/3      Completed   3m30s   True
```

## Test plan

- [ ] `make install` 로 CRD 재설치 후 `kubectl get asc` 컬럼 확인
- [ ] ready 파드 수 변경 시 `HEALTH` 컬럼 값 실시간 업데이트 확인