### PR TITLE
feat: improve Helm chart UI config with DB pool, timeouts, logging, and metrics

### DIFF
--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/configmap.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/configmap.yaml
@@ -9,6 +9,11 @@ metadata:
 data:
   CORS_ORIGINS: {{ .Values.ui.env.corsOrigins | quote }}
   LOG_LEVEL: {{ .Values.ui.env.logLevel | quote }}
+  LOG_FORMAT: {{ .Values.ui.env.logFormat | quote }}
   K8S_MANAGEMENT_ENABLED: {{ .Values.ui.k8s.enabled | quote }}
   BACKEND_URL: "http://localhost:{{ .Values.ui.service.backendPort }}"
+  DB_POOL_SIZE: {{ .Values.ui.env.dbPoolSize | quote }}
+  DB_POOL_OVERFLOW: {{ .Values.ui.env.dbPoolOverflow | quote }}
+  DB_POOL_TIMEOUT: {{ .Values.ui.env.dbPoolTimeout | quote }}
+  K8S_API_TIMEOUT: {{ .Values.ui.env.k8sApiTimeout | quote }}
 {{- end }}

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/servicemonitor.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/servicemonitor.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.ui.enabled .Values.ui.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "aerospike-ce-kubernetes-operator.ui.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "aerospike-ce-kubernetes-operator.ui.labels" . | nindent 4 }}
+    {{- with .Values.ui.metrics.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+    - port: backend
+      scheme: http
+      {{- with .Values.ui.metrics.serviceMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .Values.ui.metrics.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+  selector:
+    matchLabels:
+      {{- include "aerospike-ce-kubernetes-operator.ui.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/aerospike-ce-kubernetes-operator/values.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/values.yaml
@@ -470,10 +470,34 @@ ui:
     corsOrigins: ""
     # -- Log level (DEBUG, INFO, WARNING, ERROR)
     logLevel: "INFO"
+    # -- Log format: "text" for human-readable output, "json" for structured logging
+    logFormat: "text"
     # -- External PostgreSQL connection URL.
     # Only used when postgresql.enabled is false.
     # Example: "postgresql://user:pass@db-host:5432/aerospike_manager"
     databaseUrl: ""
+    # -- DB connection pool size
+    dbPoolSize: 5
+    # -- Max overflow connections beyond pool size
+    dbPoolOverflow: 10
+    # -- Pool checkout timeout in seconds
+    dbPoolTimeout: 30
+    # -- Kubernetes API request timeout in seconds
+    k8sApiTimeout: 30
+
+  # =============================================================================
+  # Monitoring - ServiceMonitor (Prometheus Operator)
+  # =============================================================================
+  metrics:
+    serviceMonitor:
+      # -- Create a ServiceMonitor resource for the UI backend metrics endpoint
+      enabled: false
+      # -- Scrape interval (e.g., "30s")
+      interval: 30s
+      # -- Scrape timeout (e.g., "10s")
+      scrapeTimeout: 10s
+      # -- Additional labels for the ServiceMonitor (useful for Prometheus selection)
+      labels: {}
 
   # =============================================================================
   # Scheduling


### PR DESCRIPTION
## Summary
- DB connection pool 설정 추가 (DB_POOL_SIZE, DB_POOL_OVERFLOW, DB_POOL_TIMEOUT)
- K8s API 타임아웃 설정 추가 (K8S_API_TIMEOUT)
- 구조화 로깅 포맷 옵션 추가 (LOG_FORMAT: text/json)
- UI 백엔드용 optional ServiceMonitor 추가 (Prometheus 메트릭 수집)

## Changes
- `values.yaml`: 새로운 env 변수와 metrics.serviceMonitor 섹션 추가
- `templates/ui/configmap.yaml`: 새 환경변수 매핑
- `templates/ui/servicemonitor.yaml`: 새 파일 - UI 백엔드 메트릭 수집용

## Test plan
- [ ] `helm template` 으로 렌더링 확인
- [ ] `ui.metrics.serviceMonitor.enabled=true` 시 ServiceMonitor 생성 확인
- [ ] `ui.metrics.serviceMonitor.enabled=false` (기본값) 시 ServiceMonitor 미생성 확인
- [ ] 기존 values.yaml 호환성 확인