### PR TITLE
refactor: unify cluster-manager into single Docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,35 +115,27 @@ VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "unk
 LDFLAGS = -X github.com/ksr/aerospike-ce-kubernetes-operator/internal/version.Version=$(VERSION)
 
 # Cluster Manager image settings
-BACKEND_IMG ?= ghcr.io/kimsoungryoul/aerospike-cluster-manager-backend
-FRONTEND_IMG ?= ghcr.io/kimsoungryoul/aerospike-cluster-manager-frontend
+CLUSTER_MANAGER_IMG ?= ghcr.io/kimsoungryoul/aerospike-cluster-manager
 CLUSTER_MANAGER_KIND_CLUSTER ?= kind
 CLUSTER_MANAGER_NAMESPACE ?= aerospike-operator
 CLUSTER_MANAGER_DEPLOYMENT ?= aerospike-ce-kubernetes-operator-ui
 CLUSTER_MANAGER_CONTAINER ?= aerospike-cluster-manager
-CLUSTER_MANAGER_BACKEND_CONTAINER ?= aerospike-cluster-manager-backend
 
 .PHONY: reload-cluster-manager
 NO_CACHE ?=
 BUILD_NO_CACHE_FLAG = $(if $(NO_CACHE),--no-cache,)
-reload-cluster-manager: ## Build backend and frontend images, load into kind cluster, and force-update deployment image (use NO_CACHE=1 to disable cache)
+reload-cluster-manager: ## Build cluster-manager image, load into kind cluster, and force-update deployment image (use NO_CACHE=1 to disable cache)
 	$(eval RELOAD_TAG := $(shell date +%s))
-	@echo ">>> [1/5] Building backend image: $(BACKEND_IMG):$(RELOAD_TAG)"
-	$(CONTAINER_TOOL) build $(BUILD_NO_CACHE_FLAG) -t $(BACKEND_IMG):$(RELOAD_TAG) aerospike-cluster-manager/backend/
-	@echo ">>> [2/5] Building frontend image: $(FRONTEND_IMG):$(RELOAD_TAG)"
-	$(CONTAINER_TOOL) build $(BUILD_NO_CACHE_FLAG) -t $(FRONTEND_IMG):$(RELOAD_TAG) aerospike-cluster-manager/frontend/
-	@echo ">>> [3/5] Loading images into Kind cluster '$(CLUSTER_MANAGER_KIND_CLUSTER)'"
-	$(CONTAINER_TOOL) save --format docker-archive -o /tmp/backend-image.tar $(BACKEND_IMG):$(RELOAD_TAG)
-	kind load image-archive /tmp/backend-image.tar --name $(CLUSTER_MANAGER_KIND_CLUSTER)
-	rm -f /tmp/backend-image.tar
-	$(CONTAINER_TOOL) save --format docker-archive -o /tmp/frontend-image.tar $(FRONTEND_IMG):$(RELOAD_TAG)
-	kind load image-archive /tmp/frontend-image.tar --name $(CLUSTER_MANAGER_KIND_CLUSTER)
-	rm -f /tmp/frontend-image.tar
-	@echo ">>> [4/5] Updating deployment images to tag :$(RELOAD_TAG)"
+	@echo ">>> [1/4] Building cluster-manager image: $(CLUSTER_MANAGER_IMG):$(RELOAD_TAG)"
+	$(CONTAINER_TOOL) build $(BUILD_NO_CACHE_FLAG) -t $(CLUSTER_MANAGER_IMG):$(RELOAD_TAG) aerospike-cluster-manager/
+	@echo ">>> [2/4] Loading image into Kind cluster '$(CLUSTER_MANAGER_KIND_CLUSTER)'"
+	$(CONTAINER_TOOL) save --format docker-archive -o /tmp/cluster-manager-image.tar $(CLUSTER_MANAGER_IMG):$(RELOAD_TAG)
+	kind load image-archive /tmp/cluster-manager-image.tar --name $(CLUSTER_MANAGER_KIND_CLUSTER)
+	rm -f /tmp/cluster-manager-image.tar
+	@echo ">>> [3/4] Updating deployment image to tag :$(RELOAD_TAG)"
 	kubectl -n $(CLUSTER_MANAGER_NAMESPACE) set image deployment/$(CLUSTER_MANAGER_DEPLOYMENT) \
