### PR TITLE
improve: enhance operator resilience, observability, and test coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,6 +180,11 @@ docker-buildx: ## Build and push docker image for the manager for cross-platform
 	- $(CONTAINER_TOOL) buildx rm aerospike-ce-kubernetes-operator-builder
 	rm Dockerfile.cross
 
+## Aliases (Podman terminology)
+.PHONY: container-build container-push
+container-build: docker-build  ## Alias for docker-build (Podman compatible)
+container-push: docker-push    ## Alias for docker-push (Podman compatible)
+
 .PHONY: build-installer
 build-installer: manifests generate kustomize ## Generate a consolidated YAML with CRDs and deployment.
 	mkdir -p dist
@@ -271,8 +276,7 @@ $(LOCALBIN):
 KUBECTL ?= kubectl
 KIND ?= kind
 # KIND_PROVIDER sets the container provider for Kind.
-# Override with `make setup-test-e2e KIND_PROVIDER=podman` for Podman.
-KIND_PROVIDER ?= docker
+KIND_PROVIDER ?= podman
 KUSTOMIZE ?= $(LOCALBIN)/kustomize
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest

--- a/internal/controller/aero_client.go
+++ b/internal/controller/aero_client.go
@@ -79,6 +79,43 @@ func (r *AerospikeClusterReconciler) getAerospikeClient(
 	return client, nil
 }
 
