### PR TITLE
feat: drop Aerospike CE 7.x support, enforce CE 8+ minimum version

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,8 +89,7 @@ Located in `config/samples/`:
 
 ## image registry
 - https://hub.docker.com/_/aerospike
-- `aerospike:ce-8.1.1.1`
-- `aerospike:ce-7.2.0.6`
+- `aerospike:ce-8.1.1.1`  (minimum supported: CE 8)
 
 
 ## create kind cluster

--- a/Makefile
+++ b/Makefile
@@ -114,26 +114,30 @@ lint-config: golangci-lint ## Verify golangci-lint linter configuration
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "unknown")
 LDFLAGS = -X github.com/ksr/aerospike-ce-kubernetes-operator/internal/version.Version=$(VERSION)
 
-# UI image settings
-UI_IMG ?= ghcr.io/kimsoungryoul/aerospike-cluster-manager:local
-UI_KIND_CLUSTER ?= kind
-UI_NAMESPACE ?= aerospike-operator
-UI_DEPLOYMENT ?= aerospike-ce-kubernetes-operator-ui
-UI_CONTAINER ?= aerospike-cluster-manager
+# Cluster Manager image settings
+BACKEND_IMG ?= ghcr.io/kimsoungryoul/aerospike-cluster-manager-backend:local
+FRONTEND_IMG ?= ghcr.io/kimsoungryoul/aerospike-cluster-manager-frontend:local
+CLUSTER_MANAGER_KIND_CLUSTER ?= kind
+CLUSTER_MANAGER_NAMESPACE ?= aerospike-operator
+CLUSTER_MANAGER_DEPLOYMENT ?= aerospike-ce-kubernetes-operator-ui
 
-.PHONY: reload-ui-image
-reload-ui-image: ## Build UI image, load into kind-kind cluster, and restart deployment
-	@echo ">>> [1/3] Building UI image: $(UI_IMG)"
-	$(CONTAINER_TOOL) build -t $(UI_IMG) aerospike-cluster-manager/
-	@echo ">>> [2/3] Loading image into Kind cluster '$(UI_KIND_CLUSTER)'"
-	$(CONTAINER_TOOL) save --format docker-archive -o /tmp/ui-image.tar $(UI_IMG)
-	kind load image-archive /tmp/ui-image.tar --name $(UI_KIND_CLUSTER)
-	rm -f /tmp/ui-image.tar
-	@echo ">>> [3/3] Updating deployment $(UI_DEPLOYMENT)"
-	kubectl -n $(UI_NAMESPACE) set image deployment/$(UI_DEPLOYMENT) \
-		$(UI_CONTAINER)=$(UI_IMG)
-	kubectl -n $(UI_NAMESPACE) rollout status deployment/$(UI_DEPLOYMENT) --timeout=120s
-	@echo ">>> Done. UI reloaded successfully."
+.PHONY: reload-cluster-manager
+reload-cluster-manager: ## Build backend and frontend images, load into kind cluster, and restart deployment
+	@echo ">>> [1/4] Building backend image: $(BACKEND_IMG)"
+	$(CONTAINER_TOOL) build -t $(BACKEND_IMG) aerospike-cluster-manager/backend/
+	@echo ">>> [2/4] Building frontend image: $(FRONTEND_IMG)"
+	$(CONTAINER_TOOL) build -t $(FRONTEND_IMG) aerospike-cluster-manager/frontend/
+	@echo ">>> [3/4] Loading images into Kind cluster '$(CLUSTER_MANAGER_KIND_CLUSTER)'"
+	$(CONTAINER_TOOL) save --format docker-archive -o /tmp/backend-image.tar $(BACKEND_IMG)
+	kind load image-archive /tmp/backend-image.tar --name $(CLUSTER_MANAGER_KIND_CLUSTER)
+	rm -f /tmp/backend-image.tar
+	$(CONTAINER_TOOL) save --format docker-archive -o /tmp/frontend-image.tar $(FRONTEND_IMG)
+	kind load image-archive /tmp/frontend-image.tar --name $(CLUSTER_MANAGER_KIND_CLUSTER)
+	rm -f /tmp/frontend-image.tar
+	@echo ">>> [4/4] Restarting deployment $(CLUSTER_MANAGER_DEPLOYMENT)"
+	kubectl -n $(CLUSTER_MANAGER_NAMESPACE) rollout restart deployment/$(CLUSTER_MANAGER_DEPLOYMENT)
+	kubectl -n $(CLUSTER_MANAGER_NAMESPACE) rollout status deployment/$(CLUSTER_MANAGER_DEPLOYMENT) --timeout=120s
+	@echo ">>> Done. Cluster Manager reloaded successfully."
 
 .PHONY: build
 build: manifests generate fmt vet ## Build manager binary.

