### PR TITLE
docs: add template management, operations guide, and local storage docs

### DIFF
--- a/docs/content/guide/operations.md
+++ b/docs/content/guide/operations.md
@@ -1,0 +1,321 @@
+---
+sidebar_position: 9
+title: Operations
+---
+
+# Operations
+
+The operator supports on-demand operations that let you trigger pod restarts declaratively through the `spec.operations` field. This guide covers the available operation types, how to trigger and track them, and best practices for production use.
+
+---
+
+## Overview
+
+On-demand operations provide a controlled way to restart Aerospike pods without manually deleting them. Instead of using `kubectl delete pod`, you declare the desired operation in the cluster spec, and the operator executes it with proper sequencing, status tracking, and event emission.
+
+**Key constraints:**
+
+- Only **one operation** can be active at a time
+- The operation `id` must be unique and between 1--20 characters
+- Operations cannot be modified while `InProgress`
+- Remove the operation from the spec after it completes
+
+---
+
+## Operation Types
+
+### WarmRestart
+
+A warm restart sends `SIGUSR1` to the Aerospike process, causing it to reload configuration without pod deletion. The pod stays running throughout the process.
+
+```yaml
+spec:
+  operations:
+    - kind: WarmRestart
+      id: "config-reload-v2"
+```
+
+**When to use:**
+
+- After dynamic configuration changes that require a process signal
+- When you want to minimize downtime (no pod deletion/recreation)
+- For configuration reloads that Aerospike supports via SIGUSR1
+
+:::tip
+WarmRestart is the least disruptive operation. The Aerospike process restarts in-place, preserving the pod's network identity and storage mounts.
+:::
+
+### PodRestart
+
+A pod restart (cold restart) deletes and recreates the targeted pods. This is equivalent to a full restart cycle including volume reattachment.
+
+```yaml
+spec:
+  operations:
+    - kind: PodRestart
+      id: "cold-restart-01"
+```
+
+**When to use:**
+
+- When a warm restart is insufficient (e.g., the pod is in a bad state)
+- To force volume re-initialization
+- When the Aerospike process is unresponsive to SIGUSR1
+- After node maintenance that requires fresh pod scheduling
+
+---
+
+## Targeting Specific Pods
+
+By default, an operation targets **all pods** in the cluster. Use `podList` to target specific pods:
+
+### All Pods (default)
+
+```yaml
+spec:
+  operations:
+    - kind: WarmRestart
+      id: "reload-all"
+      # podList omitted = all pods
+```
+
+### Specific Pods
+
+```yaml
+spec:
+  operations:
+    - kind: PodRestart
+      id: "restart-pod-2"
+      podList:
+        - aerospike-ce-3node-0
+        - aerospike-ce-3node-2
+```
+
+:::warning
+When targeting specific pods, ensure you use the correct pod names. Pod names follow the pattern `<cluster-name>-<rack-id>-<ordinal>` for multi-rack deployments, or `<cluster-name>-<ordinal>` for single-rack clusters.
+:::
+
+---
+
+## Triggering an Operation
+
+### Step 1: Add the operation to the cluster spec
+
+```bash
+kubectl -n aerospike patch asc aerospike-ce-3node --type merge -p '{
+  "spec": {
+    "operations": [
+      {
+        "kind": "WarmRestart",
+        "id": "config-reload-v2"
+      }
+    ]
+  }
+}'
+```
+
+### Step 2: Monitor progress
+
+```bash
+# Check operation status
+kubectl -n aerospike get asc aerospike-ce-3node \
+  -o jsonpath='{.status.operationStatus}' | jq .
+
+# Watch events
+kubectl -n aerospike get events \
+  --field-selector involvedObject.name=aerospike-ce-3node,reason=Operation -w
+```
+
+### Step 3: Remove the operation after completion
+
+Once the operation reaches `Completed` or `Error` phase, remove it from the spec:
+
+```bash
+kubectl -n aerospike patch asc aerospike-ce-3node --type merge -p '{
+  "spec": {
+    "operations": null
+  }
+}'
+```
+
+---
+
+## Operation Status Tracking
+
+The operator tracks operation progress in `status.operationStatus`:
+
+```bash
+kubectl -n aerospike get asc aerospike-ce-3node \
+  -o jsonpath='{.status.operationStatus}' | jq .
+```
+
+### Status Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Operation identifier (matches `spec.operations[].id`) |
+| `kind` | string | Operation type: `WarmRestart` or `PodRestart` |
+| `phase` | string | Current phase: `InProgress`, `Completed`, or `Error` |
+| `completedPods` | []string | Pods that have completed the operation |
+| `failedPods` | []string | Pods where the operation failed |
+
+### Phase Transitions
+
+```
+                    ┌──────────────┐
+                    │  InProgress  │
+                    └──────┬───────┘
+                           │
+              ┌────────────┴────────────┐
+              ▼                         ▼
+     ┌────────────────┐       ┌─────────────┐
+     │   Completed    │       │    Error     │
+     └────────────────┘       └─────────────┘
+```
+
+| Phase | Meaning |
+|-------|---------|
+| `InProgress` | The operator is executing the operation on targeted pods |
+| `Completed` | All targeted pods have been successfully restarted |
+| `Error` | One or more pods failed. Check `failedPods` for details |
+
+### Example Status Output
+
+```json
+{
+  "id": "config-reload-v2",
+  "kind": "WarmRestart",
+  "phase": "InProgress",
+  "completedPods": [
+    "aerospike-ce-3node-0",
+    "aerospike-ce-3node-1"
+  ],
+  "failedPods": []
+}
+```
+
+---
+
+## Pod Status After Operations
+
+After an operation completes, individual pod status reflects the restart:
+
+```bash
+kubectl -n aerospike get asc aerospike-ce-3node \
+  -o jsonpath='{.status.pods}' | jq 'to_entries[] | {pod: .key, lastRestart: .value.lastRestartReason, time: .value.lastRestartTime}'
+```
+
+The `lastRestartReason` field records why the pod was last restarted:
+
+| Value | Description |
+|-------|-------------|
+| `WarmRestart` | On-demand warm restart (SIGUSR1) |
+| `ManualRestart` | On-demand cold restart (PodRestart) |
+| `ConfigChanged` | Cold restart due to config change |
+| `ImageChanged` | Cold restart due to image update |
+| `PodSpecChanged` | Cold restart due to pod spec change |
+
+---
+
+## WarmRestart vs PodRestart
+
+| Aspect | WarmRestart | PodRestart |
+|--------|-------------|------------|
+| **Mechanism** | SIGUSR1 signal to Aerospike process | Pod delete and recreate |
+| **Downtime** | Minimal (process restarts in-place) | Full pod lifecycle (terminate, schedule, start) |
+| **Storage** | Volumes remain mounted | Volumes are detached and reattached |
+| **Network** | Pod IP preserved | Pod may get a new IP |
+| **Use case** | Config reload, graceful restart | Stuck pods, volume reset, node migration |
+| **Risk** | Low -- process restarts cleanly | Medium -- pod rescheduling, possible migration |
+
+:::info
+The cluster's `rollingUpdateBatchSize` does **not** apply to on-demand operations. Operations execute on all targeted pods according to the operator's internal sequencing.
+:::
+
+---
+
+## Validation Rules
+
+The webhook enforces these constraints on operations:
+
+| Rule | Constraint | Error Message |
+|------|-----------|---------------|
+| Max operations | Only 1 operation at a time | `only one operation allowed` |
+| ID length | 1--20 characters | `id must be between 1 and 20 characters` |
+| In-progress lock | Cannot modify while `InProgress` | `cannot modify operations while InProgress` |
+
+---
+
+## Events
+
+The operator emits events for operation lifecycle:
+
+| Reason | Type | Description |
+|--------|------|-------------|
+| `Operation` | Normal | Operation started, pod restarted, or operation completed |
+| `PodWarmRestarted` | Normal | Pod received SIGUSR1 |
+| `PodColdRestarted` | Normal | Pod deleted and recreated |
+
+```bash
+kubectl -n aerospike get events \
+  --field-selector involvedObject.name=aerospike-ce-3node,reason=Operation
+```
+
+---
+
+## Examples
+
+### Reload Configuration Across All Pods
+
+```yaml
+apiVersion: acko.io/v1alpha1
+kind: AerospikeCluster
+metadata:
+  name: aerospike-ce-3node
+  namespace: aerospike
+spec:
+  size: 3
+  image: aerospike:ce-8.1.1.1
+  operations:
+    - kind: WarmRestart
+      id: "reload-config-mar10"
+  aerospikeConfig:
+    namespaces:
+      - name: test
+        replication-factor: 2
+        storage-engine:
+          type: memory
+```
+
+### Cold Restart a Single Pod
+
+```yaml
+spec:
+  operations:
+    - kind: PodRestart
+      id: "fix-pod-2"
+      podList:
+        - aerospike-ce-3node-2
+```
+
+### Warm Restart a Subset of Pods
+
+```yaml
+spec:
+  operations:
+    - kind: WarmRestart
+      id: "reload-rack-1"
+      podList:
+        - aerospike-ce-3node-0
+        - aerospike-ce-3node-1
+```
+
+---
+
+## Best Practices
+
+1. **Use descriptive operation IDs** -- include a date or version reference (e.g., `config-reload-mar10`, `fix-pod-2-v3`) to make status tracking and event correlation easier.
+2. **Prefer WarmRestart** when possible -- it minimizes disruption and avoids pod rescheduling.
+3. **Remove completed operations** -- leaving stale operations in the spec does not cause problems, but keeping the spec clean avoids confusion.
+4. **Check operation status before adding a new one** -- the webhook rejects a second operation while one is `InProgress`.
+5. **Use `podList` for targeted restarts** -- avoid restarting the entire cluster when only one pod needs attention.