+// getAerospikeClientWithRetry wraps getAerospikeClient with retry logic using
+// exponential backoff (2s, 4s, 8s). This is useful during initial deployment
+// when DNS may not yet be resolving for the headless service.
+func (r *AerospikeClusterReconciler) getAerospikeClientWithRetry(
+	ctx context.Context,
+	cluster *ackov1alpha1.AerospikeCluster,
+) (*aero.Client, error) {
+	log := logf.FromContext(ctx)
+
+	const maxRetries = 3
+	var lastErr error
+
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		if attempt > 0 {
+			backoff := time.Duration(1<<uint(attempt)) * time.Second // 2s, 4s, 8s
+			log.V(1).Info("Retrying Aerospike client connection",
+				"attempt", attempt, "maxRetries", maxRetries, "backoff", backoff)
+
+			timer := time.NewTimer(backoff)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return nil, fmt.Errorf("context cancelled while retrying Aerospike connection: %w", ctx.Err())
+			case <-timer.C:
+			}
+		}
+
+		client, err := r.getAerospikeClient(ctx, cluster)
+		if err == nil {
+			return client, nil
+		}
+		lastErr = err
+	}
+
+	return nil, fmt.Errorf("failed after %d retries: %w", maxRetries, lastErr)
+}
+
 // closeAerospikeClient safely closes an Aerospike client.
 func closeAerospikeClient(client *aero.Client) {
 	if client != nil {

--- a/internal/controller/aero_client_test.go
+++ b/internal/controller/aero_client_test.go
@@ -98,6 +98,15 @@ func TestGetServicePort(t *testing.T) {
 	}
 }
 
+func TestGetAerospikeClientWithRetry_MethodSignature(t *testing.T) {
+	// Verify the retry wrapper compiles with the correct method signature.
+	// The assignment below fails at compile time if the signature changes.
+	var r *AerospikeClusterReconciler
+	fn := r.getAerospikeClientWithRetry
+	// Use fn to satisfy the compiler.
+	_ = fn
+}
+
 func TestBuildQuiesceCommand(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/controller/reconciler.go
+++ b/internal/controller/reconciler.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	ackoerrors "github.com/ksr/aerospike-ce-kubernetes-operator/internal/errors"
 	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/metrics"
 	aerotmpl "github.com/ksr/aerospike-ce-kubernetes-operator/internal/template"
 	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/utils"
@@ -188,7 +189,7 @@ func (r *AerospikeClusterReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	// 6. Reconcile headless service
 	if err := r.reconcileHeadlessService(ctx, cluster); err != nil {
-		log.Error(err, "Failed to reconcile headless service")
+		log.Error(err, "Failed to reconcile headless service", "cluster", cluster.Name)
 		r.Recorder.Eventf(cluster, corev1.EventTypeWarning, EventReconcileError, "Headless service: %v", err)
 		metrics.ReconcileErrorsTotal.WithLabelValues(cluster.Namespace, cluster.Name, metrics.ReasonService).Inc()
 		return r.handleReconcileError(ctx, cluster, err)
@@ -196,7 +197,7 @@ func (r *AerospikeClusterReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	// 6b. Reconcile per-pod services
 	if err := r.reconcilePodServices(ctx, cluster); err != nil {
-		log.Error(err, "Failed to reconcile per-pod services")
+		log.Error(err, "Failed to reconcile per-pod services", "cluster", cluster.Name)
 		metrics.ReconcileErrorsTotal.WithLabelValues(cluster.Namespace, cluster.Name, metrics.ReasonService).Inc()
 		return r.handleReconcileError(ctx, cluster, err)
 	}
@@ -293,12 +294,26 @@ func (r *AerospikeClusterReconciler) handleReconcileError(
 		return ctrl.Result{}, reconcileErr
 	}
 
-	latest.Status.FailedReconcileCount++
 	// Truncate error message to avoid bloating the status object.
 	errMsg := reconcileErr.Error()
 	if len(errMsg) > 256 {
 		errMsg = errMsg[:256] + "..."
 	}
+
+	// Validation errors are permanent and will never self-heal.
+	// Don't increment the circuit breaker counter for these.
+	if ackoerrors.IsValidation(reconcileErr) {
+		log.Info("Validation error detected, not incrementing circuit breaker",
+			"error", reconcileErr)
+		// Still update the error message for visibility.
+		latest.Status.LastReconcileError = errMsg
+		if err := r.Status().Update(updateCtx, latest); err != nil {
+			log.Error(err, "Failed to update validation error in status")
+		}
+		return ctrl.Result{}, reconcileErr
+	}
+
+	latest.Status.FailedReconcileCount++
 	latest.Status.LastReconcileError = errMsg
 
 	if err := r.Status().Update(updateCtx, latest); err != nil {
@@ -376,6 +391,7 @@ func (r *AerospikeClusterReconciler) reconcileCluster(
 	cluster *ackov1alpha1.AerospikeCluster,
 ) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
+	log.V(1).Info("Starting cluster reconciliation")
 	racks := r.getRacks(cluster)
 
 	// Pre-compute effective config and hash per rack.
@@ -461,7 +477,7 @@ func (r *AerospikeClusterReconciler) reconcileCluster(
 	for _, rack := range racks {
 		restarted, err := r.reconcileRollingRestart(ctx, cluster, &rack)
 		if err != nil {
-			log.Error(err, "Failed rolling restart", "rack", rack.ID)
+			log.Error(err, "Failed rolling restart", "rack", rack.ID, "statefulset", utils.StatefulSetName(cluster.Name, rack.ID))
 			metrics.ReconcileErrorsTotal.WithLabelValues(cluster.Namespace, cluster.Name, metrics.ReasonRestart).Inc()
 			return ctrl.Result{}, err
 		}
@@ -490,7 +506,7 @@ func (r *AerospikeClusterReconciler) reconcileCluster(
 		}
 	}
 	if synced, err := r.reconcileACL(ctx, cluster); err != nil {
-		log.Error(err, "Failed to reconcile ACL")
+		log.Error(err, "Failed to reconcile ACL", "cluster", cluster.Name)
 		r.Recorder.Eventf(cluster, corev1.EventTypeWarning, EventACLSyncError, "ACL sync failed: %v", err)
 		metrics.ReconcileErrorsTotal.WithLabelValues(cluster.Namespace, cluster.Name, metrics.ReasonACL).Inc()
 		aclErr = err
@@ -540,6 +556,9 @@ func (r *AerospikeClusterReconciler) reconcileRacks(
 	racks []ackov1alpha1.Rack,
 	rackInfos []rackInfo,
 ) (bool, error) {
+	log := logf.FromContext(ctx)
+	log.V(1).Info("Reconciling racks", "count", len(racks))
+
 	scaleDownDeferred := false
 	for i, rack := range racks {
 		ri := rackInfos[i]

--- a/internal/controller/reconciler_acl.go
+++ b/internal/controller/reconciler_acl.go
@@ -33,7 +33,7 @@ func (r *AerospikeClusterReconciler) reconcileACL(
 	ctx context.Context,
 	cluster *ackov1alpha1.AerospikeCluster,
 ) (bool, error) {
-	log := logf.FromContext(ctx)
+	log := logf.FromContext(ctx).WithValues("cluster", cluster.Name)
 
 	if cluster.Spec.AerospikeAccessControl == nil {
 		return false, nil
@@ -68,23 +68,42 @@ func (r *AerospikeClusterReconciler) reconcileACL(
 	r.Recorder.Eventf(cluster, corev1.EventTypeNormal, EventACLSyncStarted,
 		"ACL synchronization started")
 
-	aeroClient, err := r.getAerospikeClient(ctx, cluster)
+	aeroClient, err := r.getAerospikeClientWithRetry(ctx, cluster)
 	if err != nil {
 		metrics.ACLSyncTotal.WithLabelValues(cluster.Namespace, cluster.Name, "error").Inc()
 		return false, fmt.Errorf("ACL sync: connecting to cluster: %w", err)
 	}
 	defer closeAerospikeClient(aeroClient)
 
-	// Sync roles first (users may depend on roles)
+	// Sync roles first (users may depend on roles).
+	// Attempt ACL sync with a single retry for transient connection errors.
+	// During rolling restarts, the Aerospike cluster may briefly reject connections
+	// from nodes that are restarting.
 	if err := r.reconcileRoles(ctx, aeroClient, cluster); err != nil {
-		metrics.ACLSyncTotal.WithLabelValues(cluster.Namespace, cluster.Name, "error").Inc()
-		return false, fmt.Errorf("ACL sync roles: %w", err)
+		if isTransientAeroError(err) {
+			log.Info("Transient error during role sync, retrying once", "error", err)
+			if retryErr := r.reconcileRoles(ctx, aeroClient, cluster); retryErr != nil {
+				metrics.ACLSyncTotal.WithLabelValues(cluster.Namespace, cluster.Name, "error").Inc()
+				return false, fmt.Errorf("ACL sync roles (after retry): %w", retryErr)
+			}
+		} else {
+			metrics.ACLSyncTotal.WithLabelValues(cluster.Namespace, cluster.Name, "error").Inc()
+			return false, fmt.Errorf("ACL sync roles: %w", err)
+		}
 	}
 
-	// Sync users
+	// Sync users with the same single-retry pattern for transient errors.
 	if err := r.reconcileUsers(ctx, aeroClient, cluster); err != nil {
-		metrics.ACLSyncTotal.WithLabelValues(cluster.Namespace, cluster.Name, "error").Inc()
-		return false, fmt.Errorf("ACL sync users: %w", err)
+		if isTransientAeroError(err) {
+			log.Info("Transient error during user sync, retrying once", "error", err)
+			if retryErr := r.reconcileUsers(ctx, aeroClient, cluster); retryErr != nil {
+				metrics.ACLSyncTotal.WithLabelValues(cluster.Namespace, cluster.Name, "error").Inc()
+				return false, fmt.Errorf("ACL sync users (after retry): %w", retryErr)
+			}
+		} else {
+			metrics.ACLSyncTotal.WithLabelValues(cluster.Namespace, cluster.Name, "error").Inc()
+			return false, fmt.Errorf("ACL sync users: %w", err)
+		}
 	}
 
 	metrics.ACLSyncTotal.WithLabelValues(cluster.Namespace, cluster.Name, "success").Inc()
@@ -391,6 +410,19 @@ func privilegeSet(privs []aero.Privilege) map[string]aero.Privilege {
 		set[privilegeKey(p)] = p
 	}
 	return set
+}
+
+// isTransientAeroError checks if an Aerospike error is transient and worth retrying.
+// This includes connection resets, timeouts, and cluster-not-ready errors.
+func isTransientAeroError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "connection reset") ||
+		strings.Contains(msg, "timeout") ||
+		strings.Contains(msg, "i/o timeout") ||
+		strings.Contains(msg, "connection refused")
 }
 
 // newAdminPolicy returns an AdminPolicy with the standard operator timeout.

--- a/internal/controller/reconciler_acl_test.go
+++ b/internal/controller/reconciler_acl_test.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
@@ -305,6 +306,46 @@ func TestRoleParsedPrivileges_UnknownCodeReturnsError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "bad-role") {
 		t.Errorf("error should mention role name, got: %v", err)
+	}
+}
+
+// --- isTransientAeroError tests ---
+
+func TestIsTransientAeroError_NilError(t *testing.T) {
+	if isTransientAeroError(nil) {
+		t.Error("expected false for nil error")
+	}
+}
+
+func TestIsTransientAeroError_TransientErrors(t *testing.T) {
+	transientMessages := []string{
+		"connection reset by peer",
+		"dial tcp 10.0.0.1:3000: connection refused",
+		"i/o timeout",
+		"read tcp 10.0.0.1:3000: timeout",
+		"querying roles: connection reset",
+	}
+	for _, msg := range transientMessages {
+		err := errors.New(msg)
+		if !isTransientAeroError(err) {
+			t.Errorf("expected true for transient error %q", msg)
+		}
+	}
+}
+
+func TestIsTransientAeroError_PermanentErrors(t *testing.T) {
+	permanentMessages := []string{
+		"role already exists",
+		"user does not exist",
+		"not authenticated",
+		"invalid privilege",
+		"unknown privilege code \"bad\"",
+	}
+	for _, msg := range permanentMessages {
+		err := errors.New(msg)
+		if isTransientAeroError(err) {
+			t.Errorf("expected false for permanent error %q", msg)
+		}
 	}
 }
 

--- a/internal/controller/reconciler_dynamic_config.go
+++ b/internal/controller/reconciler_dynamic_config.go
@@ -26,7 +26,7 @@ func (r *AerospikeClusterReconciler) tryDynamicConfigUpdate(
 	oldConfig, newConfig map[string]any,
 	aeroClient *aero.Client,
 ) bool {
-	log := logf.FromContext(ctx)
+	log := logf.FromContext(ctx).WithValues("pod", pod.Name, "cluster", cluster.Name)
 
 	// Check if dynamic config update is enabled
 	if cluster.Spec.EnableDynamicConfigUpdate == nil || !*cluster.Spec.EnableDynamicConfigUpdate {
@@ -42,14 +42,20 @@ func (r *AerospikeClusterReconciler) tryDynamicConfigUpdate(
 	// If there are static changes, dynamic update alone is not sufficient
 	if diff.HasStaticChanges() {
 		log.Info("Config has static changes, dynamic update not sufficient",
-			"pod", pod.Name, "staticChanges", len(diff.Static))
+			"staticChanges", len(diff.Static))
 		return false
 	}
 
 	// Find the node corresponding to this pod
 	node := findNodeForPod(aeroClient, pod)
 	if node == nil {
-		log.Info("Could not find Aerospike node for pod, skipping dynamic update", "pod", pod.Name)
+		log.Info("Could not find Aerospike node for pod, skipping dynamic update")
+		return false
+	}
+
+	// Pre-flight: validate all changes before applying any
+	if err := validateDynamicChanges(diff.Dynamic); err != nil {
+		log.Error(err, "Pre-flight validation failed for dynamic config changes")
 		return false
 	}
 
@@ -57,18 +63,18 @@ func (r *AerospikeClusterReconciler) tryDynamicConfigUpdate(
 	for _, change := range diff.Dynamic {
 		cmd, err := buildSetConfigCommand(change)
 		if err != nil {
-			log.Error(err, "Invalid dynamic config change", "pod", pod.Name, "change", change)
+			log.Error(err, "Invalid dynamic config change", "change", change)
 			return false
 		}
-		log.Info("Applying dynamic config", "pod", pod.Name, "command", cmd)
+		log.Info("Applying dynamic config", "command", cmd)
 
 		result, err := asinfoCommandOnNode(node, cmd)
 		if err != nil {
-			log.Error(err, "Dynamic config command failed", "pod", pod.Name, "command", cmd)
+			log.Error(err, "Dynamic config command failed", "command", cmd)
 			return false
 		}
 		if result != "ok" {
-			log.Info("Dynamic config command returned non-ok", "pod", pod.Name, "command", cmd, "result", result)
+			log.Info("Dynamic config command returned non-ok", "command", cmd, "result", result)
 			return false
 		}
 	}
@@ -79,7 +85,7 @@ func (r *AerospikeClusterReconciler) tryDynamicConfigUpdate(
 
 	if desiredHash != "" {
 		if err := r.updatePodConfigHash(ctx, pod, desiredHash); err != nil {
-			log.Error(err, "Failed to update pod config hash after dynamic update", "pod", pod.Name)
+			log.Error(err, "Failed to update pod config hash after dynamic update")
 			// This is non-fatal; the pod may get restarted but config is already applied
 		}
 	}
@@ -87,7 +93,7 @@ func (r *AerospikeClusterReconciler) tryDynamicConfigUpdate(
 	metrics.DynamicConfigUpdatesTotal.WithLabelValues(cluster.Namespace, cluster.Name).Inc()
 	r.Recorder.Eventf(cluster, corev1.EventTypeNormal, EventDynamicConfigApplied,
 		"Dynamic config applied to pod %s (%d changes)", pod.Name, len(diff.Dynamic))
-	log.Info("Dynamic config update successful", "pod", pod.Name, "changes", len(diff.Dynamic))
+	log.Info("Dynamic config update successful", "changes", len(diff.Dynamic))
 
 	// Update pod status with dynamic config status
 	r.updateDynamicConfigStatus(ctx, cluster, pod.Name, "Applied")
@@ -119,6 +125,23 @@ func buildSetConfigCommand(change configdiff.Change) (string, error) {
 
 	return fmt.Sprintf("set-config:context=%s;%s=%v",
 		change.Context, change.Key, change.NewValue), nil
+}
+
+// validateDynamicChanges performs pre-flight validation on all dynamic config
+// changes to catch obvious errors before applying any of them. This prevents
+// partial config state where some changes succeed and others fail.
+func validateDynamicChanges(changes []configdiff.Change) error {
+	var errs []string
+	for _, change := range changes {
+		if _, err := buildSetConfigCommand(change); err != nil {
+			errs = append(errs, err.Error())
+		}
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("pre-flight validation failed for %d change(s): %s",
+			len(errs), strings.Join(errs, "; "))
+	}
+	return nil
 }
 
 // findNodeForPod finds the Aerospike node that corresponds to a given pod by

--- a/internal/controller/reconciler_dynamic_config_test.go
+++ b/internal/controller/reconciler_dynamic_config_test.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/configdiff"
@@ -116,6 +117,65 @@ func TestBuildSetConfigCommand_NamespaceWithHighWaterDiskPct(t *testing.T) {
 	expected := "set-config:context=namespace;id=production;high-water-disk-pct=90"
 	if cmd != expected {
 		t.Errorf("buildSetConfigCommand = %q, want %q", cmd, expected)
+	}
+}
+
+// --- validateDynamicChanges tests ---
+
+func TestValidateDynamicChanges_AllValid(t *testing.T) {
+	changes := []configdiff.Change{
+		{Path: "service.proto-fd-max", Context: "service", Key: "proto-fd-max", NewValue: 20000},
+		{Path: "namespace.default-ttl", Context: "namespace", Key: "default-ttl", NewValue: 3600, Namespace: "myns"},
+	}
+	if err := validateDynamicChanges(changes); err != nil {
+		t.Errorf("expected nil error for all valid changes, got: %v", err)
+	}
+}
+
+func TestValidateDynamicChanges_Empty(t *testing.T) {
+	if err := validateDynamicChanges(nil); err != nil {
+		t.Errorf("expected nil error for empty changes, got: %v", err)
+	}
+	if err := validateDynamicChanges([]configdiff.Change{}); err != nil {
+		t.Errorf("expected nil error for empty slice, got: %v", err)
+	}
+}
+
+func TestValidateDynamicChanges_OneInvalid(t *testing.T) {
+	changes := []configdiff.Change{
+		{Path: "service.proto-fd-max", Context: "service", Key: "proto-fd-max", NewValue: 20000},
+		{Path: "service.bad", Context: "service", Key: "bad;key", NewValue: 100},
+	}
+	err := validateDynamicChanges(changes)
+	if err == nil {
+		t.Fatal("expected error for invalid change, got nil")
+	}
+	if !strings.Contains(err.Error(), "bad;key") {
+		t.Errorf("error should mention the bad field, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "1 change(s)") {
+		t.Errorf("error should report 1 failed change, got: %v", err)
+	}
+}
+
+func TestValidateDynamicChanges_MultipleInvalid(t *testing.T) {
+	changes := []configdiff.Change{
+		{Path: "service.bad1", Context: "service", Key: "bad;key1", NewValue: 100},
+		{Path: "service.ok", Context: "service", Key: "ok-key", NewValue: 200},
+		{Path: "service.bad2", Context: "service;inject", Key: "good-key", NewValue: 300},
+	}
+	err := validateDynamicChanges(changes)
+	if err == nil {
+		t.Fatal("expected error for multiple invalid changes, got nil")
+	}
+	if !strings.Contains(err.Error(), "bad;key1") {
+		t.Errorf("error should mention bad;key1, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "service;inject") {
+		t.Errorf("error should mention service;inject, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "2 change(s)") {
+		t.Errorf("error should report 2 failed changes, got: %v", err)
 	}
 }
 

--- a/internal/controller/reconciler_monitoring.go
+++ b/internal/controller/reconciler_monitoring.go
@@ -38,6 +38,7 @@ func (r *AerospikeClusterReconciler) reconcileMonitoring(
 	cluster *ackov1alpha1.AerospikeCluster,
 ) error {
 	log := logf.FromContext(ctx)
+	log.V(1).Info("Reconciling monitoring resources", "cluster", cluster.Name)
 
 	monitoringEnabled := cluster.Spec.Monitoring != nil && cluster.Spec.Monitoring.Enabled
 
@@ -417,6 +418,19 @@ func defaultAlertRules(clusterName, namespace string) []any {
 					"annotations": map[string]any{
 						"summary":     fmt.Sprintf("K8s pod count differs from Aerospike cluster-size for cluster %s", clusterName),
 						"description": fmt.Sprintf("The number of ready K8s pods does not match the Aerospike cluster-size reported by asinfo for cluster %s.", clusterName),
+					},
+				},
+				map[string]any{
+					"alert": "AerospikeOperatorCircuitBreakerActive",
+					"expr":  fmt.Sprintf(`acko_circuit_breaker_active{namespace="%s",name="%s"} == 1`, namespace, clusterName),
+					"for":   "5m",
+					"labels": map[string]any{
+						"severity": "critical",
+						"cluster":  clusterName,
+					},
+					"annotations": map[string]any{
+						"summary":     fmt.Sprintf("Aerospike operator circuit breaker is active for cluster %s", clusterName),
+						"description": fmt.Sprintf("The operator has hit 10+ consecutive reconciliation failures for cluster %s/%s. Manual investigation required.", namespace, clusterName),
 					},
 				},
 			},

--- a/internal/controller/reconciler_monitoring_test.go
+++ b/internal/controller/reconciler_monitoring_test.go
@@ -263,7 +263,7 @@ var _ = Describe("reconcileMonitoring", func() {
 	})
 
 	Describe("defaultAlertRules", func() {
-		It("should generate 6 default alert rules", func() {
+		It("should generate 7 default alert rules", func() {
 			rules := defaultAlertRules("my-cluster", "default")
 			Expect(rules).To(HaveLen(1)) // one group
 
@@ -273,7 +273,7 @@ var _ = Describe("reconcileMonitoring", func() {
 
 			rulesList, ok := group["rules"].([]any)
 			Expect(ok).To(BeTrue())
-			Expect(rulesList).To(HaveLen(6))
+			Expect(rulesList).To(HaveLen(7))
 
 			// Verify rule names
 			expectedAlerts := []string{
@@ -283,6 +283,7 @@ var _ = Describe("reconcileMonitoring", func() {
 				"AerospikeHighMemoryUsage",
 				"AerospikeReconcileStale",
 				"AerospikeClusterSizeMismatch",
+				"AerospikeOperatorCircuitBreakerActive",
 			}
 			for i, rule := range rulesList {
 				r, ok := rule.(map[string]any)
@@ -301,6 +302,26 @@ var _ = Describe("reconcileMonitoring", func() {
 			expr := nodeDown["expr"].(string)
 			Expect(expr).To(ContainSubstring(`job="test-cluster-metrics"`))
 			Expect(expr).To(ContainSubstring(`namespace="prod"`))
+		})
+
+		It("should include circuit breaker alert with correct PromQL and severity", func() {
+			rules := defaultAlertRules("cb-cluster", "monitoring")
+			group := rules[0].(map[string]any)
+			rulesList := group["rules"].([]any)
+
+			// Circuit breaker alert is the last rule
+			cbRule := rulesList[len(rulesList)-1].(map[string]any)
+			Expect(cbRule["alert"]).To(Equal("AerospikeOperatorCircuitBreakerActive"))
+			Expect(cbRule["expr"]).To(Equal(`acko_circuit_breaker_active{namespace="monitoring",name="cb-cluster"} == 1`))
+			Expect(cbRule["for"]).To(Equal("5m"))
+
+			labels := cbRule["labels"].(map[string]any)
+			Expect(labels["severity"]).To(Equal("critical"))
+			Expect(labels["cluster"]).To(Equal("cb-cluster"))
+
+			annotations := cbRule["annotations"].(map[string]any)
+			Expect(annotations["summary"]).To(ContainSubstring("circuit breaker"))
+			Expect(annotations["description"]).To(ContainSubstring("monitoring/cb-cluster"))
 		})
 	})
 })

--- a/internal/controller/reconciler_monitoring_unit_test.go
+++ b/internal/controller/reconciler_monitoring_unit_test.go
@@ -97,6 +97,7 @@ func TestDefaultAlertRules(t *testing.T) {
 		"AerospikeHighMemoryUsage",
 		"AerospikeReconcileStale",
 		"AerospikeClusterSizeMismatch",
+		"AerospikeOperatorCircuitBreakerActive",
 	}
 
 	if len(ruleList) != len(expectedAlerts) {
@@ -146,8 +147,8 @@ func TestDefaultAlertRules_LabelSeverity(t *testing.T) {
 		}
 	}
 
-	if criticalCount != 2 {
-		t.Errorf("expected 2 critical alerts, got %d", criticalCount)
+	if criticalCount != 3 {
+		t.Errorf("expected 3 critical alerts, got %d", criticalCount)
 	}
 	if warningCount != 4 {
 		t.Errorf("expected 4 warning alerts, got %d", warningCount)

--- a/internal/controller/reconciler_networkpolicy.go
+++ b/internal/controller/reconciler_networkpolicy.go
@@ -32,6 +32,9 @@ func (r *AerospikeClusterReconciler) reconcileNetworkPolicy(
 	ctx context.Context,
 	cluster *ackov1alpha1.AerospikeCluster,
 ) error {
+	log := logf.FromContext(ctx)
+	log.V(1).Info("Reconciling network policy", "cluster", cluster.Name)
+
 	npcEnabled := cluster.Spec.NetworkPolicyConfig != nil && cluster.Spec.NetworkPolicyConfig.Enabled
 	npcType := ackov1alpha1.NetworkPolicyTypeKubernetes
 	if cluster.Spec.NetworkPolicyConfig != nil && cluster.Spec.NetworkPolicyConfig.Type != "" {

--- a/internal/controller/reconciler_restart.go
+++ b/internal/controller/reconciler_restart.go
@@ -36,6 +36,7 @@ func (r *AerospikeClusterReconciler) reconcileRollingRestart(
 	log := logf.FromContext(ctx)
 
 	stsName := utils.StatefulSetName(cluster.Name, rack.ID)
+	log = log.WithValues("rack", rack.ID, "statefulset", stsName)
 
 	sts := &appsv1.StatefulSet{}
 	if err := r.Get(ctx, types.NamespacedName{Name: stsName, Namespace: cluster.Namespace}, sts); err != nil {

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package errors
+
+import (
+	"errors"
+	"fmt"
+)
+
+// TransientError wraps errors that are temporary and worth retrying.
+// The circuit breaker should count these normally.
+type TransientError struct {
+	Err error
+}
+
+func (e *TransientError) Error() string { return e.Err.Error() }
+func (e *TransientError) Unwrap() error { return e.Err }
+
+// NewTransient wraps an error as transient.
+func NewTransient(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &TransientError{Err: err}
+}
+
+// ValidationError represents a permanent configuration or spec validation error.
+// These errors will never self-heal, so the circuit breaker should NOT count them
+// toward the failure threshold.
+type ValidationError struct {
+	Err error
+}
+
+func (e *ValidationError) Error() string { return e.Err.Error() }
+func (e *ValidationError) Unwrap() error { return e.Err }
+
+// NewValidation wraps an error as a validation error.
+func NewValidation(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &ValidationError{Err: err}
+}
+
+// NewValidationf creates a new ValidationError with a formatted message.
+func NewValidationf(format string, args ...any) error {
+	return &ValidationError{Err: fmt.Errorf(format, args...)}
+}
+
+// IsValidation checks if an error is a ValidationError.
+func IsValidation(err error) bool {
+	var ve *ValidationError
+	return errors.As(err, &ve)
+}

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package errors
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestNewTransient(t *testing.T) {
+	t.Run("nil input returns nil", func(t *testing.T) {
+		if got := NewTransient(nil); got != nil {
+			t.Fatalf("expected nil, got %v", got)
+		}
+	})
+
+	t.Run("wraps and unwraps correctly", func(t *testing.T) {
+		inner := fmt.Errorf("connection refused")
+		wrapped := NewTransient(inner)
+
+		if wrapped.Error() != "connection refused" {
+			t.Fatalf("unexpected message: %s", wrapped.Error())
+		}
+
+		var te *TransientError
+		if !errors.As(wrapped, &te) {
+			t.Fatal("errors.As should match *TransientError")
+		}
+		if te.Err != inner {
+			t.Fatal("unwrapped error should be the original")
+		}
+		if !errors.Is(wrapped, inner) {
+			t.Fatal("errors.Is should find the inner error")
+		}
+	})
+}
+
+func TestNewValidation(t *testing.T) {
+	t.Run("nil input returns nil", func(t *testing.T) {
+		if got := NewValidation(nil); got != nil {
+			t.Fatalf("expected nil, got %v", got)
+		}
+	})
+
+	t.Run("wraps and unwraps correctly", func(t *testing.T) {
+		inner := fmt.Errorf("invalid size")
+		wrapped := NewValidation(inner)
+
+		if wrapped.Error() != "invalid size" {
+			t.Fatalf("unexpected message: %s", wrapped.Error())
+		}
+
+		var ve *ValidationError
+		if !errors.As(wrapped, &ve) {
+			t.Fatal("errors.As should match *ValidationError")
+		}
+		if ve.Err != inner {
+			t.Fatal("unwrapped error should be the original")
+		}
+		if !errors.Is(wrapped, inner) {
+			t.Fatal("errors.Is should find the inner error")
+		}
+	})
+}
+
+func TestNewValidationf(t *testing.T) {
+	err := NewValidationf("template %q not found in namespace %q", "my-tmpl", "default")
+
+	expected := `template "my-tmpl" not found in namespace "default"`
+	if err.Error() != expected {
+		t.Fatalf("expected %q, got %q", expected, err.Error())
+	}
+
+	var ve *ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatal("errors.As should match *ValidationError")
+	}
+}
+
+func TestIsValidation(t *testing.T) {
+	t.Run("true for ValidationError", func(t *testing.T) {
+		err := NewValidation(fmt.Errorf("bad config"))
+		if !IsValidation(err) {
+			t.Fatal("expected true")
+		}
+	})
+
+	t.Run("true for wrapped ValidationError", func(t *testing.T) {
+		inner := NewValidation(fmt.Errorf("bad config"))
+		wrapped := fmt.Errorf("outer: %w", inner)
+		if !IsValidation(wrapped) {
+			t.Fatal("expected true through wrapping chain")
+		}
+	})
+
+	t.Run("false for non-validation error", func(t *testing.T) {
+		err := fmt.Errorf("some transient error")
+		if IsValidation(err) {
+			t.Fatal("expected false")
+		}
+	})
+
+	t.Run("false for TransientError", func(t *testing.T) {
+		err := NewTransient(fmt.Errorf("timeout"))
+		if IsValidation(err) {
+			t.Fatal("expected false for TransientError")
+		}
+	})
+
+	t.Run("false for nil", func(t *testing.T) {
+		if IsValidation(nil) {
+			t.Fatal("expected false for nil")
+		}
+	})
+}
+
+func TestErrorsIs_WrappingChain(t *testing.T) {
+	sentinel := fmt.Errorf("sentinel")
+	validated := NewValidation(sentinel)
+	wrapped := fmt.Errorf("layer1: %w", validated)
+	doubleWrapped := fmt.Errorf("layer2: %w", wrapped)
+
+	if !errors.Is(doubleWrapped, sentinel) {
+		t.Fatal("errors.Is should find sentinel through double wrapping")
+	}
+	if !IsValidation(doubleWrapped) {
+		t.Fatal("IsValidation should find ValidationError through double wrapping")
+	}
+}

--- a/internal/template/resolver.go
+++ b/internal/template/resolver.go
@@ -21,11 +21,13 @@ import (
 	"fmt"
 	"time"
 
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	ackoerrors "github.com/ksr/aerospike-ce-kubernetes-operator/internal/errors"
 )
 
 const (
@@ -61,6 +63,9 @@ func FetchAndSnapshot(
 		Name:      cluster.Spec.TemplateRef.Name,
 		Namespace: ns,
 	}, tmpl); err != nil {
+		if errors.IsNotFound(err) {
+			return nil, false, ackoerrors.NewValidationf("template %q not found in namespace %q", cluster.Spec.TemplateRef.Name, ns)
+		}
 		return nil, false, fmt.Errorf("fetching template %q in namespace %q: %w", cluster.Spec.TemplateRef.Name, ns, err)
 	}
 

--- a/test/e2e/e2e_multirack_test.go
+++ b/test/e2e/e2e_multirack_test.go
@@ -1,0 +1,206 @@
+//go:build e2e
+
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"os/exec"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	"github.com/ksr/aerospike-ce-kubernetes-operator/test/utils"
+)
+
+const multirackNS = "aerospike-multirack"
+
+var _ = Describe("Multi-rack cluster", Ordered, Label("heavy"), func() {
+
+	BeforeAll(func() {
+		By("creating multirack test namespace")
+		Expect(utils.EnsureNamespace(ctx, k8sClient, multirackNS)).To(Succeed())
+	})
+
+	AfterAll(func() {
+		By("cleaning up all multirack test clusters")
+		for _, name := range []string{"e2e-mr-basic", "e2e-mr-scale"} {
+			cmd := exec.Command("kubectl", "delete", "aerospikecluster", name,
+				"-n", multirackNS, "--ignore-not-found", "--timeout=120s")
+			_, _ = utils.Run(cmd)
+		}
+		By("deleting multirack test namespace")
+		_ = utils.DeleteNamespace(ctx, k8sClient, multirackNS)
+	})
+
+	Context("Basic multi-rack deployment", func() {
+		const clusterName = "e2e-mr-basic"
+
+		It("should create a multi-rack cluster with correct StatefulSets", func() {
+			By("creating a 4-node cluster with 2 racks")
+			cluster := newTestCluster(clusterName, multirackNS, 4, func(c *ackov1alpha1.AerospikeCluster) {
+				c.Spec.RackConfig = &ackov1alpha1.RackConfig{
+					Racks: []ackov1alpha1.Rack{
+						{ID: 1},
+						{ID: 2},
+					},
+				}
+			})
+			Eventually(func() error {
+				return k8sClient.Create(ctx, cluster)
+			}, 30*time.Second, 2*time.Second).Should(Succeed())
+
+			By("waiting for Completed phase")
+			Eventually(func(g Gomega) {
+				c, err := utils.GetCluster(ctx, k8sClient, clusterName, multirackNS)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(c.Status.Phase).To(Equal(ackov1alpha1.AerospikePhaseCompleted))
+			}, multiNodeTimeout, 2*time.Second).Should(Succeed())
+
+			By("verifying one StatefulSet per rack is created")
+			stsList, err := utils.ListClusterStatefulSets(ctx, k8sClient, clusterName, multirackNS)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(stsList.Items).To(HaveLen(2))
+
+			stsNames := make([]string, 0, len(stsList.Items))
+			for _, sts := range stsList.Items {
+				stsNames = append(stsNames, sts.Name)
+			}
+			Expect(stsNames).To(ContainElements(
+				fmt.Sprintf("%s-1", clusterName),
+				fmt.Sprintf("%s-2", clusterName),
+			))
+
+			By("verifying total pod count matches spec.size")
+			Eventually(func(g Gomega) {
+				count, err := utils.CountReadyPods(ctx, k8sClient, clusterName, multirackNS)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(count).To(Equal(4))
+			}, multiNodeTimeout, 2*time.Second).Should(Succeed())
+
+			By("verifying pods are distributed evenly across racks")
+			podList, err := utils.ListClusterPods(ctx, k8sClient, clusterName, multirackNS)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(podList.Items).To(HaveLen(4))
+
+			rackCounts := map[string]int{}
+			for _, pod := range podList.Items {
+				rack := pod.Labels["acko.io/rack"]
+				Expect(rack).NotTo(BeEmpty(), "pod %s should have rack label", pod.Name)
+				rackCounts[rack]++
+			}
+			Expect(rackCounts).To(HaveLen(2))
+			for rack, count := range rackCounts {
+				Expect(count).To(Equal(2), "rack %s should have 2 pods", rack)
+			}
+
+			By("verifying one ConfigMap per rack is created")
+			for _, rackID := range []int{1, 2} {
+				cmName := fmt.Sprintf("%s-%d-config", clusterName, rackID)
+				exists, err := utils.ConfigMapExists(ctx, k8sClient, cmName, multirackNS)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(exists).To(BeTrue(), "configmap %s should exist", cmName)
+			}
+		})
+
+		It("should report correct status for multi-rack cluster", func() {
+			cluster, err := utils.GetCluster(ctx, k8sClient, clusterName, multirackNS)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cluster.Status.Size).To(Equal(int32(4)))
+			Expect(cluster.Status.Pods).To(HaveLen(4))
+
+			for _, ps := range cluster.Status.Pods {
+				Expect(ps.IsRunningAndReady).To(BeTrue())
+				Expect(ps.Image).To(Equal("aerospike:ce-8.1.1.1"))
+				Expect(ps.Rack).To(BeElementOf(1, 2))
+			}
+		})
+	})
+
+	Context("Multi-rack scale up", func() {
+		const clusterName = "e2e-mr-scale"
+
+		It("should scale up and distribute pods across racks", func() {
+			By("creating a 2-node cluster with 2 racks")
+			cluster := newTestCluster(clusterName, multirackNS, 2, func(c *ackov1alpha1.AerospikeCluster) {
+				c.Spec.RackConfig = &ackov1alpha1.RackConfig{
+					Racks: []ackov1alpha1.Rack{
+						{ID: 1},
+						{ID: 2},
+					},
+				}
+			})
+			Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
+
+			By("waiting for Completed phase with 2 pods")
+			Eventually(func(g Gomega) {
+				c, err := utils.GetCluster(ctx, k8sClient, clusterName, multirackNS)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(c.Status.Phase).To(Equal(ackov1alpha1.AerospikePhaseCompleted))
+			}, multiNodeTimeout, 2*time.Second).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				count, err := utils.CountReadyPods(ctx, k8sClient, clusterName, multirackNS)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(count).To(Equal(2))
+			}, multiNodeTimeout, 2*time.Second).Should(Succeed())
+
+			By("scaling to 4 nodes")
+			Expect(utils.PatchCluster(ctx, k8sClient, clusterName, multirackNS,
+				[]byte(`{"spec":{"size":4}}`))).To(Succeed())
+
+			By("waiting for 4 pods to be ready")
+			Eventually(func(g Gomega) {
+				c, err := utils.GetCluster(ctx, k8sClient, clusterName, multirackNS)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(c.Status.Phase).To(Equal(ackov1alpha1.AerospikePhaseCompleted))
+			}, multiNodeTimeout, 2*time.Second).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				count, err := utils.CountReadyPods(ctx, k8sClient, clusterName, multirackNS)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(count).To(Equal(4))
+			}, multiNodeTimeout, 2*time.Second).Should(Succeed())
+
+			By("verifying pods are distributed evenly after scale up")
+			podList, err := utils.ListClusterPods(ctx, k8sClient, clusterName, multirackNS)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(podList.Items).To(HaveLen(4))
+
+			rackCounts := map[string]int{}
+			for _, pod := range podList.Items {
+				rack := pod.Labels["acko.io/rack"]
+				Expect(rack).NotTo(BeEmpty(), "pod %s should have rack label", pod.Name)
+				rackCounts[rack]++
+			}
+			Expect(rackCounts).To(HaveLen(2))
+			for rack, count := range rackCounts {
+				Expect(count).To(Equal(2), "rack %s should have 2 pods after scale up", rack)
+			}
+
+			By("verifying status.size reflects the new size")
+			Eventually(func(g Gomega) {
+				c, err := utils.GetCluster(ctx, k8sClient, clusterName, multirackNS)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(c.Status.Size).To(Equal(int32(4)))
+			}, defaultTimeout, 2*time.Second).Should(Succeed())
+		})
+	})
+})

--- a/test/e2e/e2e_pvc_test.go
+++ b/test/e2e/e2e_pvc_test.go
@@ -1,0 +1,261 @@
+//go:build e2e
+
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"os/exec"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	"github.com/ksr/aerospike-ce-kubernetes-operator/test/utils"
+)
+
+const pvcNS = "aerospike-pvc"
+
+// boolPtr returns a pointer to a bool value.
+func boolPtr(b bool) *bool { return &b }
+
+var _ = Describe("PVC management", Ordered, Label("heavy"), func() {
+
+	BeforeAll(func() {
+		By("creating PVC test namespace")
+		Expect(utils.EnsureNamespace(ctx, k8sClient, pvcNS)).To(Succeed())
+	})
+
+	AfterAll(func() {
+		By("cleaning up all PVC test clusters")
+		for _, name := range []string{"e2e-pvc-create", "e2e-pvc-cascade", "e2e-pvc-retain"} {
+			cmd := exec.Command("kubectl", "delete", "aerospikecluster", name,
+				"-n", pvcNS, "--ignore-not-found", "--timeout=120s")
+			_, _ = utils.Run(cmd)
+		}
+		By("deleting PVC test namespace")
+		_ = utils.DeleteNamespace(ctx, k8sClient, pvcNS)
+	})
+
+	Context("PVC creation for storage volumes", func() {
+		const clusterName = "e2e-pvc-create"
+
+		It("should create PVCs for storage volumes", func() {
+			By("creating a 2-node cluster with persistent storage")
+			cluster := newTestCluster(clusterName, pvcNS, 2, func(c *ackov1alpha1.AerospikeCluster) {
+				c.Spec.Storage = &ackov1alpha1.AerospikeStorageSpec{
+					Volumes: []ackov1alpha1.VolumeSpec{
+						{
+							Name: "data-vol",
+							Source: ackov1alpha1.VolumeSource{
+								PersistentVolume: &ackov1alpha1.PersistentVolumeSpec{
+									StorageClass: "standard",
+									Size:         "1Gi",
+								},
+							},
+							Aerospike: &ackov1alpha1.AerospikeVolumeAttachment{
+								Path: "/opt/aerospike/data",
+							},
+							CascadeDelete: boolPtr(false),
+						},
+					},
+				}
+				// Configure the namespace to use in-memory so the cluster
+				// can start without requiring device files on the PVC.
+				c.Spec.AerospikeConfig = &ackov1alpha1.AerospikeConfigSpec{
+					Value: map[string]any{
+						"service": map[string]any{
+							"cluster-name": clusterName,
+							"proto-fd-max": float64(15000),
+						},
+						"network": map[string]any{
+							"service":   map[string]any{"address": "any", "port": float64(3000)},
+							"heartbeat": map[string]any{"mode": "mesh", "port": float64(3002)},
+							"fabric":    map[string]any{"address": "any", "port": float64(3001)},
+						},
+						"namespaces": []any{
+							map[string]any{
+								"name":               "test",
+								"replication-factor": float64(1),
+								"storage-engine": map[string]any{
+									"type":      "memory",
+									"data-size": float64(1073741824),
+								},
+							},
+						},
+					},
+				}
+			})
+			Eventually(func() error {
+				return k8sClient.Create(ctx, cluster)
+			}, 30*time.Second, 2*time.Second).Should(Succeed())
+
+			By("waiting for Completed phase")
+			Eventually(func(g Gomega) {
+				c, err := utils.GetCluster(ctx, k8sClient, clusterName, pvcNS)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(c.Status.Phase).To(Equal(ackov1alpha1.AerospikePhaseCompleted))
+			}, multiNodeTimeout, 2*time.Second).Should(Succeed())
+
+			By("verifying PVCs are created for each pod")
+			Eventually(func(g Gomega) {
+				pvcList, err := utils.ListClusterPVCs(ctx, k8sClient, clusterName, pvcNS)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(len(pvcList.Items)).To(BeNumerically(">=", 2),
+					"should have at least 2 PVCs for 2 pods")
+			}, defaultTimeout, 2*time.Second).Should(Succeed())
+
+			By("verifying 2 pods are running and ready")
+			Eventually(func(g Gomega) {
+				count, err := utils.CountReadyPods(ctx, k8sClient, clusterName, pvcNS)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(count).To(Equal(2))
+			}, multiNodeTimeout, 2*time.Second).Should(Succeed())
+		})
+
+		It("should report correct status with storage", func() {
+			cluster, err := utils.GetCluster(ctx, k8sClient, clusterName, pvcNS)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cluster.Status.Size).To(Equal(int32(2)))
+			Expect(cluster.Status.Pods).To(HaveLen(2))
+
+			for _, ps := range cluster.Status.Pods {
+				Expect(ps.IsRunningAndReady).To(BeTrue())
+			}
+		})
+	})
+
+	Context("CascadeDelete PVC cleanup", func() {
+		const clusterName = "e2e-pvc-cascade"
+
+		It("should clean up cascade-delete PVCs on cluster deletion", func() {
+			By("creating a 1-node cluster with cascadeDelete=true")
+			cluster := newTestCluster(clusterName, pvcNS, 1, func(c *ackov1alpha1.AerospikeCluster) {
+				c.Spec.Storage = &ackov1alpha1.AerospikeStorageSpec{
+					Volumes: []ackov1alpha1.VolumeSpec{
+						{
+							Name: "data-vol",
+							Source: ackov1alpha1.VolumeSource{
+								PersistentVolume: &ackov1alpha1.PersistentVolumeSpec{
+									StorageClass: "standard",
+									Size:         "1Gi",
+								},
+							},
+							Aerospike: &ackov1alpha1.AerospikeVolumeAttachment{
+								Path: "/opt/aerospike/data",
+							},
+							CascadeDelete: boolPtr(true),
+						},
+					},
+				}
+			})
+			Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
+
+			By("waiting for Completed phase")
+			Eventually(func(g Gomega) {
+				c, err := utils.GetCluster(ctx, k8sClient, clusterName, pvcNS)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(c.Status.Phase).To(Equal(ackov1alpha1.AerospikePhaseCompleted))
+			}, defaultTimeout, 2*time.Second).Should(Succeed())
+
+			By("verifying PVCs exist before deletion")
+			Eventually(func(g Gomega) {
+				pvcList, err := utils.ListClusterPVCs(ctx, k8sClient, clusterName, pvcNS)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(len(pvcList.Items)).To(BeNumerically(">=", 1),
+					"should have at least 1 PVC")
+			}, defaultTimeout, 2*time.Second).Should(Succeed())
+
+			By("deleting the cluster")
+			Expect(utils.DeleteCluster(ctx, k8sClient, clusterName, pvcNS)).To(Succeed())
+
+			By("waiting for PVCs to be cleaned up (cascadeDelete=true)")
+			Eventually(func(g Gomega) {
+				pvcList, err := utils.ListClusterPVCs(ctx, k8sClient, clusterName, pvcNS)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(pvcList.Items).To(BeEmpty(),
+					"PVCs should be deleted with cascadeDelete=true")
+			}, defaultTimeout, 2*time.Second).Should(Succeed())
+		})
+	})
+
+	Context("Retained PVCs without cascadeDelete", func() {
+		const clusterName = "e2e-pvc-retain"
+
+		It("should retain PVCs when cascadeDelete is false", func() {
+			By("creating a 1-node cluster with cascadeDelete=false")
+			cluster := newTestCluster(clusterName, pvcNS, 1, func(c *ackov1alpha1.AerospikeCluster) {
+				c.Spec.Storage = &ackov1alpha1.AerospikeStorageSpec{
+					Volumes: []ackov1alpha1.VolumeSpec{
+						{
+							Name: "data-vol",
+							Source: ackov1alpha1.VolumeSource{
+								PersistentVolume: &ackov1alpha1.PersistentVolumeSpec{
+									StorageClass: "standard",
+									Size:         "1Gi",
+								},
+							},
+							Aerospike: &ackov1alpha1.AerospikeVolumeAttachment{
+								Path: "/opt/aerospike/data",
+							},
+							CascadeDelete: boolPtr(false),
+						},
+					},
+				}
+			})
+			Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
+
+			By("waiting for Completed phase")
+			Eventually(func(g Gomega) {
+				c, err := utils.GetCluster(ctx, k8sClient, clusterName, pvcNS)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(c.Status.Phase).To(Equal(ackov1alpha1.AerospikePhaseCompleted))
+			}, defaultTimeout, 2*time.Second).Should(Succeed())
+
+			By("verifying PVCs exist")
+			Eventually(func(g Gomega) {
+				pvcList, err := utils.ListClusterPVCs(ctx, k8sClient, clusterName, pvcNS)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(len(pvcList.Items)).To(BeNumerically(">=", 1))
+			}, defaultTimeout, 2*time.Second).Should(Succeed())
+
+			By("deleting the cluster")
+			Expect(utils.DeleteCluster(ctx, k8sClient, clusterName, pvcNS)).To(Succeed())
+
+			By("waiting for the cluster CR to be gone")
+			Eventually(func(g Gomega) {
+				_, err := utils.GetCluster(ctx, k8sClient, clusterName, pvcNS)
+				g.Expect(err).To(HaveOccurred(), "cluster should be deleted")
+			}, defaultTimeout, 2*time.Second).Should(Succeed())
+
+			By("verifying PVCs are retained (cascadeDelete=false)")
+			// Wait a bit and then verify PVCs still exist.
+			Consistently(func(g Gomega) {
+				pvcList, err := utils.ListClusterPVCs(ctx, k8sClient, clusterName, pvcNS)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(len(pvcList.Items)).To(BeNumerically(">=", 1),
+					"PVCs should be retained when cascadeDelete=false")
+			}, 15*time.Second, 3*time.Second).Should(Succeed())
+
+			By("cleaning up retained PVCs manually")
+			cmd := exec.Command("kubectl", "delete", "pvc", "-l",
+				"acko.io/cluster="+clusterName, "-n", pvcNS, "--ignore-not-found")
+			_, _ = utils.Run(cmd)
+		})
+	})
+})

--- a/test/e2e/e2e_template_test.go
+++ b/test/e2e/e2e_template_test.go
@@ -1,0 +1,210 @@
+//go:build e2e
+
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"os/exec"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	"github.com/ksr/aerospike-ce-kubernetes-operator/test/utils"
+)
+
+const templateNS = "aerospike-template"
+
+var _ = Describe("Cluster templates", Ordered, Label("heavy"), func() {
+
+	BeforeAll(func() {
+		By("creating template test namespace")
+		Expect(utils.EnsureNamespace(ctx, k8sClient, templateNS)).To(Succeed())
+	})
+
+	AfterAll(func() {
+		By("cleaning up all template test clusters")
+		for _, name := range []string{"e2e-tpl-basic", "e2e-tpl-drift"} {
+			cmd := exec.Command("kubectl", "delete", "aerospikecluster", name,
+				"-n", templateNS, "--ignore-not-found", "--timeout=120s")
+			_, _ = utils.Run(cmd)
+		}
+		By("cleaning up templates")
+		for _, name := range []string{"e2e-template", "e2e-template-drift"} {
+			cmd := exec.Command("kubectl", "delete", "aerospikeclustertemplate", name,
+				"-n", templateNS, "--ignore-not-found", "--timeout=60s")
+			_, _ = utils.Run(cmd)
+		}
+		By("deleting template test namespace")
+		_ = utils.DeleteNamespace(ctx, k8sClient, templateNS)
+	})
+
+	Context("Create cluster from template", func() {
+		const (
+			templateName = "e2e-template"
+			clusterName  = "e2e-tpl-basic"
+		)
+
+		It("should create a cluster from a template", func() {
+			By("creating the template")
+			protoFdMax := float64(8000)
+			template := &ackov1alpha1.AerospikeClusterTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      templateName,
+					Namespace: templateNS,
+				},
+				Spec: ackov1alpha1.AerospikeClusterTemplateSpec{
+					Image: "aerospike:ce-8.1.1.1",
+					AerospikeConfig: &ackov1alpha1.TemplateAerospikeConfig{
+						Service: &ackov1alpha1.AerospikeConfigSpec{
+							Value: map[string]any{
+								"proto-fd-max": protoFdMax,
+							},
+						},
+						NamespaceDefaults: &ackov1alpha1.AerospikeConfigSpec{
+							Value: map[string]any{
+								"replication-factor": float64(1),
+							},
+						},
+					},
+				},
+			}
+			Eventually(func() error {
+				return k8sClient.Create(ctx, template)
+			}, 30*time.Second, 2*time.Second).Should(Succeed())
+
+			By("creating a cluster that references the template")
+			cluster := newTestCluster(clusterName, templateNS, 1, func(c *ackov1alpha1.AerospikeCluster) {
+				c.Spec.TemplateRef = &ackov1alpha1.TemplateRef{
+					Name:      templateName,
+					Namespace: templateNS,
+				}
+			})
+			Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
+
+			By("waiting for Completed phase")
+			Eventually(func(g Gomega) {
+				c, err := utils.GetCluster(ctx, k8sClient, clusterName, templateNS)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(c.Status.Phase).To(Equal(ackov1alpha1.AerospikePhaseCompleted))
+			}, defaultTimeout, 2*time.Second).Should(Succeed())
+
+			By("verifying the cluster has a template snapshot in status")
+			Eventually(func(g Gomega) {
+				c, err := utils.GetCluster(ctx, k8sClient, clusterName, templateNS)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(c.Status.TemplateSnapshot).NotTo(BeNil(),
+					"templateSnapshot should be populated")
+				g.Expect(c.Status.TemplateSnapshot.Name).To(Equal(templateName))
+				g.Expect(c.Status.TemplateSnapshot.Synced).To(BeTrue(),
+					"template snapshot should be synced initially")
+			}, defaultTimeout, 2*time.Second).Should(Succeed())
+
+			By("verifying 1 pod is running and ready")
+			Eventually(func(g Gomega) {
+				count, err := utils.CountReadyPods(ctx, k8sClient, clusterName, templateNS)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(count).To(Equal(1))
+			}, defaultTimeout, 2*time.Second).Should(Succeed())
+		})
+	})
+
+	Context("Template drift detection", func() {
+		const (
+			templateName = "e2e-template-drift"
+			clusterName  = "e2e-tpl-drift"
+		)
+
+		It("should detect template drift after template modification", func() {
+			By("creating the template")
+			template := &ackov1alpha1.AerospikeClusterTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      templateName,
+					Namespace: templateNS,
+				},
+				Spec: ackov1alpha1.AerospikeClusterTemplateSpec{
+					Image: "aerospike:ce-8.1.1.1",
+					AerospikeConfig: &ackov1alpha1.TemplateAerospikeConfig{
+						Service: &ackov1alpha1.AerospikeConfigSpec{
+							Value: map[string]any{
+								"proto-fd-max": float64(10000),
+							},
+						},
+						NamespaceDefaults: &ackov1alpha1.AerospikeConfigSpec{
+							Value: map[string]any{
+								"replication-factor": float64(1),
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, template)).To(Succeed())
+
+			By("creating a cluster with templateRef")
+			cluster := newTestCluster(clusterName, templateNS, 1, func(c *ackov1alpha1.AerospikeCluster) {
+				c.Spec.TemplateRef = &ackov1alpha1.TemplateRef{
+					Name:      templateName,
+					Namespace: templateNS,
+				}
+			})
+			Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
+
+			By("waiting for Completed phase")
+			Eventually(func(g Gomega) {
+				c, err := utils.GetCluster(ctx, k8sClient, clusterName, templateNS)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(c.Status.Phase).To(Equal(ackov1alpha1.AerospikePhaseCompleted))
+			}, defaultTimeout, 2*time.Second).Should(Succeed())
+
+			By("verifying snapshot is initially synced")
+			Eventually(func(g Gomega) {
+				c, err := utils.GetCluster(ctx, k8sClient, clusterName, templateNS)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(c.Status.TemplateSnapshot).NotTo(BeNil())
+				g.Expect(c.Status.TemplateSnapshot.Synced).To(BeTrue())
+			}, defaultTimeout, 2*time.Second).Should(Succeed())
+
+			By("recording the template snapshot resourceVersion")
+			c, err := utils.GetCluster(ctx, k8sClient, clusterName, templateNS)
+			Expect(err).NotTo(HaveOccurred())
+			oldResourceVersion := c.Status.TemplateSnapshot.ResourceVersion
+
+			By("modifying the template to trigger drift")
+			Expect(utils.PatchTemplate(ctx, k8sClient, templateName, templateNS,
+				[]byte(`{"spec":{"aerospikeConfig":{"service":{"proto-fd-max":12000}}}}`))).To(Succeed())
+
+			By("waiting for cluster status to show synced=false (drift detected)")
+			Eventually(func(g Gomega) {
+				c, err := utils.GetCluster(ctx, k8sClient, clusterName, templateNS)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(c.Status.TemplateSnapshot).NotTo(BeNil())
+				g.Expect(c.Status.TemplateSnapshot.Synced).To(BeFalse(),
+					"template snapshot should be out of sync after template change")
+			}, defaultTimeout, 2*time.Second).Should(Succeed())
+
+			By("verifying the snapshot still references the old resourceVersion")
+			c, err = utils.GetCluster(ctx, k8sClient, clusterName, templateNS)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(c.Status.TemplateSnapshot.ResourceVersion).To(Equal(oldResourceVersion),
+				"snapshot resourceVersion should not change until resync")
+		})
+	})
+})

--- a/test/utils/k8s_client_helpers.go
+++ b/test/utils/k8s_client_helpers.go
@@ -180,3 +180,20 @@ func ConfigMapExists(ctx context.Context, c client.Client, name, ns string) (boo
 func PDBExists(ctx context.Context, c client.Client, name, ns string) (bool, error) {
 	return resourceExists(ctx, c, &policyv1.PodDisruptionBudget{}, name, ns)
 }
+
+// --- AerospikeClusterTemplate helpers ---
+
+// GetTemplate retrieves an AerospikeClusterTemplate by name and namespace.
+func GetTemplate(ctx context.Context, c client.Client, name, ns string) (*ackov1alpha1.AerospikeClusterTemplate, error) {
+	template := &ackov1alpha1.AerospikeClusterTemplate{}
+	err := c.Get(ctx, types.NamespacedName{Name: name, Namespace: ns}, template)
+	return template, err
+}
+
+// PatchTemplate applies a JSON merge patch to an AerospikeClusterTemplate.
+func PatchTemplate(ctx context.Context, c client.Client, name, ns string, patch []byte) error {
+	template := &ackov1alpha1.AerospikeClusterTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+	}
+	return c.Patch(ctx, template, client.RawPatch(types.MergePatchType, patch))
+}


### PR DESCRIPTION
## Summary

- **Client retry wrapper**: `getAerospikeClientWithRetry()` with 3 retries and exponential backoff (2s/4s/8s) for DNS resolution delays during initial deployment
- **ACL sync retry**: Single-retry for transient connection errors (reset, timeout, refused) during rolling restarts
- **Dynamic config pre-flight**: `validateDynamicChanges()` validates all changes before applying any, preventing partial config state
- **Custom error types**: `ValidationError` and `TransientError` in `internal/errors/` — circuit breaker skips counter increment for permanent validation errors
- **Structured logging**: `WithValues()` sub-loggers for rack/pod/statefulset context; `V(1)` debug logging at reconciler entry points
- **Circuit breaker alert**: `AerospikeOperatorCircuitBreakerActive` PrometheusRule (severity: critical, for: 5m)
- **E2E test expansion**: Multi-rack scaling, template drift detection, PVC cascade delete scenarios
- **Makefile Podman alignment**: `KIND_PROVIDER` defaults to `podman`; `container-build`/`container-push` aliases

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` — all 14 packages pass (including new `internal/errors`)
- [x] `make lint` — 0 issues
- [ ] `make test-e2e` — new E2E tests on Kind cluster (requires manual verification)