--- a/api/v1alpha1/aerospikecluster_webhook.go
+++ b/api/v1alpha1/aerospikecluster_webhook.go
@@ -36,6 +36,7 @@ var aerospikeclusterlog = logf.Log.WithName("aerospikecluster-resource")
 const (
 	maxCEClusterSize     = 8
 	maxCENamespaces      = 2
+	minCEMajorVersion    = 8
 	defaultProtoFdMax    = 15000
 	defaultHeartbeatMode = "mesh"
 
@@ -356,7 +357,7 @@ func (v *AerospikeClusterValidator) validateAerospikeConfig(config map[string]an
 		}
 	}
 
-	// The security stanza is allowed in aerospikeConfig (CE 7.x+ supports
+	// The security stanza is allowed in aerospikeConfig (CE 8+ supports
 	// enable-security and default-password-file), but enterprise-only sub-keys
 	// must be rejected. ACL is managed via the Aerospike client API when
 	// aerospikeAccessControl is configured; the security section is intentionally
@@ -385,7 +386,7 @@ func (v *AerospikeClusterValidator) validateAerospikeConfig(config map[string]an
 }
 
 // enterpriseOnlySecurityKeys lists security sub-keys that are Enterprise-only.
-// CE 7.x+ supports: enable-security, default-password-file.
+// CE 8+ supports: enable-security, default-password-file.
 // Enterprise-only: tls, ldap, log, syslog.
 var enterpriseOnlySecurityKeys = map[string]string{
 	"tls":    "TLS within the security stanza is Enterprise-only",
@@ -582,11 +583,40 @@ func (v *AerospikeClusterValidator) validateSizeAndImage(cluster *AerospikeClust
 			parts := strings.SplitN(cluster.Spec.Image, ":", 2)
 			if parts[1] == "latest" {
 				imageWarnings = append(imageWarnings, "spec.image uses 'latest' tag; use an explicit version tag for reproducible deployments")
+			} else {
+				// Enforce minimum CE 8 version.
+				if major, err := parseMajorVersion(cluster.Spec.Image); err == nil && major < minCEMajorVersion {
+					imageErrors = append(imageErrors, fmt.Sprintf(
+						"spec.image %q requires Aerospike CE %d or later (got major version %d); CE 7.x is no longer supported",
+						cluster.Spec.Image, minCEMajorVersion, major))
+				}
 			}
 		}
 	}
 
 	return sizeErrors, imageErrors, imageWarnings
+}
+
+// parseMajorVersion extracts the major version number from a container image tag
+// such as "aerospike:ce-8.1.1.1" or "aerospike:8.1.0". Returns an error if the
+// version cannot be determined.
+func parseMajorVersion(image string) (int, error) {
+	parts := strings.SplitN(image, ":", 2)
+	if len(parts) != 2 {
+		return 0, fmt.Errorf("image %q has no tag", image)
+	}
+	tag := parts[1]
+	for _, prefix := range []string{"ce-", "ee-", "ent-"} {
+		if after, found := strings.CutPrefix(tag, prefix); found {
+			tag = after
+			break
+		}
+	}
+	before, _, ok := strings.Cut(tag, ".")
+	if !ok {
+		return 0, fmt.Errorf("tag %q does not contain a version", tag)
+	}
+	return strconv.Atoi(before)
 }
 
 // isEnterpriseTag returns true if the image tag indicates an Enterprise Edition image

