### PR TITLE
fix: reconcile PDB selector and label drift

### DIFF
--- a/internal/controller/reconciler_pdb.go
+++ b/internal/controller/reconciler_pdb.go
@@ -82,7 +82,10 @@ func (r *AerospikeClusterReconciler) reconcilePDB(
 		return nil
 	}
 
-	existing.Labels = labels
+	if existing.Labels == nil {
+		existing.Labels = make(map[string]string, len(labels))
+	}
+	maps.Copy(existing.Labels, labels)
 	existing.Spec.MinAvailable = nil
 	existing.Spec.MaxUnavailable = &maxUnavailable
 	existing.Spec.Selector = &metav1.LabelSelector{MatchLabels: selectorLabels}
@@ -110,7 +113,12 @@ func pdbNeedsUpdate(
 	if !equality.Semantic.DeepEqual(existing.Spec.Selector, desiredSelector) {
 		return true
 	}
-	return !maps.Equal(existing.Labels, desiredLabels)
+	for k, v := range desiredLabels {
+		if existing.Labels[k] != v {
+			return true
+		}
+	}
+	return false
 }
 
 // intOrStringEqual compares two IntOrString values by type and value,

--- a/internal/controller/reconciler_pdb_test.go
+++ b/internal/controller/reconciler_pdb_test.go
@@ -73,11 +73,18 @@ func TestPDBNeedsUpdate(t *testing.T) {
 			expected: true,
 		},
 		{
-			name: "label drift",
+			name: "operator label drift",
 			mutate: func(pdb *policyv1.PodDisruptionBudget) {
-				pdb.Labels["custom"] = "drifted"
+				pdb.Labels[utils.InstanceLabel] = "wrong"
 			},
 			expected: true,
+		},
+		{
+			name: "extra external label is not drift",
+			mutate: func(pdb *policyv1.PodDisruptionBudget) {
+				pdb.Labels["custom"] = "external"
+			},
+			expected: false,
 		},
 		{
 			name: "min available drift",
@@ -121,7 +128,6 @@ func TestReconcilePDBRepairsGeneratedDrift(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "demo",
 			Namespace: "default",
-			UID:       "cluster-uid",
 		},
 	}
 
@@ -186,12 +192,34 @@ func TestReconcilePDBRepairsGeneratedDrift(t *testing.T) {
 	if got := updated.Spec.Selector.MatchLabels; len(got) != len(utils.SelectorLabelsForCluster(cluster.Name)) || got[utils.InstanceLabel] != cluster.Name {
 		t.Fatalf("Selector.MatchLabels = %v, want %v", got, utils.SelectorLabelsForCluster(cluster.Name))
 	}
-	if len(updated.Labels) != len(wantLabels) {
-		t.Fatalf("Labels = %v, want %v", updated.Labels, wantLabels)
-	}
 	for k, v := range wantLabels {
 		if updated.Labels[k] != v {
 			t.Fatalf("Labels[%q] = %q, want %q", k, updated.Labels[k], v)
 		}
+	}
+	if updated.Labels["custom"] != "drifted" {
+		t.Fatalf("external label 'custom' was not preserved, got %q", updated.Labels["custom"])
+	}
+}
+
+func TestIntOrStringEqual(t *testing.T) {
+	tests := []struct {
+		name     string
+		a, b     intstr.IntOrString
+		expected bool
+	}{
+		{"same int", intstr.FromInt32(1), intstr.FromInt32(1), true},
+		{"different int", intstr.FromInt32(1), intstr.FromInt32(2), false},
+		{"same string", intstr.FromString("50%"), intstr.FromString("50%"), true},
+		{"different string", intstr.FromString("50%"), intstr.FromString("25%"), false},
+		{"int vs string same text", intstr.FromInt32(1), intstr.FromString("1"), false},
+		{"zero values", intstr.IntOrString{}, intstr.IntOrString{}, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := intOrStringEqual(tc.a, tc.b); got != tc.expected {
+				t.Fatalf("intOrStringEqual() = %v, want %v", got, tc.expected)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## 요약
- PodDisruptionBudget의 MaxUnavailable 뿐만 아니라 Label, Selector, MinAvailable 드리프트를 감지하고 복원
- operator 관리 라벨만 비교하여 외부 시스템(Argo CD, Helm 등)이 추가한 라벨은 보존
- 불필요한 MinAvailable 설정을 정리하고 드리프트 케이스별 단위 테스트 추가

## 변경 사항
- `pdbNeedsUpdate` pure function 추출 — Label/Selector/MaxUnavailable/MinAvailable 드리프트 감지
- `maps.Copy`로 기존 라벨 보존하면서 operator 라벨만 병합
- `intOrStringEqual` 테이블 기반 단위 테스트 복원 (int vs string 엣지 케이스 포함)
- fake client 기반 통합 테스트로 전체 복원 흐름 검증

## 검증
- `make lint` ✅
- `make test` (unit + envtest) ✅