### PR TITLE
feat: namespace dropdown from API, reload-ui-image make target, KO docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ endif
 # Be aware that the target commands are only tested with Docker which is
 # scaffolded by default. However, you might want to replace it to use other
 # tools. (i.e. podman)
-CONTAINER_TOOL ?= docker
+CONTAINER_TOOL ?= podman
 
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.
@@ -113,6 +113,27 @@ lint-config: golangci-lint ## Verify golangci-lint linter configuration
 
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "unknown")
 LDFLAGS = -X github.com/ksr/aerospike-ce-kubernetes-operator/internal/version.Version=$(VERSION)
+
+# UI image settings
+UI_IMG ?= ghcr.io/kimsoungryoul/aerospike-cluster-manager:local
+UI_KIND_CLUSTER ?= kind
+UI_NAMESPACE ?= aerospike-operator
+UI_DEPLOYMENT ?= aerospike-ce-kubernetes-operator-ui
+UI_CONTAINER ?= aerospike-cluster-manager
+
+.PHONY: reload-ui-image
+reload-ui-image: ## Build UI image, load into kind-kind cluster, and restart deployment
+	@echo ">>> [1/3] Building UI image: $(UI_IMG)"
+	$(CONTAINER_TOOL) build -t $(UI_IMG) aerospike-cluster-manager/
+	@echo ">>> [2/3] Loading image into Kind cluster '$(UI_KIND_CLUSTER)'"
+	$(CONTAINER_TOOL) save --format docker-archive -o /tmp/ui-image.tar $(UI_IMG)
+	kind load image-archive /tmp/ui-image.tar --name $(UI_KIND_CLUSTER)
+	rm -f /tmp/ui-image.tar
+	@echo ">>> [3/3] Updating deployment $(UI_DEPLOYMENT)"
+	kubectl -n $(UI_NAMESPACE) set image deployment/$(UI_DEPLOYMENT) \
+		$(UI_CONTAINER)=$(UI_IMG)
+	kubectl -n $(UI_NAMESPACE) rollout status deployment/$(UI_DEPLOYMENT) --timeout=120s
+	@echo ">>> Done. UI reloaded successfully."
 
 .PHONY: build
 build: manifests generate fmt vet ## Build manager binary.

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/api-reference/aerospikecluster.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/api-reference/aerospikecluster.md
@@ -40,7 +40,7 @@ Aerospike CE 클러스터의 원하는 상태를 정의합니다.
 | `storage` | [AerospikeStorageSpec](#aerospikestoragespec) | 아니요 | — | Aerospike 파드의 볼륨 정의. |
 | `rackConfig` | [RackConfig](#rackconfig) | 아니요 | — | 랙 인식 배포 토폴로지. |
 | `aerospikeNetworkPolicy` | [AerospikeNetworkPolicy](#aerospikenetworkpolicy) | 아니요 | — | 클라이언트 접근 네트워크 설정. |
-| `podSpec` | [AerospikePodSpec](#aerospikecepodspec) | 아니요 | — | 파드 레벨 설정. |
+| `podSpec` | [AerospikePodSpec](#aerospikepodspec) | 아니요 | — | 파드 레벨 설정. |
 | `aerospikeAccessControl` | [AerospikeAccessControlSpec](#aerospikeaccesscontrolspec) | 아니요 | — | ACL 역할 및 사용자. |
 | `monitoring` | [AerospikeMonitoringSpec](#aerospikemonitoringspec) | 아니요 | — | Prometheus 모니터링 설정. |
 | `networkPolicyConfig` | [NetworkPolicyConfig](#networkpolicyconfig) | 아니요 | — | 자동 NetworkPolicy 생성. |

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/guide/access-control.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/guide/access-control.md
@@ -1,0 +1,212 @@
+---
+sidebar_position: 4
+title: 접근 제어 (ACL)
+---
+
+# 접근 제어 (ACL)
+
+이 가이드는 오퍼레이터를 사용하여 Aerospike CE 클러스터의 인증 및 권한 부여를 설정하는 방법을 다룹니다.
+
+## 개요
+
+Aerospike CE는 클러스터에 접속하는 대상과 수행 가능한 작업을 제한하는 접근 제어(ACL)를 지원합니다. ACL을 활성화하면:
+
+- 모든 클라이언트 연결은 사용자명과 비밀번호로 인증해야 합니다.
+- 각 사용자는 권한을 정의하는 하나 이상의 **역할(role)** 을 부여받습니다.
+- 오퍼레이터는 Aerospike 관리 API를 통해 역할과 사용자 생성을 관리합니다.
+
+:::warning
+Aerospike CE 8.x는 `aerospike.conf`의 `security` 스탠자를 지원하지 않습니다. ACL은 오퍼레이터의 `aerospikeAccessControl` 스펙을 통해서만 관리되며, 런타임에 Aerospike 관리 API를 사용하여 사용자와 역할을 구성합니다.
+:::
+
+## 사전 준비
+
+### Kubernetes Secret 생성
+
+각 사용자의 비밀번호는 Kubernetes Secret에 저장해야 합니다. Secret에는 `password` 키가 포함되어야 합니다.
+
+```bash
+# admin 사용자 Secret 생성
+kubectl -n aerospike create secret generic admin-secret \
+  --from-literal=password='admin-password-here'
+
+# 애플리케이션 사용자 Secret 생성
+kubectl -n aerospike create secret generic app-secret \
+  --from-literal=password='app-password-here'
+```
+
+## 기본 ACL 설정
+
+최소 ACL 구성은 `sys-admin`과 `user-admin` 역할을 모두 가진 사용자가 최소 한 명 필요합니다.
+
+```yaml
+apiVersion: acko.io/v1alpha1
+kind: AerospikeCluster
+metadata:
+  name: aerospike-acl
+  namespace: aerospike
+spec:
+  size: 3
+  image: aerospike:ce-8.1.1.1
+  aerospikeAccessControl:
+    users:
+      - name: admin
+        secretName: admin-secret
+        roles:
+          - sys-admin
+          - user-admin
+      - name: appuser
+        secretName: app-secret
+        roles:
+          - read-write
+  aerospikeConfig:
+    service:
+      cluster-name: aerospike-acl
+    namespaces:
+      - name: test
+        replication-factor: 2
+        storage-engine:
+          type: memory
+```
+
+## 내장 역할
+
+Aerospike CE는 다음과 같은 사전 정의된 역할을 제공합니다. `roles` 목록에 별도로 정의하지 않고 사용자에게 직접 부여할 수 있습니다.
+
+| 역할 | 설명 |
+|------|------|
+| `user-admin` | 사용자 생성/삭제, 역할 부여/회수 |
+| `sys-admin` | 클러스터 관리 (truncate, config, info 명령) |
+| `data-admin` | 인덱스 관리 (보조 인덱스 생성/삭제, UDF) |
+| `read` | 레코드 읽기 |
+| `write` | 레코드 쓰기 (삽입/수정/삭제) |
+| `read-write` | 레코드 읽기 및 쓰기 |
+| `read-write-udf` | 레코드 읽기, 쓰기, UDF 실행 |
+| `truncate` | 네임스페이스/셋 Truncate |
+
+:::info
+`superuser` 역할은 Aerospike Enterprise Edition에서만 존재합니다. CE 클러스터는 위의 내장 역할을 사용하거나 커스텀 역할을 정의해야 합니다.
+:::
+
+## 커스텀 역할
+
+세밀한 권한으로 커스텀 역할을 정의할 수 있습니다.
+
+```yaml
+spec:
+  aerospikeAccessControl:
+    roles:
+      - name: inventory-reader
+        privileges:
+          - read.inventory           # 'inventory' 네임스페이스 읽기
+      - name: orders-writer
+        privileges:
+          - read-write.orders        # 'orders' 네임스페이스 읽기/쓰기
+          - read-write.orders.items  # 'orders.items' 셋 읽기/쓰기
+    users:
+      - name: admin
+        secretName: admin-secret
+        roles:
+          - sys-admin
+          - user-admin
+      - name: inventory-svc
+        secretName: inventory-secret
+        roles:
+          - inventory-reader
+      - name: orders-svc
+        secretName: orders-secret
+        roles:
+          - orders-writer
+```
+
+### 권한 형식
+
+권한은 `<코드>[.<네임스페이스>[.<셋>]]` 형식을 따릅니다.
+
+| 코드 | 설명 |
+|------|------|
+| `read` | 레코드 읽기 |
+| `write` | 레코드 쓰기 |
+| `read-write` | 레코드 읽기 및 쓰기 |
+| `read-write-udf` | 레코드 읽기, 쓰기, UDF 실행 |
+| `sys-admin` | 시스템 관리 |
+| `user-admin` | 사용자 관리 |
+| `data-admin` | 데이터 관리 |
+| `truncate` | 데이터 Truncate |
+
+**예시:**
+- `read` — 모든 네임스페이스에 대한 전역 읽기
+- `read-write.myns` — `myns` 네임스페이스에 대한 읽기/쓰기
+- `write.myns.myset` — `myns` 내 `myset` 셋에 대한 쓰기
+
+## Webhook 검증 규칙
+
+오퍼레이터의 admission webhook은 다음 ACL 규칙을 적용합니다.
+
+1. **Admin 사용자 필수**: 최소 한 명의 사용자가 `sys-admin`과 `user-admin` 역할을 모두 보유해야 합니다. 이 조건이 충족되지 않으면 초기 설정 이후 오퍼레이터가 ACL을 관리할 수 없습니다.
+
+2. **역할 교차 검증**: 사용자가 참조하는 모든 역할은 내장 역할이거나 `roles` 목록에 명시적으로 정의되어 있어야 합니다. 정의되지 않은 역할 참조는 거부됩니다.
+
+3. **권한 코드 검증**: 커스텀 역할의 각 권한은 유효한 권한 코드를 사용해야 합니다. 유효하지 않은 코드는 설명적인 오류와 함께 거부됩니다.
+
+4. **Secret 필수**: 모든 사용자는 비밀번호가 포함된 Kubernetes Secret을 가리키는 `secretName`이 있어야 합니다.
+
+## 문제 해결
+
+### 일반적인 검증 오류
+
+**"must have at least one user with both 'sys-admin' and 'user-admin' roles"**
+
+최소 한 명의 사용자가 두 역할을 모두 보유하고 있는지 확인하세요.
+
+```yaml
+users:
+  - name: admin
+    secretName: admin-secret
+    roles:
+      - sys-admin
+      - user-admin    # 동일한 사용자에게 두 역할 모두 필요
+```
+
+**"user X references undefined role Y"**
+
+해당 역할이 내장 역할이거나 `roles` 목록에 정의되어 있어야 합니다.
+
+```yaml
+roles:
+  - name: custom-role       # 커스텀 역할 정의
+    privileges:
+      - read.myns
+users:
+  - name: myuser
+    secretName: myuser-secret
+    roles:
+      - custom-role          # 이제 이 참조가 유효합니다
+```
+
+**"role X has invalid privilege code Y"**
+
+유효한 권한 코드(`read`, `write`, `read-write`, `read-write-udf`, `sys-admin`, `user-admin`, `data-admin`, `truncate`)만 사용하세요.
+
+```yaml
+roles:
+  - name: my-role
+    privileges:
+      - read-write.myns     # 유효
+      # - admin.myns        # 유효하지 않음 — 'sys-admin' 또는 'data-admin' 사용
+```
+
+### ACL 상태 확인
+
+배포 후 ACL이 정상 동작하는지 확인합니다.
+
+```bash
+# ACL 동기화에 대한 오퍼레이터 로그 확인
+kubectl -n aerospike-operator logs -l control-plane=controller-manager | grep -i acl
+
+# 인증 정보로 클러스터에 접속
+kubectl -n aerospike exec -it aerospike-acl-0-0 -- asadm -Uadmin -Padmin-password-here
+
+# 사용자 목록 확인 (asadm 내부)
+manage acl show users
+```

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/guide/cluster-manager-ui.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/guide/cluster-manager-ui.md
@@ -1,0 +1,260 @@
+---
+sidebar_position: 6
+title: 클러스터 매니저 UI
+---
+
+# Aerospike 클러스터 매니저 UI
+
+[Aerospike Cluster Manager](https://github.com/KimSoungRyoul/aerospike-cluster-manager)는 Aerospike CE 클러스터를 관리하기 위한 웹 기반 GUI입니다. 오퍼레이터 Helm 차트에 번들로 포함되어 있으며, 오퍼레이터와 함께 선택적 컴포넌트로 배포할 수 있습니다.
+
+UI에는 클러스터 연결 프로파일을 저장하기 위한 PostgreSQL 사이드카(PVC 포함)가 내장되어 있습니다.
+
+---
+
+## 설치
+
+오퍼레이터 설치 시 UI를 활성화합니다.
+
+```bash
+helm install acko oci://ghcr.io/kimsoungryoul/charts/aerospike-ce-kubernetes-operator \
+  --namespace aerospike-operator --create-namespace \
+  --set ui.enabled=true
+```
+
+UI Pod가 실행 중인지 확인합니다.
+
+```bash
+kubectl -n aerospike-operator get pods -l app.kubernetes.io/component=ui
+```
+
+---
+
+## UI 접속
+
+### 포트 포워딩 (개발용)
+
+```bash
+kubectl -n aerospike-operator port-forward svc/acko-aerospike-ce-kubernetes-operator-ui 3000:3000
+```
+
+브라우저에서 [http://localhost:3000](http://localhost:3000)을 엽니다.
+
+:::tip
+서비스 이름은 `<릴리스명>-aerospike-ce-kubernetes-operator-ui` 패턴을 따릅니다. 다른 릴리스 이름을 사용한 경우 그에 맞게 조정하세요.
+```bash
+kubectl -n aerospike-operator port-forward svc/<릴리스명>-aerospike-ce-kubernetes-operator-ui 3000:3000
+```
+:::
+
+### Ingress (운영 환경)
+
+외부에서 지속적으로 접근하려면 Ingress를 활성화합니다.
+
+```bash
+helm install acko oci://ghcr.io/kimsoungryoul/charts/aerospike-ce-kubernetes-operator \
+  --namespace aerospike-operator --create-namespace \
+  --set ui.enabled=true \
+  --set ui.ingress.enabled=true \
+  --set ui.ingress.className=nginx \
+  --set "ui.ingress.hosts[0].host=aerospike-admin.example.com" \
+  --set "ui.ingress.hosts[0].paths[0].path=/" \
+  --set "ui.ingress.hosts[0].paths[0].pathType=Prefix"
+```
+
+---
+
+## 설정 옵션
+
+| 파라미터 | 설명 | 기본값 |
+|----------|------|--------|
+| `ui.enabled` | 클러스터 매니저 UI 활성화 | `false` |
+| `ui.replicaCount` | UI 레플리카 수 | `1` |
+| `ui.image.repository` | UI 컨테이너 이미지 | `ghcr.io/kimsoungryoul/aerospike-cluster-manager` |
+| `ui.image.tag` | 이미지 태그 (비어 있으면 Chart appVersion 사용) | `""` |
+| `ui.service.type` | 서비스 타입 (`ClusterIP`, `NodePort`, `LoadBalancer`) | `ClusterIP` |
+| `ui.service.frontendPort` | 프론트엔드 (Next.js) 포트 | `3000` |
+| `ui.service.backendPort` | 백엔드 (FastAPI) 포트 | `8000` |
+| `ui.postgresql.enabled` | 내장 PostgreSQL 사이드카 배포 | `true` |
+| `ui.k8s.enabled` | K8s 클러스터 관리 기능 활성화 | `true` |
+| `ui.ingress.enabled` | 외부 접근용 Ingress 생성 | `false` |
+| `ui.persistence.enabled` | PostgreSQL 데이터용 PVC 활성화 | `true` |
+| `ui.persistence.size` | PVC 스토리지 크기 | `1Gi` |
+| `ui.env.databaseUrl` | 외부 PostgreSQL URL (`postgresql.enabled=false` 일 때) | `""` |
+| `ui.rbac.create` | K8s API 접근용 ClusterRole 및 ClusterRoleBinding 생성 | `true` |
+| `ui.serviceAccount.create` | UI Pod용 ServiceAccount 생성 | `true` |
+| `ui.networkPolicy.enabled` | UI Pod 네트워크 트래픽 제한 | `false` |
+| `ui.image.pullPolicy` | 이미지 풀 정책 | `IfNotPresent` |
+| `ui.persistence.storageClassName` | PostgreSQL PVC 스토리지 클래스 | `""` (기본값) |
+| `ui.postgresql.existingSecret` | 데이터베이스 자격 증명에 기존 Secret 사용 | `""` |
+
+:::tip
+프로브, 보안 컨텍스트, 톨러레이션, 어피니티, 오토스케일링 등 전체 설정 옵션 목록은 다음 명령으로 확인할 수 있습니다.
+```bash
+helm show values oci://ghcr.io/kimsoungryoul/charts/aerospike-ce-kubernetes-operator | grep -A 500 "^ui:"
+```
+:::
+
+---
+
+## 기능
+
+### 연결 관리
+
+색상 코드가 있는 프로파일로 여러 Aerospike 클러스터 연결을 관리합니다. 각 연결은 호스트, 포트, 선택적 인증 정보를 저장하며, 프로파일은 내장 PostgreSQL 데이터베이스에 영속 저장됩니다.
+
+### 클러스터 모니터링
+
+TPS, 클라이언트 연결 수, 성공률을 보여주는 실시간 대시보드입니다. 네임스페이스 사용량, 스토리지 활용도, 클러스터 상태를 한눈에 확인할 수 있습니다.
+
+### 레코드 브라우저
+
+페이지네이션을 지원하여 레코드를 탐색, 생성, 수정, 삭제합니다. 네임스페이스와 셋을 탐색하고, 전체 메타데이터와 함께 개별 레코드를 검사할 수 있습니다.
+
+### 쿼리 빌더
+
+프레디케이트를 사용하여 스캔/쿼리 작업을 빌드하고 실행합니다. AQL을 직접 작성하지 않고 시각적으로 쿼리를 구성합니다.
+
+### K8s 클러스터 관리
+
+`ui.k8s.enabled=true`(기본값)인 경우 UI는 Kubernetes 네이티브 클러스터 관리 기능을 제공합니다.
+
+- **클러스터 생성** — 안내형 마법사로 새 AerospikeCluster CR 배포
+- **클러스터 편집** — 편집 다이얼로그를 통해 실행 중인 클러스터 설정 수정 (이미지, 크기, 동적 설정, Aerospike 설정)
+- **클러스터 스케일** — 클러스터 크기 조정 (CE는 1~8 노드)
+- **상태 모니터링** — 클러스터 단계, 조건, Pod 상세 정보 조회
+- **템플릿 관리** — AerospikeClusterTemplate 생성, 탐색, 삭제 및 동기화 상태 확인
+- **템플릿 CRUD** — 전체 템플릿 라이프사이클: 기본 이미지, 크기, 리소스, 스케줄링, 스토리지, 모니터링, 네트워크 설정으로 템플릿 생성; 사용 현황 추적이 포함된 템플릿 상세 보기; 미사용 템플릿 삭제 (클러스터가 먼저 링크 해제해야 함)
+- **템플릿 스냅샷** — 동기화 상태(동기화됨/비동기화)와 함께 해결된 템플릿 스펙 조회
+- **작업 트리거** — 선택적 Pod 지정을 통한 웜 재시작 및 Pod 재시작 개시
+- **Pod 선택** — 체크박스로 특정 Pod를 선택하여 타겟 재시작 작업 수행
+- **일시 정지/재개** — 조정(Reconciliation) 일시 정지 및 재개
+- **ACL 설정** — 역할, 사용자, K8s Secret 기반 인증 정보로 접근 제어 설정 (Secret 선택 드롭다운 포함)
+- **롤링 업데이트 전략** — 배치 크기, 최대 불가용 수, PDB 설정 구성
+- **작업 모니터링** — 활성 작업 상태, 완료/실패한 Pod 실시간 조회
+- **동적 설정 상태** — Pod별 동적 설정 상태(Applied/Failed/Pending) 및 마지막 재시작 사유 조회
+- **조정 추적** — 조정 오류 횟수 및 실패 원인 확인
+- **이벤트 조회** — 각 클러스터의 K8s 이벤트 타임라인 탐색 (전환 단계에서 자동 갱신)
+- **Pod 로그** — Pod 테이블에서 직접 컨테이너 로그 조회 (tail lines 선택, 복사, 다운로드)
+- **CR YAML 내보내기** — 디버깅 또는 마이그레이션을 위해 클러스터의 AerospikeCluster CR을 깔끔한 YAML로 복사
+- **헬스 대시보드** — 클러스터 상태 한눈에 보기: Pod 준비 상태, 마이그레이션 상태, 설정 상태, 가용성, 랙 분배
+- **스토리지 정책** — PVC의 볼륨 초기화 방식(deleteFiles/dd/blkdiscard/headerCleanup), 와이프 방식, 캐스케이드 삭제 동작 설정
+- **네트워크 접근 타입** — 클라이언트가 클러스터에 접근하는 방식 선택: Pod IP (기본값), 호스트 내부 IP, 호스트 외부 IP, 또는 설정된 IP; 노드 간 통신용 Fabric 타입 설정
+- **노드 차단 목록** — Aerospike Pod가 스케줄되어서는 안 되는 Kubernetes 노드 지정 (편집 다이얼로그)
+
+:::info
+K8s 클러스터 관리 기능은 UI 서비스 어카운트가 AerospikeCluster 리소스에 대한 RBAC 접근 권한을 가져야 합니다. `ui.rbac.create=true`(기본값)인 경우 자동으로 설정됩니다.
+:::
+
+### 랙 설정
+
+마법사에는 다중 랙, 존 인식 배포를 위한 **랙 설정** 단계가 포함되어 있습니다.
+
+- **랙 추가/삭제**: 고유한 ID로 여러 랙 설정
+- **존 어피니티**: 라이브 노드 데이터에서 K8s 가용 영역 선택
+- **Pod 분배**: 각 랙의 노드당 최대 Pod 수 설정
+- **분배 미리보기**: 랙 간 예상 Pod 분배 확인
+
+각 랙은 별도의 StatefulSet을 생성하여 존 인식 고가용성을 지원합니다.
+
+### 스토리지 정책
+
+영속 스토리지(device 모드)를 사용할 때 마법사에서 다음을 설정할 수 있습니다.
+
+- **초기화 방식**: 첫 사용 시 볼륨 준비 방법 (`none`, `deleteFiles`, `dd`, `blkdiscard`, `headerCleanup`)
+- **와이프 방식**: Pod 재시작 시 더티 볼륨 정리 방법 (`none`, `deleteFiles`, `dd`, `blkdiscard`, `headerCleanup`, `blkdiscardWithHeaderCleanup`)
+- **캐스케이드 삭제**: 클러스터 CR 삭제 시 PVC 자동 삭제 여부 (기본값: 활성화)
+
+### 네트워크 접근
+
+클라이언트-클러스터 간 및 노드 간 통신을 설정합니다.
+
+- **클라이언트 접근 타입**: `pod` (기본값 — Pod IP 사용), `hostInternal` (노드 내부 IP), `hostExternal` (노드 외부 IP), `configuredIP` (어노테이션 기반)
+- **Fabric 타입**: 노드 간 Fabric 통신용 네트워크 타입 (기본값: `pod`)
+
+### 인덱스 관리
+
+보조 인덱스를 생성, 조회, 삭제합니다. 인덱스 빌드 진행 상황을 모니터링하고 인덱스 통계를 확인합니다.
+
+### 사용자/역할 관리 (ACL)
+
+UI를 통해 Aerospike 사용자와 역할을 관리합니다. 커맨드라인 도구 없이 사용자 생성, 역할 부여, 비밀번호 변경이 가능합니다.
+
+### UDF 관리
+
+Aerospike 클러스터에 등록된 사용자 정의 함수(Lua 모듈)를 업로드, 조회, 삭제합니다.
+
+### AQL 터미널
+
+신택스 하이라이팅과 결과 포맷팅을 지원하는 AQL 명령을 브라우저에서 직접 실행합니다.
+
+### 라이트/다크 테마
+
+취향에 맞게 라이트 테마와 다크 테마 간 전환할 수 있습니다.
+
+---
+
+## 외부 PostgreSQL 사용
+
+내장 사이드카 대신 기존 PostgreSQL 인스턴스를 사용하려면:
+
+```bash
+helm install acko oci://ghcr.io/kimsoungryoul/charts/aerospike-ce-kubernetes-operator \
+  --namespace aerospike-operator --create-namespace \
+  --set ui.enabled=true \
+  --set ui.postgresql.enabled=false \
+  --set ui.env.databaseUrl="postgresql://user:pass@db-host:5432/aerospike_manager"
+```
+
+:::tip
+`ui.postgresql.existingSecret`에 Secret 이름을 설정하여 기존 Kubernetes Secret의 데이터베이스 자격 증명을 사용할 수도 있습니다. Secret에는 `POSTGRES_PASSWORD`와 `DATABASE_URL` 키가 포함되어야 합니다.
+:::
+
+---
+
+## 보안
+
+### RBAC
+
+`ui.rbac.create=true`(기본값)인 경우 Helm 차트는 UI 서비스 어카운트에 다음 권한을 부여하는 ClusterRole과 ClusterRoleBinding을 생성합니다.
+
+- `AerospikeCluster` 리소스에 대한 **읽기/쓰기** 접근 (생성, 스케일, 수정, 삭제)
+- `AerospikeClusterTemplate` 리소스에 대한 **생성/삭제/읽기** 접근 (전체 템플릿 관리)
+- Pod, Service, Event, Namespace에 대한 **읽기 전용** 접근 (클러스터 모니터링, 이벤트 타임라인, 마법사 드롭다운용)
+- Pod 로그(`pods/log`)에 대한 **읽기 전용** 접근 (UI에서 컨테이너 로그 조회용)
+- Secret에 대한 **목록 전용** 접근 (ACL 인증 정보 선택을 위한 이름 열거 — 내용은 읽지 않음)
+- StorageClass에 대한 **목록 전용** 접근 (스토리지 마법사 드롭다운용)
+- Node에 대한 **읽기 전용** 접근 (`get`, `list`) (랙 설정에 사용되는 가용 영역 정보 조회용)
+
+### Pod 보안
+
+UI는 기본적으로 비루트(`runAsUser: 1001`)로 실행되며, Next.js 런타임 요구 사항을 지원하기 위해 읽기 전용 루트 파일 시스템은 비활성화됩니다. 권한 상승이 차단되고 모든 Linux 기능이 제거됩니다.
+
+### 네트워크 정책
+
+UI Pod에 대한 트래픽을 제한합니다.
+
+```bash
+helm install acko oci://ghcr.io/kimsoungryoul/charts/aerospike-ce-kubernetes-operator \
+  --namespace aerospike-operator --create-namespace \
+  --set ui.enabled=true \
+  --set ui.networkPolicy.enabled=true
+```
+
+---
+
+## 전체 예시
+
+UI, 모니터링, Ingress를 모두 활성화하여 오퍼레이터를 배포합니다.
+
+```bash
+helm install acko oci://ghcr.io/kimsoungryoul/charts/aerospike-ce-kubernetes-operator \
+  --namespace aerospike-operator --create-namespace \
+  --set ui.enabled=true \
+  --set ui.ingress.enabled=true \
+  --set ui.ingress.className=nginx \
+  --set "ui.ingress.hosts[0].host=aerospike-admin.example.com" \
+  --set "ui.ingress.hosts[0].paths[0].path=/" \
+  --set "ui.ingress.hosts[0].paths[0].pathType=Prefix" \
+  --set serviceMonitor.enabled=true \
+  --set grafanaDashboard.enabled=true
+```


### PR DESCRIPTION
## Summary

- **UI**: 클러스터 생성 마법사의 namespace 필드를 하드코딩(`aerospike`)에서 `/api/k8s/namespaces` API로 동적 조회하도록 변경. 로딩 중 disabled + placeholder 표시, 미선택 시 Next 버튼 비활성화
- **Backend**: namespace auto-create 로직 제거 → 존재하지 않는 namespace에 명확한 400 에러 반환 (available namespaces 포함)
- **Makefile**: `CONTAINER_TOOL` 기본값 `docker` → `podman` 변경; `reload-ui-image` 타겟 추가 (build → kind load → kubectl rollout)
- **Docs (KO)**: `aerospikecluster.md` broken anchor 수정 (`#aerospikecepodspec` → `#aerospikepodspec`); 한국어 번역 2개 추가 (`guide/access-control.md`, `guide/cluster-manager-ui.md`)

## Test plan

- [ ] `make reload-ui-image` 실행 후 kind-kind 클러스터에 UI 반영 확인
- [ ] 클러스터 생성 마법사 Step 1에서 namespace 드롭다운에 실제 K8s namespace 목록 표시 확인
- [ ] 존재하지 않는 namespace를 직접 API로 보낼 경우 400 에러 및 available namespaces 메시지 확인
- [ ] `cd docs && npm run build` 빌드 시 broken anchor/link 경고 없음 확인
- [ ] 한국어 ↔ 영어 언어 전환 시 모든 페이지 정상 이동 확인