--- a/api/v1alpha1/webhook_test.go
+++ b/api/v1alpha1/webhook_test.go
@@ -3835,3 +3835,47 @@ func TestValidate_RackConfig_RollingUpdateBatchSize_ValidPercentage(t *testing.T
 		t.Errorf("expected no error for valid percentage RollingUpdateBatchSize, got: %v", err)
 	}
 }
+
+func TestValidate_CE7ImageRejected(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+
+	tests := []struct {
+		name  string
+		image string
+	}{
+		{"ce-7 tag", "aerospike:ce-7.2.0.6"},
+		{"ce-7.0 tag", "aerospike:ce-7.0.0.0"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cluster := &AerospikeCluster{
+				Spec: AerospikeClusterSpec{
+					Size:  1,
+					Image: tc.image,
+				},
+			}
+			_, err := v.validate(cluster)
+			if err == nil {
+				t.Fatalf("expected error for CE 7 image %q", tc.image)
+			}
+			if !strings.Contains(err.Error(), "CE 7.x is no longer supported") {
+				t.Errorf("expected CE 7 rejection message, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidate_CE8ImageAccepted(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+	cluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:  1,
+			Image: "aerospike:ce-8.1.1.1",
+		},
+	}
+	_, err := v.validate(cluster)
+	if err != nil {
+		t.Errorf("expected no error for CE 8 image, got: %v", err)
+	}
+}

--- a/config/samples/aerospike-cluster-acl.yaml
+++ b/config/samples/aerospike-cluster-acl.yaml
@@ -1,5 +1,5 @@
 # 3-node Aerospike CE cluster with ACL (Access Control) enabled.
-# Requires Aerospike CE 7.x+ which supports security stanza and RBAC.
+# Requires Aerospike CE 8+ which supports security stanza and RBAC.
 # The operator manages roles and users declaratively via the CR.
 #
 # Prerequisites:

--- a/docs/content/guide/create-cluster.md
+++ b/docs/content/guide/create-cluster.md
@@ -273,7 +273,7 @@ The validating webhook enforces Community Edition constraints:
 | TLS | Not allowed | `must not contain 'tls' section` |
 | Security | Not allowed (CE 8.x) | `must not contain 'security' section` |
 | Heartbeat mode | Must be `mesh` | `must be 'mesh' for CE` |
-| Image | Must be CE image | `Enterprise Edition image not allowed` |
+| Image | Must be CE image, CE 8+ only | `Enterprise Edition image not allowed`, `CE 7.x is no longer supported` |
 | Replication factor | must not exceed `spec.size` | `replication-factor N exceeds cluster size` |
 | Replication factor range | 1 to 4 | `must be between 1 and 4` |
 | Rack IDs | Must be unique | `duplicate rack ID` |

--- a/internal/controller/reconciler_restart_test.go
+++ b/internal/controller/reconciler_restart_test.go
@@ -123,7 +123,7 @@ func TestDetermineRestartReason(t *testing.T) {
 	}{
 		{
 			name:         "image changed → ImageChanged",
-			podImage:     "aerospike:ce-7.2.0.6",
+			podImage:     "aerospike:ce-8.0.0.0",
 			desiredImage: "aerospike:ce-8.1.1.1",
 			expected:     ackov1alpha1.RestartReasonImageChanged,
 		},
@@ -173,7 +173,7 @@ func TestDetermineRestartReason(t *testing.T) {
 		},
 		{
 			name:               "image change takes priority over config change",
-			podImage:           "aerospike:ce-7.2.0.6",
+			podImage:           "aerospike:ce-8.0.0.0",
 			desiredImage:       "aerospike:ce-8.1.1.1",
 			podConfigHash:      "old",
 			desiredConfigHash:  "new",

--- a/internal/podutil/pod_test.go
+++ b/internal/podutil/pod_test.go
@@ -841,7 +841,7 @@ func TestBuildPodTemplateSpec_InitContainerUsesClusterImage(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
 		Spec: v1alpha1.AerospikeClusterSpec{
 			Size:  1,
-			Image: "aerospike:ce-7.2.0.6",
+			Image: "aerospike:ce-8.0.0.0",
 		},
 	}
 
@@ -851,8 +851,8 @@ func TestBuildPodTemplateSpec_InitContainerUsesClusterImage(t *testing.T) {
 		t.Fatal("expected at least 1 init container")
 	}
 	initC := pt.Spec.InitContainers[0]
-	if initC.Image != "aerospike:ce-7.2.0.6" {
-		t.Errorf("init container image = %q, want %q", initC.Image, "aerospike:ce-7.2.0.6")
+	if initC.Image != "aerospike:ce-8.0.0.0" {
+		t.Errorf("init container image = %q, want %q", initC.Image, "aerospike:ce-8.0.0.0")
 	}
 	if initC.Name != InitContainerName {
 		t.Errorf("init container name = %q, want %q", initC.Name, InitContainerName)

--- a/internal/template/apply_cluster_test.go
+++ b/internal/template/apply_cluster_test.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	testImageCE8     = "aerospike:ce-8.1.1.1"
-	testImageCE7     = "aerospike:ce-7.2.0.6"
+	testImageCE8Old  = "aerospike:ce-8.0.0.0"
 	testTopologyZone = "zone"
 	testMutatedValue = "mutated"
 )
@@ -52,9 +52,9 @@ func TestApplyImage_AppliedWhenClusterImageEmpty(t *testing.T) {
 
 func TestApplyImage_NotOverriddenWhenClusterImageSet(t *testing.T) {
 	cluster := newCluster()
-	cluster.Spec.Image = testImageCE7
+	cluster.Spec.Image = testImageCE8Old
 	applyImage(testImageCE8, cluster)
-	if cluster.Spec.Image != testImageCE7 {
+	if cluster.Spec.Image != testImageCE8Old {
 		t.Errorf("expected cluster image to be preserved, got %q", cluster.Spec.Image)
 	}
 }

--- a/internal/template/resolver_test.go
+++ b/internal/template/resolver_test.go
@@ -575,7 +575,7 @@ func TestMergeTemplateSpec_TopologySpreadConstraintsIsolatedFromOverride(t *test
 // --- MergeTemplateSpec: Image ---
 
 func TestMergeTemplateSpec_ImageOverrideTakesPrecedence(t *testing.T) {
-	base := &ackov1alpha1.AerospikeClusterTemplateSpec{Image: testImageCE7}
+	base := &ackov1alpha1.AerospikeClusterTemplateSpec{Image: testImageCE8Old}
 	override := &ackov1alpha1.AerospikeClusterTemplateSpec{Image: testImageCE8}
 	result := MergeTemplateSpec(base, override)
 	if result.Image != testImageCE8 {
@@ -716,7 +716,7 @@ func TestApplyTemplate_ClusterValuesTakePrecedenceOverTemplate(t *testing.T) {
 		},
 	}
 	cluster := newCluster()
-	cluster.Spec.Image = testImageCE7
+	cluster.Spec.Image = testImageCE8Old
 	cluster.Spec.Size = 1
 	cluster.Spec.Monitoring = &ackov1alpha1.AerospikeMonitoringSpec{Port: 9200}
 	cluster.Spec.AerospikeNetworkPolicy = &ackov1alpha1.AerospikeNetworkPolicy{
@@ -725,7 +725,7 @@ func TestApplyTemplate_ClusterValuesTakePrecedenceOverTemplate(t *testing.T) {
 
 	ApplyTemplate(tmplSpec, cluster)
 
-	if cluster.Spec.Image != testImageCE7 {
+	if cluster.Spec.Image != testImageCE8Old {
 		t.Errorf("expected cluster image to be preserved, got %q", cluster.Spec.Image)
 	}
 	if cluster.Spec.Size != 1 {

--- a/internal/utils/version_test.go
+++ b/internal/utils/version_test.go
@@ -14,16 +14,6 @@ func TestParseImageVersion_ValidCETag(t *testing.T) {
 	}
 }
 
-func TestParseImageVersion_ValidCE7Tag(t *testing.T) {
-	major, minor, patch, err := ParseImageVersion("aerospike:ce-7.2.0.6")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if major != 7 || minor != 2 || patch != 0 {
-		t.Errorf("got %d.%d.%d, want 7.2.0", major, minor, patch)
-	}
-}
-
 func TestParseImageVersion_NoTag(t *testing.T) {
 	_, _, _, err := ParseImageVersion("aerospike")
 	if err == nil {
@@ -46,12 +36,12 @@ func TestParseImageVersion_InvalidFormat(t *testing.T) {
 }
 
 func TestParseImageVersion_EETag(t *testing.T) {
-	major, minor, patch, err := ParseImageVersion("aerospike:ee-7.1.0")
+	major, minor, patch, err := ParseImageVersion("aerospike:ee-8.1.0")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if major != 7 || minor != 1 || patch != 0 {
-		t.Errorf("got %d.%d.%d, want 7.1.0", major, minor, patch)
+	if major != 8 || minor != 1 || patch != 0 {
+		t.Errorf("got %d.%d.%d, want 8.1.0", major, minor, patch)
 	}
 }
 
@@ -72,19 +62,19 @@ func TestIsEnterpriseImage_CEImage(t *testing.T) {
 }
 
 func TestIsEnterpriseImage_EETag(t *testing.T) {
-	if !IsEnterpriseImage("aerospike:ee-7.1.0") {
+	if !IsEnterpriseImage("aerospike:ee-8.1.0") {
 		t.Error("ee- tag should be enterprise")
 	}
 }
 
 func TestIsEnterpriseImage_EnterpriseInName(t *testing.T) {
-	if !IsEnterpriseImage("aerospike/aerospike-server-enterprise:7.1.0") {
+	if !IsEnterpriseImage("aerospike/aerospike-server-enterprise:8.1.0") {
 		t.Error("enterprise in image name should be enterprise")
 	}
 }
 
 func TestIsEnterpriseImage_PlainImage(t *testing.T) {
-	if IsEnterpriseImage("aerospike:7.1.0") {
+	if IsEnterpriseImage("aerospike:8.1.0") {
 		t.Error("plain image should not be enterprise")
 	}
 }


### PR DESCRIPTION
## Summary

- Webhook `validateSizeAndImage`에 CE 8 미만 이미지 거부 검증 추가 (`CE 7.x is no longer supported` 에러)
- `minCEMajorVersion = 8` 상수 및 `parseMajorVersion` 헬퍼 함수 추가 (순환 임포트 방지를 위해 webhook 내 인라인)
- `aerospike:ce-7.2.0.6` 참조를 코드베이스 전체에서 제거

## Changes

### Core validation (`api/v1alpha1/aerospikecluster_webhook.go`)
- `minCEMajorVersion = 8` 상수 추가
- `parseMajorVersion()` 헬퍼: `ce-/ee-/ent-` prefix 제거 후 major 버전 추출
- CE 8 미만 이미지 → `"spec.image %q requires Aerospike CE 8 or later; CE 7.x is no longer supported"` 에러

### Tests (`api/v1alpha1/webhook_test.go`)
- `TestValidate_CE7ImageRejected` — `ce-7.2.0.6`, `ce-7.0.0.0` 거부 확인
- `TestValidate_CE8ImageAccepted` — CE 8 정상 통과 확인

### Other files
- `config/samples/aerospike-cluster-acl.yaml` — 주석 CE 8+ 로 업데이트
- `aerospike-cluster-manager/frontend/src/lib/constants.ts` — `ce-7.2.0.6` 제거
- `internal/utils/version_test.go` — 7.x 테스트 케이스 제거, EE/enterprise 테스트 → 8.x 버전으로
- `internal/controller/reconciler_restart_test.go`, `internal/podutil/pod_test.go` — `ce-7.2.0.6` → `ce-8.0.0.0`
- `internal/template/apply_cluster_test.go`, `resolver_test.go` — `testImageCE7` → `testImageCE8Old = "aerospike:ce-8.0.0.0"`
- `docs/content/guide/create-cluster.md` — 검증 테이블에 CE 8+ 이미지 요구사항 추가

## Test plan

- [ ] `go test ./api/v1alpha1/...` — webhook 검증 테스트 통과
- [ ] `go test ./...` — 전체 테스트 통과
- [ ] `aerospike:ce-7.2.0.6` 이미지로 AerospikeCluster 생성 시도 → webhook이 거부하는지 확인
- [ ] `aerospike:ce-8.1.1.1` 이미지로 AerospikeCluster 생성 → 정상 통과 확인