-		$(CLUSTER_MANAGER_CONTAINER)=$(FRONTEND_IMG):$(RELOAD_TAG) \
-		$(CLUSTER_MANAGER_BACKEND_CONTAINER)=$(BACKEND_IMG):$(RELOAD_TAG)
-	@echo ">>> [5/5] Waiting for rollout $(CLUSTER_MANAGER_DEPLOYMENT)"
+		$(CLUSTER_MANAGER_CONTAINER)=$(CLUSTER_MANAGER_IMG):$(RELOAD_TAG)
+	@echo ">>> [4/4] Waiting for rollout $(CLUSTER_MANAGER_DEPLOYMENT)"
 	kubectl -n $(CLUSTER_MANAGER_NAMESPACE) rollout status deployment/$(CLUSTER_MANAGER_DEPLOYMENT) --timeout=120s
 	@echo ">>> Done. Cluster Manager reloaded successfully (tag: $(RELOAD_TAG))"
 

--- a/charts/aerospike-ce-kubernetes-operator/templates/_helpers.tpl
+++ b/charts/aerospike-ce-kubernetes-operator/templates/_helpers.tpl
@@ -174,16 +174,9 @@ UI service account name.
 {{- end }}
 
 {{/*
-UI frontend container image with tag.
+UI container image with tag.
 UI is versioned independently from the operator; tag is set explicitly in values.yaml.
 */}}
 {{- define "aerospike-ce-kubernetes-operator.ui.image" -}}
 {{- printf "%s:%s" .Values.ui.image.repository (.Values.ui.image.tag | toString) -}}
-{{- end }}
-
-{{/*
-UI backend container image with tag.
-*/}}
-{{- define "aerospike-ce-kubernetes-operator.ui.backendImage" -}}
-{{- printf "%s:%s" .Values.ui.backendImage.repository (.Values.ui.backendImage.tag | toString) -}}
 {{- end }}

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/deployment.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/deployment.yaml
@@ -52,9 +52,14 @@ spec:
             - name: frontend
               containerPort: {{ .Values.ui.service.frontendPort }}
               protocol: TCP
+            - name: backend
+              containerPort: {{ .Values.ui.service.backendPort }}
+              protocol: TCP
           envFrom:
             - configMapRef:
                 name: {{ include "aerospike-ce-kubernetes-operator.ui.fullname" . }}-config
+            - secretRef:
+                name: {{ .Values.ui.postgresql.existingSecret | default (printf "%s-db" (include "aerospike-ce-kubernetes-operator.ui.fullname" .)) }}
           {{- with .Values.ui.extraEnv }}
           env:
             {{- toYaml . | nindent 12 }}
@@ -76,38 +81,6 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.ui.resources }}
-          resources:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-        - name: aerospike-cluster-manager-backend
-          image: {{ include "aerospike-ce-kubernetes-operator.ui.backendImage" . }}
-          imagePullPolicy: {{ .Values.ui.backendImage.pullPolicy }}
-          ports:
-            - name: backend
-              containerPort: {{ .Values.ui.service.backendPort }}
-              protocol: TCP
-          envFrom:
-            - configMapRef:
-                name: {{ include "aerospike-ce-kubernetes-operator.ui.fullname" . }}-config
-            - secretRef:
-                name: {{ .Values.ui.postgresql.existingSecret | default (printf "%s-db" (include "aerospike-ce-kubernetes-operator.ui.fullname" .)) }}
-          {{- with .Values.ui.securityContext }}
-          securityContext:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          {{- with .Values.ui.backendLivenessProbe }}
-          livenessProbe:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          {{- with .Values.ui.backendReadinessProbe }}
-          readinessProbe:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          {{- with .Values.ui.backendStartupProbe }}
-          startupProbe:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          {{- with .Values.ui.backendResources }}
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/aerospike-ce-kubernetes-operator/values.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/values.yaml
@@ -250,21 +250,12 @@ ui:
   # -- Number of UI replicas
   replicaCount: 1
 