--- a/docs/content/guide/storage.md
+++ b/docs/content/guide/storage.md
@@ -42,6 +42,8 @@ storage:
   cleanupThreads: 2
 ```
 
+See [Local Storage](#local-storage) below for a detailed explanation.
+
 ---
 
 ## Volume Types
@@ -300,3 +302,133 @@ Apply it with:
 ```bash
 kubectl apply -f config/samples/aerospike-cluster-storage-advanced.yaml
 ```
+
+---
+
+## Local Storage
+
+Local persistent volumes (local PVs) are node-bound storage that provide high I/O performance but do not survive pod migration to a different node. The operator provides two fields to handle local storage correctly: `localStorageClasses` and `deleteLocalStorageOnRestart`.
+
+### When to Use Local Storage
+
+- **High-performance workloads** -- local NVMe or SSD storage provides the lowest latency
+- **Bare-metal clusters** -- nodes with directly attached storage
+- **Cost optimization** -- avoid network-attached storage overhead when data is replicated at the Aerospike level
+
+:::warning
+Local PVs are tied to a specific node. If a pod is rescheduled to a different node, it cannot reattach the old PV. The operator handles this automatically when `deleteLocalStorageOnRestart` is enabled.
+:::
+
+### Configuration
+
+#### `localStorageClasses`
+
+A list of StorageClass names that the operator should treat as local storage. Any PVC backed by one of these classes receives special handling during pod restarts.
+
+Common local StorageClass examples:
+- `local-path` (Rancher Local Path Provisioner)
+- `openebs-hostpath` (OpenEBS)
+- `local-storage` (Kubernetes `local` volume plugin)
+
+#### `deleteLocalStorageOnRestart`
+
+When set to `true`, the operator deletes PVCs backed by local storage classes **before** deleting the pod during a cold restart. This forces the PVC to be re-provisioned on whichever node the pod is rescheduled to.
+
+Without this setting, the pod would be stuck in `Pending` state if rescheduled to a different node, because the local PV is only available on the original node.
+
+### Example Configuration
+
+```yaml
+apiVersion: acko.io/v1alpha1
+kind: AerospikeCluster
+metadata:
+  name: aerospike-local-storage
+  namespace: aerospike
+spec:
+  size: 3
+  image: aerospike:ce-8.1.1.1
+
+  storage:
+    localStorageClasses:
+      - local-path
+      - openebs-hostpath
+    deleteLocalStorageOnRestart: true
+
+    filesystemVolumePolicy:
+      initMethod: deleteFiles
+      cascadeDelete: true
+
+    volumes:
+      - name: data-vol
+        source:
+          persistentVolume:
+            storageClass: local-path
+            size: 50Gi
+        aerospike:
+          path: /opt/aerospike/data
+
+  aerospikeConfig:
+    namespaces:
+      - name: data
+        replication-factor: 2
+        storage-engine:
+          type: device
+          file: /opt/aerospike/data/data.dat
+          filesize: 42949672960
+```
+
+### How It Works
+
+During a cold restart (image change, config change, or PodRestart operation):
+
+1. The operator identifies PVCs backed by storage classes listed in `localStorageClasses`
+2. If `deleteLocalStorageOnRestart` is `true`, those PVCs are deleted **before** the pod
+3. The pod is deleted
+4. Kubernetes schedules the pod (possibly on a different node)
+5. The StorageClass provisioner creates a new local PV on the target node
+6. The pod starts with a fresh volume
+
+:::info
+If local PVC deletion fails, the operator emits a `LocalPVCDeleteFailed` warning event and proceeds with the pod restart. The PVC will be cleaned up on the next reconciliation.
+:::
+
+### Local Storage with Rack Configuration
+
+When using local storage with rack-aware deployments, combine `localStorageClasses` with `rackLabel` scheduling to ensure pods are placed on nodes with local storage available:
+
+```yaml
+spec:
+  storage:
+    localStorageClasses:
+      - local-path
+    deleteLocalStorageOnRestart: true
+    volumes:
+      - name: data-vol
+        source:
+          persistentVolume:
+            storageClass: local-path
+            size: 50Gi
+        aerospike:
+          path: /opt/aerospike/data
+
+  rackConfig:
+    racks:
+      - id: 1
+        rackLabel: zone-a    # Nodes with acko.io/rack=zone-a and local storage
+      - id: 2
+        rackLabel: zone-b
+```
+
+### Local Storage vs Network-Attached Storage
+
+| Aspect | Local Storage | Network-Attached (EBS, PD, etc.) |
+|--------|--------------|----------------------------------|
+| **Latency** | Lowest (direct-attached) | Higher (network round-trip) |
+| **Pod migration** | PVC must be deleted and re-provisioned | PVC reattaches automatically |
+| **Data durability** | Node-level only | Independent of node lifecycle |
+| **Cost** | Lower (no network storage fees) | Higher (provisioned IOPS, throughput) |
+| **Best for** | High-throughput, Aerospike-replicated data | Single-replica or stateful workloads |
+
+:::tip
+When using local storage, always set `replication-factor: 2` or higher in Aerospike to ensure data survives node failures. The data on a lost local PV is recovered from replicas on other nodes.
+:::

--- a/docs/content/guide/templates.md
+++ b/docs/content/guide/templates.md
@@ -1,0 +1,443 @@
+---
+sidebar_position: 8
+title: Template Management
+---
+
+# Template Management
+
+The `AerospikeClusterTemplate` CRD enables reusable, organization-wide configuration profiles for Aerospike clusters. This guide covers the full template lifecycle: creation, usage, overrides, sync behavior, and best practices.
+
+For the CRD field reference, see [AerospikeClusterTemplate API Reference](../api-reference/aerospikeclustertemplate.md).
+
+---
+
+## How Templates Work
+
+Templates follow a **snapshot model**:
+
+1. You create an `AerospikeClusterTemplate` with shared defaults (image, size, resources, scheduling, storage, monitoring, network policy, Aerospike config).
+2. An `AerospikeCluster` references the template via `spec.templateRef.name`.
+3. At cluster creation, the operator resolves the template and stores the full spec in `status.templateSnapshot`.
+4. The cluster operates independently from that point. Template changes are **not** automatically propagated.
+
+```
+┌─────────────────────┐       templateRef        ┌─────────────────────┐
+│  AerospikeCluster   │ ─────────────────────►   │ AerospikeCluster    │
+│  (spec.templateRef) │                          │ Template            │
+└─────────────────────┘                          └─────────────────────┘
+         │                                                │
+         ▼                                                │
+  status.templateSnapshot                                 │
+  (frozen copy of template spec)                          │
+         │                                                │
+         │   acko.io/resync-template=true                 │
+         └────────────────────────────────────────────────┘
+                     (manual resync)
+```
+
+:::info
+`AerospikeClusterTemplate` is a **cluster-scoped** resource. It does not belong to any namespace. Reference it by name only.
+:::
+
+---
+
+## Creating Templates
+
+### Minimal Template (Development)
+
+A lightweight template for development and quick prototyping:
+
+```yaml
+apiVersion: acko.io/v1alpha1
+kind: AerospikeClusterTemplate
+metadata:
+  name: minimal
+spec:
+  description: "Development template - single node, minimal resources"
+  image: aerospike:ce-8.1.1.1
+  size: 1
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 100m
+      memory: 256Mi
+
+  scheduling:
+    podAntiAffinityLevel: none
+
+  storage:
+    storageClassName: standard
+    resources:
+      requests:
+        storage: 1Gi
+
+  aerospikeConfig:
+    namespaceDefaults:
+      replication-factor: 1
+      data-size: 1073741824   # 1 GiB
+```
+
+### Soft-Rack Template (Staging)
+
+Provides rack awareness with soft anti-affinity, suitable for staging environments:
+
+```yaml
+apiVersion: acko.io/v1alpha1
+kind: AerospikeClusterTemplate
+metadata:
+  name: soft-rack
+spec:
+  description: "Staging template - soft anti-affinity, 3 nodes"
+  image: aerospike:ce-8.1.1.1
+  size: 3
+
+  resources:
+    requests:
+      cpu: 500m
+      memory: 1Gi
+    limits:
+      cpu: 500m
+      memory: 1Gi
+
+  scheduling:
+    podAntiAffinityLevel: preferred
+
+  storage:
+    storageClassName: standard
+    resources:
+      requests:
+        storage: 10Gi
+
+  aerospikeConfig:
+    namespaceDefaults:
+      replication-factor: 2
+      data-size: 2147483648   # 2 GiB
+```
+
+### Hard-Rack Template (Production)
+
+Enforces strict anti-affinity (one pod per node), local storage, and monitoring:
+
+```yaml
+apiVersion: acko.io/v1alpha1
+kind: AerospikeClusterTemplate
+metadata:
+  name: hard-rack
+spec:
+  description: "Production template - hard anti-affinity, local PVs, monitoring"
+  image: aerospike:ce-8.1.1.1
+  size: 6
+
+  monitoring:
+    enabled: true
+    port: 9145
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        cpu: 200m
+        memory: 128Mi
+    serviceMonitor:
+      enabled: true
+      interval: 30s
+
+  aerospikeNetworkPolicy:
+    accessType: pod
+    alternateAccessType: pod
+    fabricType: pod
+
+  scheduling:
+    podAntiAffinityLevel: required
+    tolerations:
+      - key: "aerospike"
+        operator: "Exists"
+        effect: "NoSchedule"
+
+  storage:
+    storageClassName: local-path
+    localPVRequired: true
+    resources:
+      requests:
+        storage: 100Gi
+
+  resources:
+    requests:
+      cpu: "2"
+      memory: "4Gi"
+    limits:
+      cpu: "2"
+      memory: "4Gi"
+
+  aerospikeConfig:
+    service:
+      proto-fd-max: 15000
+    namespaceDefaults:
+      replication-factor: 2
+      data-size: 2147483648   # 2 GiB
+```
+
+Apply templates:
+
+```bash
+kubectl apply -f config/samples/acko_v1alpha1_template_dev.yaml     # minimal
+kubectl apply -f config/samples/acko_v1alpha1_template_stage.yaml   # soft-rack
+kubectl apply -f config/samples/acko_v1alpha1_template_prod.yaml    # hard-rack
+```
+
+---
+
+## Using Templates in Clusters
+
+### Basic Reference
+
+Reference a template by name. When the template supplies `image` and `size`, the cluster can omit those fields:
+
+```yaml
+apiVersion: acko.io/v1alpha1
+kind: AerospikeCluster
+metadata:
+  name: my-cluster
+spec:
+  templateRef:
+    name: soft-rack
+  aerospikeConfig:
+    namespaces:
+      - name: data
+        storage-engine:
+          type: memory
+```
+
+### Overriding Template Defaults
+
+Set `spec.image` or `spec.size` explicitly on the cluster to override the template value:
+
+```yaml
+spec:
+  image: aerospike:ce-8.1.1.1   # override: pin a specific image
+  size: 3                         # override: use 3 instead of template's default
+  templateRef:
+    name: hard-rack
+```
+
+---
+
+## Template Overrides
+
+Use `spec.overrides` to selectively modify template fields without creating a new template:
+
+```yaml
+spec:
+  templateRef:
+    name: hard-rack
+  overrides:
+    resources:
+      requests:
+        cpu: "4"
+        memory: "8Gi"
+      limits:
+        cpu: "4"
+        memory: "8Gi"
+    scheduling:
+      podAntiAffinityLevel: preferred   # relax anti-affinity for this cluster
+```
+
+### Merge Priority
+
+Fields are resolved in this order (highest priority first):
+
+1. **`spec.overrides`** -- cluster-specific overrides
+2. **`template.spec`** -- template defaults
+3. **Operator defaults** -- built-in fallback values
+
+### Merge Behavior
+
+| Field Type | Behavior | Example |
+|------------|----------|---------|
+| Scalar (string, int, bool) | Override replaces template value | `size: 3` overrides template's `size: 6` |
+| Map (nested object) | Recursive merge -- only specified keys are overridden | `aerospikeConfig.service.proto-fd-max: 20000` overrides just that key |
+| Array (list) | Override replaces entire array | `tolerations: [...]` replaces all template tolerations |
+
+:::tip
+For maps like `aerospikeConfig.service`, you only need to specify the keys you want to change. Unspecified keys inherit from the template.
+:::
+
+---
+
+## Overridable Fields
+
+Templates can supply defaults for these fields:
+
+| Field | Description |
+|-------|-------------|
+| `image` | Aerospike CE container image |
+| `size` | Default cluster size (1--8) |
+| `resources` | CPU/memory requests and limits |
+| `scheduling` | Anti-affinity level, tolerations, node affinity, topology spread |
+| `storage` | Storage class, volume mode, size, local PV flag |
+| `rackConfig` | Rack configuration defaults (maxRacksPerNode) |
+| `aerospikeConfig` | Service and namespace default settings |
+| `monitoring` | Prometheus exporter sidecar configuration |
+| `aerospikeNetworkPolicy` | Client/fabric network access types |
+
+---
+
+## Template Sync Behavior
+
+### Why Templates Are Not Auto-Propagated
+
+Templates use a snapshot model for safety. Automatically propagating template changes to running production clusters could cause unexpected rolling restarts or configuration conflicts. Instead, the operator:
+
+1. Detects template drift and sets `status.templateSnapshot.synced: false`
+2. Emits a `TemplateDrifted` warning event on affected clusters
+3. Waits for explicit resync approval per cluster
+
+### Checking Sync Status
+
+```bash
+kubectl get aerospikecluster hard-rack-cluster \
+  -o jsonpath='{.status.templateSnapshot}'
+```
+
+Example output:
+
+```json
+{
+  "name": "hard-rack",
+  "resourceVersion": "12345",
+  "snapshotTimestamp": "2026-03-01T10:00:00Z",
+  "synced": true
+}
+```
+
+When `synced` is `false`, the cluster is running on an older template version.
+
+### Resyncing a Cluster
+
+To apply the updated template to a specific cluster:
+
+```bash
+kubectl annotate aerospikecluster hard-rack-cluster acko.io/resync-template=true
+```
+
+The operator will:
+
+1. Re-fetch the template
+2. Update `status.templateSnapshot` with the new spec
+3. Emit a `TemplateApplied` event
+4. Remove the annotation
+5. Trigger reconciliation (which may cause a rolling restart if the config changed)
+
+:::warning
+Resync may trigger a rolling restart if the template changes affect the Aerospike configuration, image, or pod spec. Review the template diff before resyncing production clusters.
+:::
+
+---
+
+## Template Lifecycle
+
+### Checking Which Clusters Use a Template
+
+The `status.usedBy` field tracks all clusters referencing the template:
+
+```bash
+kubectl get aerospikeclustertemplate hard-rack -o jsonpath='{.status.usedBy}'
+```
+
+```json
+["hard-rack-cluster", "prod-cluster-east", "prod-cluster-west"]
+```
+
+### Deleting a Template
+
+A template cannot be deleted while `usedBy` is non-empty. Remove all cluster references first, then delete:
+
+```bash
+# Check current references
+kubectl get aerospikeclustertemplate hard-rack -o jsonpath='{.status.usedBy}'
+
+# Remove template reference from a cluster (set image/size explicitly)
+kubectl -n aerospike patch asc hard-rack-cluster --type merge \
+  -p '{"spec":{"image":"aerospike:ce-8.1.1.1","size":3,"templateRef":null}}'
+
+# Delete the template once usedBy is empty
+kubectl delete aerospikeclustertemplate hard-rack
+```
+
+### Updating a Template
+
+Update a template like any Kubernetes resource:
+
+```bash
+kubectl patch aerospikeclustertemplate hard-rack --type merge \
+  -p '{"spec":{"image":"aerospike:ce-8.1.2.0"}}'
+```
+
+After updating, all referencing clusters will show `synced: false` and emit `TemplateDrifted` events. Resync each cluster individually when ready.
+
+---
+
+## Installing Default Templates via Helm
+
+Use the `defaultTemplates.enabled=true` Helm value to create all three template tiers during installation:
+
+```bash
+helm install aerospike-ce-kubernetes-operator \
+  oci://ghcr.io/kimsoungryoul/charts/aerospike-ce-kubernetes-operator \
+  -n aerospike-operator --create-namespace \
+  --set certManagerSubchart.enabled=true \
+  --set defaultTemplates.enabled=true
+```
+
+Verify:
+
+```bash
+kubectl get aerospikeclustertemplate
+# NAME         AGE
+# minimal      10s
+# soft-rack    10s
+# hard-rack    10s
+```
+
+---
+
+## Managing Templates via Cluster Manager UI
+
+When the Cluster Manager UI is enabled (`ui.enabled=true` and `ui.k8s.enabled=true`), templates can be managed from the web interface:
+
+- **Create** -- guided wizard for all template fields
+- **View** -- detail page showing resolved spec and referencing clusters
+- **Edit** -- patch/update templates (requires RBAC `patch` and `update` permissions)
+- **Delete** -- remove unused templates (blocked if any cluster still references it)
+- **Resync** -- trigger template resync from the cluster detail page
+
+See [Cluster Manager UI -- Template Management](cluster-manager-ui.md#template-management) for details.
+
+---
+
+## Best Practices
+
+1. **Name templates by environment tier** -- `minimal`, `soft-rack`, `hard-rack` communicate the intended use clearly.
+2. **Use `description`** -- the `spec.description` field (up to 500 characters) helps teams understand a template's purpose.
+3. **Pin images in production templates** -- avoid `latest` or untagged images. Pin to a specific CE version.
+4. **Set Guaranteed QoS in production** -- set resource requests equal to limits for predictable performance.
+5. **Resync staging before production** -- after updating a template, resync staging clusters first to validate changes.
+6. **Use overrides sparingly** -- if many clusters need the same override, consider creating a new template tier instead.
+
+---
+
+## Template Comparison
+
+| | `minimal` | `soft-rack` | `hard-rack` |
+|---|-----------|-------------|-------------|
+| **Purpose** | Dev / quick-start | Staging | Production |
+| **size** | 1 | 3 | 6 |
+| **anti-affinity** | none | preferred | required |
+| **storage** | standard 1 Gi | standard 10 Gi | local-path 100 Gi |
+| **rack guarantee** | none | soft (same node OK) | hard (1 node : 1 rack) |
+| **resources** | 100 m / 256 Mi | 500 m / 1 Gi | 2 / 4 Gi (Guaranteed QoS) |
+| **monitoring** | disabled | disabled | enabled |
+| **RF** | 1 | 2 | 2 |

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/guide/operations.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/guide/operations.md
@@ -1,0 +1,321 @@
+---
+sidebar_position: 9
+title: 오퍼레이션
+---
+
+# 오퍼레이션
+
+오퍼레이터는 `spec.operations` 필드를 통해 파드 재시작을 선언적으로 트리거할 수 있는 온디맨드 오퍼레이션을 지원합니다. 이 가이드에서는 사용 가능한 오퍼레이션 유형, 트리거 및 추적 방법, 프로덕션 환경에서의 모범 사례를 다룹니다.
+
+---
+
+## 개요
+
+온디맨드 오퍼레이션은 수동으로 파드를 삭제하지 않고도 Aerospike 파드를 제어된 방식으로 재시작하는 방법을 제공합니다. `kubectl delete pod`를 사용하는 대신, 클러스터 스펙에 원하는 오퍼레이션을 선언하면 오퍼레이터가 적절한 순서, 상태 추적, 이벤트 발행과 함께 실행합니다.
+
+**주요 제약사항:**
+
+- 한 번에 **하나의 오퍼레이션**만 활성화할 수 있습니다
+- 오퍼레이션 `id`는 고유해야 하며 1--20자 사이여야 합니다
+- `InProgress` 상태에서는 오퍼레이션을 수정할 수 없습니다
+- 완료 후 스펙에서 오퍼레이션을 제거하세요
+
+---
+
+## 오퍼레이션 유형
+
+### WarmRestart
+
+WarmRestart는 Aerospike 프로세스에 `SIGUSR1` 신호를 보내 파드 삭제 없이 설정을 리로드합니다. 파드는 프로세스 전체에서 계속 실행됩니다.
+
+```yaml
+spec:
+  operations:
+    - kind: WarmRestart
+      id: "config-reload-v2"
+```
+
+**사용 시기:**
+
+- 프로세스 신호가 필요한 동적 설정 변경 후
+- 다운타임을 최소화하고 싶을 때 (파드 삭제/재생성 없음)
+- Aerospike가 SIGUSR1을 통해 지원하는 설정 리로드에 사용
+
+:::tip
+WarmRestart는 가장 덜 파괴적인 오퍼레이션입니다. Aerospike 프로세스가 제자리에서 재시작되어 파드의 네트워크 ID와 스토리지 마운트를 유지합니다.
+:::
+
+### PodRestart
+
+PodRestart(콜드 재시작)는 대상 파드를 삭제하고 재생성합니다. 볼륨 재연결을 포함한 전체 재시작 사이클과 동일합니다.
+
+```yaml
+spec:
+  operations:
+    - kind: PodRestart
+      id: "cold-restart-01"
+```
+
+**사용 시기:**
+
+- WarmRestart로 충분하지 않을 때 (예: 파드가 비정상 상태)
+- 볼륨 재초기화를 강제하고 싶을 때
+- Aerospike 프로세스가 SIGUSR1에 응답하지 않을 때
+- 새로운 파드 스케줄링이 필요한 노드 유지보수 후
+
+---
+
+## 특정 파드 대상 지정
+
+기본적으로 오퍼레이션은 클러스터의 **모든 파드**를 대상으로 합니다. `podList`를 사용하여 특정 파드를 대상으로 지정할 수 있습니다:
+
+### 모든 파드 (기본값)
+
+```yaml
+spec:
+  operations:
+    - kind: WarmRestart
+      id: "reload-all"
+      # podList 생략 = 모든 파드
+```
+
+### 특정 파드
+
+```yaml
+spec:
+  operations:
+    - kind: PodRestart
+      id: "restart-pod-2"
+      podList:
+        - aerospike-ce-3node-0
+        - aerospike-ce-3node-2
+```
+
+:::warning
+특정 파드를 대상으로 지정할 때 올바른 파드 이름을 사용하세요. 파드 이름은 멀티 랙 배포의 경우 `<클러스터명>-<랙ID>-<순서>`, 단일 랙 클러스터의 경우 `<클러스터명>-<순서>` 패턴을 따릅니다.
+:::
+
+---
+
+## 오퍼레이션 트리거
+
+### 1단계: 클러스터 스펙에 오퍼레이션 추가
+
+```bash
+kubectl -n aerospike patch asc aerospike-ce-3node --type merge -p '{
+  "spec": {
+    "operations": [
+      {
+        "kind": "WarmRestart",
+        "id": "config-reload-v2"
+      }
+    ]
+  }
+}'
+```
+
+### 2단계: 진행 상황 모니터링
+
+```bash
+# 오퍼레이션 상태 확인
+kubectl -n aerospike get asc aerospike-ce-3node \
+  -o jsonpath='{.status.operationStatus}' | jq .
+
+# 이벤트 감시
+kubectl -n aerospike get events \
+  --field-selector involvedObject.name=aerospike-ce-3node,reason=Operation -w
+```
+
+### 3단계: 완료 후 오퍼레이션 제거
+
+오퍼레이션이 `Completed` 또는 `Error` 단계에 도달하면 스펙에서 제거하세요:
+
+```bash
+kubectl -n aerospike patch asc aerospike-ce-3node --type merge -p '{
+  "spec": {
+    "operations": null
+  }
+}'
+```
+
+---
+
+## 오퍼레이션 상태 추적
+
+오퍼레이터는 `status.operationStatus`에서 오퍼레이션 진행 상황을 추적합니다:
+
+```bash
+kubectl -n aerospike get asc aerospike-ce-3node \
+  -o jsonpath='{.status.operationStatus}' | jq .
+```
+
+### 상태 필드
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| `id` | string | 오퍼레이션 식별자 (`spec.operations[].id`와 일치) |
+| `kind` | string | 오퍼레이션 유형: `WarmRestart` 또는 `PodRestart` |
+| `phase` | string | 현재 단계: `InProgress`, `Completed` 또는 `Error` |
+| `completedPods` | []string | 오퍼레이션이 완료된 파드 목록 |
+| `failedPods` | []string | 오퍼레이션이 실패한 파드 목록 |
+
+### 단계 전환
+
+```
+                    ┌──────────────┐
+                    │  InProgress  │
+                    └──────┬───────┘
+                           │
+              ┌────────────┴────────────┐
+              ▼                         ▼
+     ┌────────────────┐       ┌─────────────┐
+     │   Completed    │       │    Error     │
+     └────────────────┘       └─────────────┘
+```
+
+| 단계 | 의미 |
+|------|------|
+| `InProgress` | 오퍼레이터가 대상 파드에서 오퍼레이션을 실행 중 |
+| `Completed` | 모든 대상 파드가 성공적으로 재시작됨 |
+| `Error` | 하나 이상의 파드가 실패. 자세한 내용은 `failedPods` 확인 |
+
+### 상태 출력 예시
+
+```json
+{
+  "id": "config-reload-v2",
+  "kind": "WarmRestart",
+  "phase": "InProgress",
+  "completedPods": [
+    "aerospike-ce-3node-0",
+    "aerospike-ce-3node-1"
+  ],
+  "failedPods": []
+}
+```
+
+---
+
+## 오퍼레이션 후 파드 상태
+
+오퍼레이션이 완료된 후 개별 파드 상태에 재시작 정보가 반영됩니다:
+
+```bash
+kubectl -n aerospike get asc aerospike-ce-3node \
+  -o jsonpath='{.status.pods}' | jq 'to_entries[] | {pod: .key, lastRestart: .value.lastRestartReason, time: .value.lastRestartTime}'
+```
+
+`lastRestartReason` 필드는 파드가 마지막으로 재시작된 이유를 기록합니다:
+
+| 값 | 설명 |
+|----|------|
+| `WarmRestart` | 온디맨드 웜 재시작 (SIGUSR1) |
+| `ManualRestart` | 온디맨드 콜드 재시작 (PodRestart) |
+| `ConfigChanged` | 설정 변경으로 인한 콜드 재시작 |
+| `ImageChanged` | 이미지 업데이트로 인한 콜드 재시작 |
+| `PodSpecChanged` | 파드 스펙 변경으로 인한 콜드 재시작 |
+
+---
+
+## WarmRestart vs PodRestart
+
+| 측면 | WarmRestart | PodRestart |
+|------|-------------|------------|
+| **메커니즘** | Aerospike 프로세스에 SIGUSR1 신호 | 파드 삭제 및 재생성 |
+| **다운타임** | 최소 (프로세스 제자리 재시작) | 전체 파드 라이프사이클 (종료, 스케줄링, 시작) |
+| **스토리지** | 볼륨이 마운트된 상태 유지 | 볼륨 분리 후 재연결 |
+| **네트워크** | 파드 IP 유지 | 새로운 IP를 받을 수 있음 |
+| **사용 사례** | 설정 리로드, 정상 재시작 | 멈춘 파드, 볼륨 리셋, 노드 마이그레이션 |
+| **위험도** | 낮음 -- 프로세스가 깨끗하게 재시작 | 중간 -- 파드 재스케줄링, 마이그레이션 가능성 |
+
+:::info
+클러스터의 `rollingUpdateBatchSize`는 온디맨드 오퍼레이션에 적용되지 **않습니다**. 오퍼레이션은 오퍼레이터의 내부 순서에 따라 모든 대상 파드에서 실행됩니다.
+:::
+
+---
+
+## 검증 규칙
+
+웹훅은 오퍼레이션에 대해 다음 제약조건을 적용합니다:
+
+| 규칙 | 제약조건 | 오류 메시지 |
+|------|----------|------------|
+| 최대 오퍼레이션 수 | 한 번에 1개만 | `only one operation allowed` |
+| ID 길이 | 1--20자 | `id must be between 1 and 20 characters` |
+| 진행 중 잠금 | `InProgress` 중 수정 불가 | `cannot modify operations while InProgress` |
+
+---
+
+## 이벤트
+
+오퍼레이터는 오퍼레이션 라이프사이클에 대한 이벤트를 발행합니다:
+
+| Reason | Type | 설명 |
+|--------|------|------|
+| `Operation` | Normal | 오퍼레이션 시작, 파드 재시작 또는 오퍼레이션 완료 |
+| `PodWarmRestarted` | Normal | 파드가 SIGUSR1을 수신 |
+| `PodColdRestarted` | Normal | 파드가 삭제되고 재생성됨 |
+
+```bash
+kubectl -n aerospike get events \
+  --field-selector involvedObject.name=aerospike-ce-3node,reason=Operation
+```
+
+---
+
+## 예시
+
+### 모든 파드에 설정 리로드
+
+```yaml
+apiVersion: acko.io/v1alpha1
+kind: AerospikeCluster
+metadata:
+  name: aerospike-ce-3node
+  namespace: aerospike
+spec:
+  size: 3
+  image: aerospike:ce-8.1.1.1
+  operations:
+    - kind: WarmRestart
+      id: "reload-config-mar10"
+  aerospikeConfig:
+    namespaces:
+      - name: test
+        replication-factor: 2
+        storage-engine:
+          type: memory
+```
+
+### 단일 파드 콜드 재시작
+
+```yaml
+spec:
+  operations:
+    - kind: PodRestart
+      id: "fix-pod-2"
+      podList:
+        - aerospike-ce-3node-2
+```
+
+### 파드 부분 집합 웜 재시작
+
+```yaml
+spec:
+  operations:
+    - kind: WarmRestart
+      id: "reload-rack-1"
+      podList:
+        - aerospike-ce-3node-0
+        - aerospike-ce-3node-1
+```
+
+---
+
+## 모범 사례
+
+1. **설명적인 오퍼레이션 ID 사용** -- 날짜나 버전 참조를 포함하세요 (예: `config-reload-mar10`, `fix-pod-2-v3`). 상태 추적과 이벤트 상관관계 분석이 쉬워집니다.
+2. **가능하면 WarmRestart 선호** -- 파괴를 최소화하고 파드 재스케줄링을 피합니다.
+3. **완료된 오퍼레이션 제거** -- 오래된 오퍼레이션을 스펙에 남겨두어도 문제가 발생하지 않지만, 스펙을 깨끗하게 유지하면 혼동을 피할 수 있습니다.
+4. **새 오퍼레이션 추가 전 상태 확인** -- 웹훅은 `InProgress` 상태에서 두 번째 오퍼레이션을 거부합니다.
+5. **대상 지정된 재시작에 `podList` 사용** -- 하나의 파드에만 주의가 필요할 때 전체 클러스터를 재시작하지 마세요.

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/guide/storage.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/guide/storage.md
@@ -42,6 +42,8 @@ storage:
   cleanupThreads: 2
 ```
 
