### PR TITLE
feat: support cross-namespace template references

### DIFF
--- a/.claude/skills/run-local/SKILL.md
+++ b/.claude/skills/run-local/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: run-local
+description: Set up a local Kind dev environment and run the operator on the host via `make run`
+disable-model-invocation: false
+---
+
+# Local Dev Environment (make run)
+
+Kind 클러스터를 생성하고 operator를 로컬 호스트 프로세스로 실행하는 개발 환경을 구성합니다.
+Webhook은 비활성 상태이므로 cert-manager가 불필요하며, 코드 수정 후 Ctrl+C → `make run`으로 즉시 반영됩니다.
+
+## Setup Steps
+
+### 1. Kind 클러스터 생성
+
+기존 클러스터를 삭제하고 재생성합니다 (3-worker 노드, zone label 포함).
+
+```bash
+make setup-kind
+```
+
+클러스터 생성을 확인합니다:
+```bash
+kubectl get nodes
+```
+
+### 2. CRD 설치
+
+CRD만 설치합니다 (webhook config 제외). `make install`이 annotation 크기 제한으로 실패하면 `kubectl replace`를 사용합니다.
+
+```bash
+make install
+```
+
+실패 시 대안:
+```bash
+make manifests && bin/kustomize build config/crd | kubectl replace -f -
+```
+
+### 3. Operator 로컬 실행
+
+`make run`은 manifests 생성, fmt, vet을 포함하므로 별도의 `make build`가 불필요합니다.
+
+```bash
+make run
+```
+
+foreground 프로세스로 실행됩니다. 로그가 터미널에 출력됩니다.
+코드 수정 후: **Ctrl+C → `make run`** 으로 즉시 반영.
+
+### 4. Sample CR 배포 (선택)
+
+다른 터미널에서 실행:
+
+```bash
+kubectl create namespace aerospike --dry-run=client -o yaml | kubectl apply -f -
+kubectl apply -f config/samples/acko_v1alpha1_aerospikecluster.yaml
+```
+
+상태 확인:
+```bash
+kubectl -n aerospike get asc
+kubectl -n aerospike get pods -w
+```
+
+## Available Samples
+
+| 파일 | 설명 |
+|------|------|
+| `acko_v1alpha1_aerospikecluster.yaml` | 단일 노드 in-memory |
+| `aerospike-cluster-3node.yaml` | 3노드 PV storage |
+| `aerospike-cluster-multirack.yaml` | 6노드 multi-rack |
+| `aerospike-cluster-acl.yaml` | 3노드 ACL |
+
+## Cleanup
+
+```bash
+kind delete cluster --name kind
+```
+
+## Troubleshooting
+
+- **make run 시 webhook cert 에러**: 무시 가능. webhook 서버는 자체 self-signed cert를 생성하지만, 클러스터에 webhook config가 없으므로 apiserver가 호출하지 않습니다.
+- **CRD 설치 실패 (annotation too long)**: `bin/kustomize build config/crd | kubectl replace -f -` 사용.
+- **Pod pending**: Kind에서 PVC를 사용하는 샘플은 storage provisioner가 필요합니다. in-memory 샘플(`acko_v1alpha1_aerospikecluster.yaml`)부터 시작하세요.
+- **컨텍스트 확인**: `kubectl config current-context`가 `kind-kind`인지 확인.

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,11 @@ test: test-unit test-integration ## Run all tests (unit + integration).
 # - CERT_MANAGER_INSTALL_SKIP=true
 KIND_CLUSTER ?= aerospike-ce-kubernetes-operator-test-e2e
 
+.PHONY: setup-kind
+setup-kind: ## Delete existing Kind cluster and create a fresh one with kind-config.yaml (3-worker, zone labels)
+	@$(KIND) delete cluster --name kind 2>/dev/null || true
+	KIND_EXPERIMENTAL_PROVIDER=$(KIND_PROVIDER) $(KIND) create cluster --config kind-config.yaml --name kind
+
 .PHONY: setup-test-e2e
 setup-test-e2e: ## Set up a Kind cluster for e2e tests if it does not exist
 	@command -v $(KIND) >/dev/null 2>&1 || { \

--- a/docs/content/guide/cluster-templates.md
+++ b/docs/content/guide/cluster-templates.md
@@ -110,6 +110,15 @@ spec:
           type: memory
 ```
 
+If the template lives in a different namespace (e.g. the operator namespace), specify `namespace` explicitly:
+
+```yaml
+spec:
+  templateRef:
+    name: hard-rack
+    namespace: aerospike-operator   # cross-namespace reference
+```
+
 You can still set `spec.image` or `spec.size` explicitly on the cluster to override the template:
 
 ```yaml

--- a/internal/controller/reconciler.go
+++ b/internal/controller/reconciler.go
@@ -683,7 +683,6 @@ func (r *AerospikeClusterReconciler) mapTemplateToCluster(ctx context.Context, o
 		if cl.Spec.TemplateRef == nil || cl.Spec.TemplateRef.Name != obj.GetName() {
 			continue
 		}
-
 		// Verify the cluster actually references a template in this namespace.
 		refNS := cl.Spec.TemplateRef.Namespace
 		if refNS == "" {


### PR DESCRIPTION
## Summary
- Add optional `namespace` field to `TemplateRef` so AerospikeCluster CRs can reference templates in other namespaces (e.g. Helm-deployed templates in `aerospike-operator` from CRs in `default`)
- Update template resolver and template watch to resolve the correct namespace, falling back to the cluster's own namespace when unset
- Add `make setup-kind` target for quick local Kind cluster setup
- Add `/run-local` Claude skill for local dev environment workflow

## Test plan
- [x] Template resolver unit tests pass (`go test ./internal/template/`)
- [x] `make build` succeeds
- [ ] E2E: create AerospikeCluster in `default` NS referencing template in `aerospike-operator` NS
- [ ] Unit tests pass (`make test`)
- [ ] Lint passes (`make lint`)