-  # -- Container image settings for the frontend (Next.js)
+  # -- Container image settings (single image containing both frontend and backend)
   image:
-    # -- Frontend container image repository
-    repository: ghcr.io/kimsoungryoul/aerospike-cluster-manager-frontend
+    # -- Container image repository
+    repository: ghcr.io/kimsoungryoul/aerospike-cluster-manager
     # -- Container image tag. UI is versioned independently from the operator.
-    tag: "0.2.3"
-    # -- Image pull policy
-    pullPolicy: IfNotPresent
-
-  # -- Container image settings for the backend (FastAPI)
-  backendImage:
-    # -- Backend container image repository
-    repository: ghcr.io/kimsoungryoul/aerospike-cluster-manager-backend
-    # -- Container image tag (kept in sync with ui.image.tag)
-    tag: "0.2.3"
+    tag: "latest"
     # -- Image pull policy
     pullPolicy: IfNotPresent
 
@@ -393,67 +384,31 @@ ui:
         - ALL
 
   # =============================================================================
-  # Probes — Frontend (Next.js, port: frontend/3000)
+  # Probes (backend /api/health checks both frontend and backend health)
   # =============================================================================
   livenessProbe:
     httpGet:
-      path: /
-      port: frontend
+      path: /api/health
+      port: backend
     initialDelaySeconds: 15
     periodSeconds: 20
     timeoutSeconds: 5
 
   readinessProbe:
     httpGet:
-      path: /
-      port: frontend
+      path: /api/health
+      port: backend
     initialDelaySeconds: 5
     periodSeconds: 10
     timeoutSeconds: 5
 
   startupProbe:
     httpGet:
-      path: /
-      port: frontend
-    periodSeconds: 5
-    timeoutSeconds: 3
-    failureThreshold: 30
-
-  # =============================================================================
-  # Probes — Backend (FastAPI, port: backend/8000)
-  # =============================================================================
-  backendLivenessProbe:
-    httpGet:
-      path: /api/health
-      port: backend
-    initialDelaySeconds: 15
-    periodSeconds: 20
-    timeoutSeconds: 5
-
-  backendReadinessProbe:
-    httpGet:
-      path: /api/health
-      port: backend
-    initialDelaySeconds: 5
-    periodSeconds: 10
-    timeoutSeconds: 5
-
-  backendStartupProbe:
-    httpGet:
       path: /api/health
       port: backend
     periodSeconds: 5
     timeoutSeconds: 3
     failureThreshold: 30
-
-  # -- Resource requests and limits for the backend container
-  backendResources:
-    requests:
-      cpu: 100m
-      memory: 128Mi
-    limits:
-      cpu: 500m
-      memory: 256Mi
 
   # =============================================================================
   # Environment


### PR DESCRIPTION
## Summary
- Replace separate frontend/backend container images with a single combined image (`ghcr.io/kimsoungryoul/aerospike-cluster-manager`) that runs both Next.js and FastAPI via `entrypoint.sh`
- Merge 2-container pod into 1-container pod in Helm deployment template, removing `backendImage`, `backendResources`, and `backend*Probe` from values.yaml
- Simplify Makefile `reload-cluster-manager` target from 5 steps (2 builds, 2 loads) to 4 steps (1 build, 1 load)

## Test plan
- [x] `helm template` renders correctly with single container
- [x] `helm lint` passes
- [ ] E2E test with Kind cluster (`make reload-cluster-manager`)