+자세한 내용은 아래 [로컬 스토리지](#로컬-스토리지) 섹션을 참조하세요.
+
 ---
 
 ## 볼륨 타입
@@ -289,3 +291,133 @@ spec:
 ```bash
 kubectl apply -f config/samples/aerospike-cluster-storage-advanced.yaml
 ```
+
+---
+
+## 로컬 스토리지
+
+로컬 영구 볼륨(로컬 PV)은 노드에 바인딩된 스토리지로 높은 I/O 성능을 제공하지만, 파드가 다른 노드로 마이그레이션되면 생존할 수 없습니다. 오퍼레이터는 로컬 스토리지를 올바르게 처리하기 위해 `localStorageClasses`와 `deleteLocalStorageOnRestart` 두 가지 필드를 제공합니다.
+
+### 로컬 스토리지 사용 시기
+
+- **고성능 워크로드** -- 로컬 NVMe 또는 SSD 스토리지가 가장 낮은 지연 시간을 제공
+- **베어메탈 클러스터** -- 직접 연결된 스토리지가 있는 노드
+- **비용 최적화** -- 데이터가 Aerospike 레벨에서 복제될 때 네트워크 연결 스토리지 오버헤드 회피
+
+:::warning
+로컬 PV는 특정 노드에 종속됩니다. 파드가 다른 노드로 재스케줄링되면 이전 PV를 다시 연결할 수 없습니다. `deleteLocalStorageOnRestart`가 활성화되면 오퍼레이터가 이를 자동으로 처리합니다.
+:::
+
+### 설정
+
+#### `localStorageClasses`
+
+오퍼레이터가 로컬 스토리지로 취급해야 하는 StorageClass 이름 목록입니다. 이러한 클래스로 프로비저닝된 PVC는 파드 재시작 시 특별한 처리를 받습니다.
+
+일반적인 로컬 StorageClass 예시:
+- `local-path` (Rancher Local Path Provisioner)
+- `openebs-hostpath` (OpenEBS)
+- `local-storage` (Kubernetes `local` 볼륨 플러그인)
+
+#### `deleteLocalStorageOnRestart`
+
+`true`로 설정하면, 콜드 재시작 시 파드를 삭제하기 **전에** 로컬 스토리지 클래스로 프로비저닝된 PVC를 삭제합니다. 이렇게 하면 파드가 재스케줄링되는 노드에서 PVC가 다시 프로비저닝됩니다.
+
+이 설정이 없으면, 파드가 다른 노드로 재스케줄링될 경우 로컬 PV가 원래 노드에서만 사용 가능하기 때문에 `Pending` 상태에서 멈출 수 있습니다.
+
+### 설정 예제
+
+```yaml
+apiVersion: acko.io/v1alpha1
+kind: AerospikeCluster
+metadata:
+  name: aerospike-local-storage
+  namespace: aerospike
+spec:
+  size: 3
+  image: aerospike:ce-8.1.1.1
+
+  storage:
+    localStorageClasses:
+      - local-path
+      - openebs-hostpath
+    deleteLocalStorageOnRestart: true
+
+    filesystemVolumePolicy:
+      initMethod: deleteFiles
+      cascadeDelete: true
+
+    volumes:
+      - name: data-vol
+        source:
+          persistentVolume:
+            storageClass: local-path
+            size: 50Gi
+        aerospike:
+          path: /opt/aerospike/data
+
+  aerospikeConfig:
+    namespaces:
+      - name: data
+        replication-factor: 2
+        storage-engine:
+          type: device
+          file: /opt/aerospike/data/data.dat
+          filesize: 42949672960
+```
+
+### 동작 원리
+
+콜드 재시작(이미지 변경, 설정 변경, PodRestart 오퍼레이션) 시:
+
+1. 오퍼레이터가 `localStorageClasses`에 나열된 스토리지 클래스로 프로비저닝된 PVC를 식별합니다
+2. `deleteLocalStorageOnRestart`가 `true`이면 해당 PVC를 파드보다 **먼저** 삭제합니다
+3. 파드가 삭제됩니다
+4. Kubernetes가 파드를 스케줄링합니다 (다른 노드일 수 있음)
+5. StorageClass 프로비저너가 대상 노드에 새 로컬 PV를 생성합니다
+6. 파드가 새 볼륨으로 시작됩니다
+
+:::info
+로컬 PVC 삭제가 실패하면, 오퍼레이터는 `LocalPVCDeleteFailed` 경고 이벤트를 발행하고 파드 재시작을 계속합니다. PVC는 다음 리컨실레이션에서 정리됩니다.
+:::
+
+### 랙 설정과 로컬 스토리지
+
+랙 인식 배포에서 로컬 스토리지를 사용할 때, `localStorageClasses`와 `rackLabel` 스케줄링을 결합하여 로컬 스토리지가 있는 노드에 파드가 배치되도록 합니다:
+
+```yaml
+spec:
+  storage:
+    localStorageClasses:
+      - local-path
+    deleteLocalStorageOnRestart: true
+    volumes:
+      - name: data-vol
+        source:
+          persistentVolume:
+            storageClass: local-path
+            size: 50Gi
+        aerospike:
+          path: /opt/aerospike/data
+
+  rackConfig:
+    racks:
+      - id: 1
+        rackLabel: zone-a    # acko.io/rack=zone-a 레이블이 있고 로컬 스토리지가 있는 노드
+      - id: 2
+        rackLabel: zone-b
+```
+
+### 로컬 스토리지 vs 네트워크 연결 스토리지
+
+| 측면 | 로컬 스토리지 | 네트워크 연결 (EBS, PD 등) |
+|------|-------------|--------------------------|
+| **지연 시간** | 가장 낮음 (직접 연결) | 높음 (네트워크 왕복) |
+| **파드 마이그레이션** | PVC를 삭제하고 재프로비저닝 필요 | PVC가 자동으로 재연결 |
+| **데이터 내구성** | 노드 수준에서만 | 노드 라이프사이클과 독립적 |
+| **비용** | 낮음 (네트워크 스토리지 비용 없음) | 높음 (프로비저닝된 IOPS, 처리량) |
+| **적합한 용도** | 고처리량, Aerospike 복제 데이터 | 단일 복제본 또는 상태 유지 워크로드 |
+
+:::tip
+로컬 스토리지 사용 시 Aerospike에서 항상 `replication-factor: 2` 이상으로 설정하여 노드 장애 시 데이터가 보존되도록 하세요. 손실된 로컬 PV의 데이터는 다른 노드의 복제본에서 복구됩니다.
+:::

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/guide/templates.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/guide/templates.md
@@ -1,0 +1,443 @@
+---
+sidebar_position: 8
+title: 템플릿 관리
+---
+
+# 템플릿 관리
+
+`AerospikeClusterTemplate` CRD를 사용하면 조직 전체에서 재사용 가능한 Aerospike 클러스터 설정 프로필을 정의할 수 있습니다. 이 가이드에서는 템플릿의 전체 라이프사이클(생성, 사용, 오버라이드, 동기화 동작, 모범 사례)을 다룹니다.
+
+CRD 필드 레퍼런스는 [AerospikeClusterTemplate API Reference](../api-reference/aerospikeclustertemplate.md)를 참조하세요.
+
+---
+
+## 템플릿 동작 원리
+
+템플릿은 **스냅샷 모델**을 따릅니다:
+
+1. 공유 기본값(이미지, 크기, 리소스, 스케줄링, 스토리지, 모니터링, 네트워크 정책, Aerospike 설정)을 포함하는 `AerospikeClusterTemplate`을 생성합니다.
+2. `AerospikeCluster`에서 `spec.templateRef.name`으로 템플릿을 참조합니다.
+3. 클러스터 생성 시 오퍼레이터가 템플릿을 해석하고 전체 스펙을 `status.templateSnapshot`에 저장합니다.
+4. 이후 클러스터는 독립적으로 운영됩니다. 템플릿 변경은 **자동으로 전파되지 않습니다**.
+
+```
+┌─────────────────────┐       templateRef        ┌─────────────────────┐
+│  AerospikeCluster   │ ─────────────────────►   │ AerospikeCluster    │
+│  (spec.templateRef) │                          │ Template            │
+└─────────────────────┘                          └─────────────────────┘
+         │                                                │
+         ▼                                                │
+  status.templateSnapshot                                 │
+  (템플릿 스펙의 고정 복사본)                               │
+         │                                                │
+         │   acko.io/resync-template=true                 │
+         └────────────────────────────────────────────────┘
+                     (수동 재동기화)
+```
+
+:::info
+`AerospikeClusterTemplate`은 **클러스터 스코프** 리소스입니다. 네임스페이스에 속하지 않으며, 이름만으로 참조합니다.
+:::
+
+---
+
+## 템플릿 생성
+
+### Minimal 템플릿 (개발용)
+
+개발 및 빠른 프로토타이핑을 위한 경량 템플릿:
+
+```yaml
+apiVersion: acko.io/v1alpha1
+kind: AerospikeClusterTemplate
+metadata:
+  name: minimal
+spec:
+  description: "개발용 템플릿 - 단일 노드, 최소 리소스"
+  image: aerospike:ce-8.1.1.1
+  size: 1
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 100m
+      memory: 256Mi
+
+  scheduling:
+    podAntiAffinityLevel: none
+
+  storage:
+    storageClassName: standard
+    resources:
+      requests:
+        storage: 1Gi
+
+  aerospikeConfig:
+    namespaceDefaults:
+      replication-factor: 1
+      data-size: 1073741824   # 1 GiB
+```
+
+### Soft-Rack 템플릿 (스테이징용)
+
+소프트 anti-affinity를 사용한 랙 인식 구성으로, 스테이징 환경에 적합합니다:
+
+```yaml
+apiVersion: acko.io/v1alpha1
+kind: AerospikeClusterTemplate
+metadata:
+  name: soft-rack
+spec:
+  description: "스테이징 템플릿 - 소프트 anti-affinity, 3노드"
+  image: aerospike:ce-8.1.1.1
+  size: 3
+
+  resources:
+    requests:
+      cpu: 500m
+      memory: 1Gi
+    limits:
+      cpu: 500m
+      memory: 1Gi
+
+  scheduling:
+    podAntiAffinityLevel: preferred
+
+  storage:
+    storageClassName: standard
+    resources:
+      requests:
+        storage: 10Gi
+
+  aerospikeConfig:
+    namespaceDefaults:
+      replication-factor: 2
+      data-size: 2147483648   # 2 GiB
+```
+
+### Hard-Rack 템플릿 (프로덕션용)
+
+엄격한 anti-affinity(노드당 하나의 파드), 로컬 스토리지, 모니터링을 적용합니다:
+
+```yaml
+apiVersion: acko.io/v1alpha1
+kind: AerospikeClusterTemplate
+metadata:
+  name: hard-rack
+spec:
+  description: "프로덕션 템플릿 - 하드 anti-affinity, 로컬 PV, 모니터링"
+  image: aerospike:ce-8.1.1.1
+  size: 6
+
+  monitoring:
+    enabled: true
+    port: 9145
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        cpu: 200m
+        memory: 128Mi
+    serviceMonitor:
+      enabled: true
+      interval: 30s
+
+  aerospikeNetworkPolicy:
+    accessType: pod
+    alternateAccessType: pod
+    fabricType: pod
+
+  scheduling:
+    podAntiAffinityLevel: required
+    tolerations:
+      - key: "aerospike"
+        operator: "Exists"
+        effect: "NoSchedule"
+
+  storage:
+    storageClassName: local-path
+    localPVRequired: true
+    resources:
+      requests:
+        storage: 100Gi
+
+  resources:
+    requests:
+      cpu: "2"
+      memory: "4Gi"
+    limits:
+      cpu: "2"
+      memory: "4Gi"
+
+  aerospikeConfig:
+    service:
+      proto-fd-max: 15000
+    namespaceDefaults:
+      replication-factor: 2
+      data-size: 2147483648   # 2 GiB
+```
+
+템플릿 적용:
+
+```bash
+kubectl apply -f config/samples/acko_v1alpha1_template_dev.yaml     # minimal
+kubectl apply -f config/samples/acko_v1alpha1_template_stage.yaml   # soft-rack
+kubectl apply -f config/samples/acko_v1alpha1_template_prod.yaml    # hard-rack
+```
+
+---
+
+## 클러스터에서 템플릿 사용
+
+### 기본 참조
+
+이름으로 템플릿을 참조합니다. 템플릿이 `image`와 `size`를 제공하면 클러스터에서 해당 필드를 생략할 수 있습니다:
+
+```yaml
+apiVersion: acko.io/v1alpha1
+kind: AerospikeCluster
+metadata:
+  name: my-cluster
+spec:
+  templateRef:
+    name: soft-rack
+  aerospikeConfig:
+    namespaces:
+      - name: data
+        storage-engine:
+          type: memory
+```
+
+### 템플릿 기본값 오버라이드
+
+클러스터에서 `spec.image`나 `spec.size`를 명시적으로 설정하여 템플릿 값을 오버라이드할 수 있습니다:
+
+```yaml
+spec:
+  image: aerospike:ce-8.1.1.1   # 오버라이드: 특정 이미지 고정
+  size: 3                         # 오버라이드: 템플릿의 기본값 대신 3 사용
+  templateRef:
+    name: hard-rack
+```
+
+---
+
+## 템플릿 오버라이드
+
+`spec.overrides`를 사용하여 새 템플릿을 만들지 않고도 특정 필드를 선택적으로 수정할 수 있습니다:
+
+```yaml
+spec:
+  templateRef:
+    name: hard-rack
+  overrides:
+    resources:
+      requests:
+        cpu: "4"
+        memory: "8Gi"
+      limits:
+        cpu: "4"
+        memory: "8Gi"
+    scheduling:
+      podAntiAffinityLevel: preferred   # 이 클러스터에 대해 anti-affinity 완화
+```
+
+### 병합 우선순위
+
+필드는 다음 순서로 해석됩니다 (가장 높은 우선순위 먼저):
+
+1. **`spec.overrides`** -- 클러스터별 오버라이드
+2. **`template.spec`** -- 템플릿 기본값
+3. **오퍼레이터 기본값** -- 내장 폴백 값
+
+### 병합 동작
+
+| 필드 유형 | 동작 | 예시 |
+|-----------|------|------|
+| 스칼라 (string, int, bool) | 오버라이드가 템플릿 값을 대체 | `size: 3`이 템플릿의 `size: 6`을 대체 |
+| 맵 (중첩 객체) | 재귀적 병합 -- 지정된 키만 오버라이드 | `aerospikeConfig.service.proto-fd-max: 20000`은 해당 키만 오버라이드 |
+| 배열 (리스트) | 오버라이드가 전체 배열을 대체 | `tolerations: [...]`이 모든 템플릿 톨러레이션을 대체 |
+
+:::tip
+`aerospikeConfig.service`와 같은 맵의 경우, 변경하려는 키만 지정하면 됩니다. 지정하지 않은 키는 템플릿에서 상속됩니다.
+:::
+
+---
+
+## 오버라이드 가능한 필드
+
+템플릿이 기본값을 제공할 수 있는 필드:
+
+| 필드 | 설명 |
+|------|------|
+| `image` | Aerospike CE 컨테이너 이미지 |
+| `size` | 기본 클러스터 크기 (1--8) |
+| `resources` | CPU/메모리 요청 및 제한 |
+| `scheduling` | Anti-affinity 레벨, 톨러레이션, 노드 어피니티, 토폴로지 분산 |
+| `storage` | 스토리지 클래스, 볼륨 모드, 크기, 로컬 PV 플래그 |
+| `rackConfig` | 랙 설정 기본값 (maxRacksPerNode) |
+| `aerospikeConfig` | 서비스 및 네임스페이스 기본 설정 |
+| `monitoring` | Prometheus 익스포터 사이드카 설정 |
+| `aerospikeNetworkPolicy` | 클라이언트/패브릭 네트워크 접근 유형 |
+
+---
+
+## 템플릿 동기화 동작
+
+### 자동 전파되지 않는 이유
+
+템플릿은 안전을 위해 스냅샷 모델을 사용합니다. 템플릿 변경을 실행 중인 프로덕션 클러스터에 자동으로 전파하면 예기치 않은 롤링 재시작이나 설정 충돌이 발생할 수 있습니다. 대신 오퍼레이터는:
+
+1. 템플릿 드리프트를 감지하고 `status.templateSnapshot.synced: false`를 설정합니다
+2. 영향을 받는 클러스터에 `TemplateDrifted` 경고 이벤트를 발생시킵니다
+3. 클러스터별로 명시적인 재동기화 승인을 대기합니다
+
+### 동기화 상태 확인
+
+```bash
+kubectl get aerospikecluster hard-rack-cluster \
+  -o jsonpath='{.status.templateSnapshot}'
+```
+
+출력 예시:
+
+```json
+{
+  "name": "hard-rack",
+  "resourceVersion": "12345",
+  "snapshotTimestamp": "2026-03-01T10:00:00Z",
+  "synced": true
+}
+```
+
+`synced`가 `false`이면 클러스터가 이전 버전의 템플릿으로 실행 중입니다.
+
+### 클러스터 재동기화
+
+업데이트된 템플릿을 특정 클러스터에 적용하려면:
+
+```bash
+kubectl annotate aerospikecluster hard-rack-cluster acko.io/resync-template=true
+```
+
+오퍼레이터는:
+
+1. 템플릿을 다시 가져옵니다
+2. `status.templateSnapshot`을 새 스펙으로 업데이트합니다
+3. `TemplateApplied` 이벤트를 발생시킵니다
+4. 어노테이션을 제거합니다
+5. 리컨실레이션을 트리거합니다 (설정이 변경된 경우 롤링 재시작이 발생할 수 있음)
+
+:::warning
+재동기화는 Aerospike 설정, 이미지 또는 파드 스펙에 영향을 미치는 템플릿 변경이 있는 경우 롤링 재시작을 트리거할 수 있습니다. 프로덕션 클러스터를 재동기화하기 전에 템플릿 차이를 확인하세요.
+:::
+
+---
+
+## 템플릿 라이프사이클
+
+### 템플릿을 사용하는 클러스터 확인
+
+`status.usedBy` 필드는 템플릿을 참조하는 모든 클러스터를 추적합니다:
+
+```bash
+kubectl get aerospikeclustertemplate hard-rack -o jsonpath='{.status.usedBy}'
+```
+
+```json
+["hard-rack-cluster", "prod-cluster-east", "prod-cluster-west"]
+```
+
+### 템플릿 삭제
+
+`usedBy`가 비어 있지 않으면 템플릿을 삭제할 수 없습니다. 먼저 모든 클러스터 참조를 제거한 후 삭제하세요:
+
+```bash
+# 현재 참조 확인
+kubectl get aerospikeclustertemplate hard-rack -o jsonpath='{.status.usedBy}'
+
+# 클러스터에서 템플릿 참조 제거 (image/size 직접 설정)
+kubectl -n aerospike patch asc hard-rack-cluster --type merge \
+  -p '{"spec":{"image":"aerospike:ce-8.1.1.1","size":3,"templateRef":null}}'
+
+# usedBy가 비어 있으면 템플릿 삭제
+kubectl delete aerospikeclustertemplate hard-rack
+```
+
+### 템플릿 업데이트
+
+다른 Kubernetes 리소스처럼 템플릿을 업데이트합니다:
+
+```bash
+kubectl patch aerospikeclustertemplate hard-rack --type merge \
+  -p '{"spec":{"image":"aerospike:ce-8.1.2.0"}}'
+```
+
+업데이트 후 참조하는 모든 클러스터에 `synced: false`가 표시되고 `TemplateDrifted` 이벤트가 발생합니다. 준비가 되면 각 클러스터를 개별적으로 재동기화하세요.
+
+---
+
+## Helm을 통한 기본 템플릿 설치
+
+설치 시 `defaultTemplates.enabled=true` Helm 값을 사용하여 세 가지 템플릿 티어를 모두 생성할 수 있습니다:
+
+```bash
+helm install aerospike-ce-kubernetes-operator \
+  oci://ghcr.io/kimsoungryoul/charts/aerospike-ce-kubernetes-operator \
+  -n aerospike-operator --create-namespace \
+  --set certManagerSubchart.enabled=true \
+  --set defaultTemplates.enabled=true
+```
+
+확인:
+
+```bash
+kubectl get aerospikeclustertemplate
+# NAME         AGE
+# minimal      10s
+# soft-rack    10s
+# hard-rack    10s
+```
+
+---
+
+## Cluster Manager UI를 통한 템플릿 관리
+
+Cluster Manager UI가 활성화된 경우 (`ui.enabled=true` 및 `ui.k8s.enabled=true`), 웹 인터페이스에서 템플릿을 관리할 수 있습니다:
+
+- **생성** -- 모든 템플릿 필드를 위한 가이드 마법사
+- **조회** -- 해석된 스펙과 참조 클러스터를 보여주는 상세 페이지
+- **편집** -- 템플릿 패치/업데이트 (RBAC `patch` 및 `update` 권한 필요)
+- **삭제** -- 미사용 템플릿 제거 (클러스터가 참조 중이면 차단)
+- **재동기화** -- 클러스터 상세 페이지에서 템플릿 재동기화 트리거
+
+자세한 내용은 [Cluster Manager UI](cluster-manager-ui.md)를 참조하세요.
+
+---
+
+## 모범 사례
+
+1. **환경 티어별로 템플릿 이름 지정** -- `minimal`, `soft-rack`, `hard-rack`은 의도된 용도를 명확히 전달합니다.
+2. **`description` 사용** -- `spec.description` 필드(최대 500자)는 팀이 템플릿의 목적을 이해하는 데 도움이 됩니다.
+3. **프로덕션 템플릿에서 이미지 고정** -- `latest`나 태그 없는 이미지를 피하고 특정 CE 버전으로 고정하세요.
+4. **프로덕션에서 Guaranteed QoS 설정** -- 예측 가능한 성능을 위해 리소스 요청을 제한과 동일하게 설정하세요.
+5. **프로덕션 전에 스테이징 먼저 재동기화** -- 템플릿 업데이트 후 변경 사항을 검증하기 위해 스테이징 클러스터를 먼저 재동기화하세요.
+6. **오버라이드는 최소한으로 사용** -- 많은 클러스터에 동일한 오버라이드가 필요하면 새 템플릿 티어를 만드는 것이 좋습니다.
+
+---
+
+## 템플릿 비교
+
+| | `minimal` | `soft-rack` | `hard-rack` |
+|---|-----------|-------------|-------------|
+| **용도** | 개발 / 빠른 시작 | 스테이징 | 프로덕션 |
+| **size** | 1 | 3 | 6 |
+| **anti-affinity** | none | preferred | required |
+| **스토리지** | standard 1 Gi | standard 10 Gi | local-path 100 Gi |
+| **랙 보장** | 없음 | 소프트 (같은 노드 허용) | 하드 (1 노드 : 1 랙) |
+| **리소스** | 100 m / 256 Mi | 500 m / 1 Gi | 2 / 4 Gi (Guaranteed QoS) |
+| **모니터링** | 비활성화 | 비활성화 | 활성화 |
+| **RF** | 1 | 2 | 2 |

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -18,6 +18,8 @@ const sidebars = {
         'guide/networking',
         'guide/advanced-configuration',
         'guide/cluster-templates',
+        'guide/templates',
+        'guide/operations',
         'guide/cluster-manager-ui',
         'guide/glossary',
       ],


### PR DESCRIPTION
## Summary
- **Template Management guide**: Comprehensive guide covering AerospikeClusterTemplate CRD, creating/using templates, override mechanism, sync behavior, and best practices
- **Operations guide**: WarmRestart vs PodRestart comparison, triggering operations, status tracking, and pod targeting
- **Local Storage section**: Added to storage guide covering `localStorageClasses` and `deleteLocalStorageOnRestart` fields with use cases
- All guides include Korean translations

## Changes
### New files
- `docs/content/guide/templates.md` - Template Management guide (EN)
- `docs/content/guide/operations.md` - Operations guide (EN)
- `docs/i18n/ko/.../guide/templates.md` - Template Management guide (KO)
- `docs/i18n/ko/.../guide/operations.md` - Operations guide (KO)

### Modified files
- `docs/content/guide/storage.md` - Added Local Storage section (EN)
- `docs/i18n/ko/.../guide/storage.md` - Added Local Storage section (KO)
- `docs/sidebars.js` - Added templates and operations entries

## Test plan
- [ ] Run `make docs-build` and verify no broken links
- [ ] Verify sidebar shows Templates and Operations entries correctly
- [ ] Verify Korean translations render properly