### PR TITLE
docs: improve access control, advanced config, cluster management, and API reference

### DIFF
--- a/docs/content/api-reference/aerospikecluster.md
+++ b/docs/content/api-reference/aerospikecluster.md
@@ -125,8 +125,9 @@ Observed state of the Aerospike CE cluster.
 
 | Field | Type | Description |
 |---|---|---|
-| `phase` | string | Cluster phase: `InProgress`, `Completed`, `Error`, `ScalingUp`, `ScalingDown`, `RollingRestart`, `ACLSync`, `Paused`, `Deleting`. |
-| `size` | int32 | Current cluster size. |
+| `phase` | string | Cluster phase: `InProgress`, `Completed`, `Error`, `ScalingUp`, `ScalingDown`, `WaitingForMigration`, `RollingRestart`, `ACLSync`, `Paused`, `Deleting`. |
+| `size` | int32 | Current number of ready pods. |
+| `health` | string | Human-readable pod readiness summary in `ready/total` format (e.g., `3/3`). |
 | `conditions` | [][Condition](https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/conditions/) | Latest observations of cluster state. |
 | `pods` | map[string][AerospikePodStatus](#aerospikepodstatus) | Per-pod status information, keyed by pod name. |
 | `observedGeneration` | int64 | Most recent generation observed by the controller. |
@@ -140,6 +141,8 @@ Observed state of the Aerospike CE cluster.
 | `pendingRestartPods` | []string | Pods queued for restart in the current rolling restart. Cleared when complete. |
 | `lastReconcileTime` | [Time](https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/object-meta/#System) | Timestamp of the last successful reconciliation. |
 | `templateSnapshot` | [TemplateSnapshotStatus](#templatesnapshotstatus) | Resolved template spec at last sync time. |
+| `failedReconcileCount` | int32 | Number of consecutive failed reconciliations. Reset to 0 on success. When this exceeds the circuit breaker threshold (default 10), the operator backs off exponentially. |
+| `lastReconcileError` | string | Error message from the most recent failed reconciliation. Cleared on success. |
 
 ---
 

--- a/docs/content/guide/access-control.md
+++ b/docs/content/guide/access-control.md
@@ -139,6 +139,96 @@ Privileges follow the format: `<code>[.<namespace>[.<set>]]`
 - `read-write.myns` — read-write on the `myns` namespace
 - `write.myns.myset` — write on the `myset` set within `myns`
 
+## Role Whitelists (IP Allowlisting)
+
+Each custom role can include a `whitelist` field to restrict which client IP addresses are allowed to authenticate with that role. Whitelisted CIDRs apply at the Aerospike server level, providing an additional layer of network-based access control beyond Kubernetes NetworkPolicy.
+
+```yaml
+spec:
+  aerospikeAccessControl:
+    roles:
+      - name: internal-reader
+        privileges:
+          - read.data
+        whitelist:
+          - "10.0.0.0/8"         # Allow only internal network
+          - "172.16.0.0/12"
+      - name: monitoring-role
+        privileges:
+          - read
+        whitelist:
+          - "10.100.0.0/16"      # Allow only the monitoring subnet
+    users:
+      - name: admin
+        secretName: admin-secret
+        roles:
+          - sys-admin
+          - user-admin
+      - name: internal-app
+        secretName: internal-app-secret
+        roles:
+          - internal-reader
+      - name: prometheus
+        secretName: prometheus-secret
+        roles:
+          - monitoring-role
+```
+
+**When to use whitelists:**
+
+- Restrict database access to specific application subnets
+- Limit monitoring access to the Prometheus/Grafana network range
+- Add defense-in-depth alongside Kubernetes NetworkPolicy
+
+:::note
+Whitelists apply per role. If a user has multiple roles, the user can connect from any IP allowed by any of their assigned roles. Built-in roles (e.g., `read-write`) do not support whitelists -- you must create a custom role to use this feature.
+:::
+
+## Admin Policy
+
+The `adminPolicy` field configures the timeout for admin API operations (user/role creation, password changes, etc.) performed by the operator. This is useful when the Aerospike cluster is under heavy load and admin operations may take longer than the default 2-second timeout.
+
+```yaml
+spec:
+  aerospikeAccessControl:
+    adminPolicy:
+      timeout: 5000    # 5 seconds (default: 2000ms)
+    users:
+      - name: admin
+        secretName: admin-secret
+        roles:
+          - sys-admin
+          - user-admin
+```
+
+| Field | Default | Range | Description |
+|-------|---------|-------|-------------|
+| `timeout` | `2000` | 100 -- 30000 ms | Admin operation timeout in milliseconds |
+
+Increase this value if you see `ACLSyncError` events with timeout-related error messages, especially during initial cluster creation with many users/roles or under heavy load.
+
+## Password Rotation
+
+The operator watches Kubernetes Secrets referenced by `aerospikeAccessControl.users[*].secretName`. When a Secret's data changes, the operator automatically syncs the updated password to Aerospike without requiring any change to the AerospikeCluster CR.
+
+```bash
+# Rotate a user's password by updating the Secret
+kubectl -n aerospike create secret generic app-secret \
+  --from-literal=password='new-password-here' \
+  --dry-run=client -o yaml | kubectl apply -f -
+```
+
+Verify the sync via events:
+
+```bash
+kubectl get events --field-selector reason=ACLSyncStarted -n aerospike
+kubectl get events --field-selector reason=ACLSyncCompleted -n aerospike
+```
+
+:::info
+Only Secrets actively referenced by an AerospikeCluster's ACL configuration trigger reconciliation. Unrelated Secret changes in the same namespace are ignored.
+:::
+
 ## Webhook Validation Rules
 
 The operator's admission webhook enforces the following ACL rules:

--- a/docs/content/guide/advanced-configuration.md
+++ b/docs/content/guide/advanced-configuration.md
@@ -259,6 +259,185 @@ spec:
 
 ---
 
+## Pod Customization
+
+The `spec.podSpec` field provides access to several Kubernetes pod-level features beyond scheduling. This section covers sidecar containers, init containers, security contexts, service accounts, and image pull secrets.
+
+### Custom Sidecars
+
+Add sidecar containers to every Aerospike pod. These run alongside the main Aerospike server container and share the pod's network namespace and volumes.
+
+```yaml
+spec:
+  podSpec:
+    sidecars:
+      - name: log-forwarder
+        image: fluent/fluent-bit:latest
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            cpu: 100m
+            memory: 128Mi
+        volumeMounts:
+          - name: aerospike-logs
+            mountPath: /var/log/aerospike
+            readOnly: true
+  storage:
+    volumes:
+      - name: aerospike-logs
+        source:
+          emptyDir: {}
+        aerospike:
+          path: /var/log/aerospike
+        sidecars:
+          - containerName: log-forwarder
+            path: /var/log/aerospike
+            readOnly: true
+```
+
+:::tip
+When using the monitoring exporter sidecar (`spec.monitoring.enabled: true`), the operator automatically adds it. You do not need to include it in the `sidecars` list.
+:::
+
+### Init Containers
+
+Add init containers that run before the Aerospike server starts. These execute after the operator's built-in init container (which handles volume initialization).
+
+**Use cases:** Pre-populating data, setting file permissions, downloading configuration from external sources, waiting for dependencies.
+
+```yaml
+spec:
+  podSpec:
+    initContainers:
+      - name: set-permissions
+        image: busybox:1.36
+        command: ["sh", "-c", "chown -R 1000:1000 /opt/aerospike/data"]
+        volumeMounts:
+          - name: data-vol
+            mountPath: /opt/aerospike/data
+  storage:
+    volumes:
+      - name: data-vol
+        source:
+          persistentVolume:
+            storageClass: standard
+            size: 50Gi
+        aerospike:
+          path: /opt/aerospike/data
+        initContainers:
+          - containerName: set-permissions
+            path: /opt/aerospike/data
+```
+
+### Security Context
+
+Set pod-level and container-level security attributes to meet your organization's security policies.
+
+**Pod-level security context** applies to all containers in the pod:
+
+```yaml
+spec:
+  podSpec:
+    securityContext:
+      runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 1000
+      runAsNonRoot: true
+```
+
+**Container-level security context** applies only to the Aerospike server container:
+
+```yaml
+spec:
+  podSpec:
+    aerospikeContainer:
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: false
+        capabilities:
+          drop:
+            - ALL
+```
+
+### Service Account
+
+Specify a custom ServiceAccount for Aerospike pods. This is useful when pods need access to cloud provider APIs (e.g., for backup/restore via IAM roles) or when running in a namespace with restricted RBAC.
+
+```yaml
+spec:
+  podSpec:
+    serviceAccountName: aerospike-sa
+```
+
+### Image Pull Secrets
+
+Reference Kubernetes Secrets containing container registry credentials. Required when pulling from private registries.
+
+```yaml
+spec:
+  podSpec:
+    imagePullSecrets:
+      - name: my-registry-secret
+```
+
+Create the secret first:
+
+```bash
+kubectl -n aerospike create secret docker-registry my-registry-secret \
+  --docker-server=registry.example.com \
+  --docker-username=myuser \
+  --docker-password=mypassword
+```
+
+---
+
+## Secret and ConfigMap Volumes
+
+In addition to PVC, emptyDir, and hostPath volumes, you can mount Kubernetes Secrets and ConfigMaps directly into Aerospike pods. This is useful for TLS certificates, custom configuration files, or credential injection.
+
+### Secret Volume
+
+Mount a Kubernetes Secret as files in the Aerospike container:
+
+```yaml
+spec:
+  storage:
+    volumes:
+      - name: aerospike-creds
+        source:
+          secret:
+            secretName: aerospike-credentials
+            items:
+              - key: tls.crt
+                path: tls.crt
+              - key: tls.key
+                path: tls.key
+        aerospike:
+          path: /opt/aerospike/certs
+          readOnly: true
+```
+
+### ConfigMap Volume
+
+Mount a ConfigMap to provide additional configuration files:
+
+```yaml
+spec:
+  storage:
+    volumes:
+      - name: custom-config
+        source:
+          configMap:
+            name: aerospike-custom-config
+        aerospike:
+          path: /opt/aerospike/custom
+          readOnly: true
+```
+
+---
+
 ## Rack-level Overrides
 
 Each rack in `spec.rackConfig.racks` can override cluster-level settings for `aerospikeConfig`, `storage`, and `podSpec`. This enables heterogeneous configurations across failure domains.

--- a/docs/content/guide/manage-cluster.md
+++ b/docs/content/guide/manage-cluster.md
@@ -239,24 +239,125 @@ If a restart is blocked waiting for the gate, a `ReadinessGateBlocking` warning 
 kubectl -n aerospike get events --field-selector reason=ReadinessGateBlocking
 ```
 
-## Pausing Reconciliation
+## Pausing and Resuming Reconciliation
 
-Temporarily stop the operator from reconciling:
+Temporarily stop the operator from reconciling a cluster by setting `spec.paused: true`. While paused, the operator skips all reconciliation for this cluster -- no scaling, rolling restarts, config changes, or ACL syncs will be performed. The cluster phase changes to `Paused` and the `ReconciliationPaused` condition is set to `True`.
 
-```yaml
-spec:
-  paused: true
-```
+**When to pause:**
 
-While paused, the operator skips all reconciliation. Set back to `false` (or remove the field) to resume.
+- During planned infrastructure maintenance (node upgrades, storage migrations)
+- To prevent the operator from interfering with manual debugging
+- Before making multiple spec changes that you want to apply as a single batch
+- When investigating a stuck cluster without the operator retrying
 
 ```bash
-# Pause
+# Pause reconciliation
 kubectl -n aerospike patch asc aerospike-ce-3node --type merge -p '{"spec":{"paused":true}}'
 
-# Resume
+# Verify paused state
+kubectl -n aerospike get asc aerospike-ce-3node -o jsonpath='{.status.phase}'
+# Output: Paused
+```
+
+To resume reconciliation, set `paused` to `false` or remove it entirely. The operator immediately begins reconciling the cluster toward its desired state:
+
+```bash
+# Resume reconciliation
 kubectl -n aerospike patch asc aerospike-ce-3node --type merge -p '{"spec":{"paused":null}}'
 ```
+
+:::warning
+Pausing does not stop the Aerospike cluster itself -- pods continue running and serving traffic. It only stops the operator from making changes to the cluster's Kubernetes resources.
+:::
+
+## Cluster Status and Conditions
+
+The operator provides detailed status information through the `status` subresource. Understanding these fields helps with monitoring and troubleshooting.
+
+### Phase
+
+The `status.phase` field provides a high-level view of what the operator is doing:
+
+```bash
+kubectl -n aerospike get asc
+```
+
+| Phase | Meaning |
+|---|---|
+| `Completed` | Cluster is healthy and matches the desired spec |
+| `InProgress` | Generic reconciliation in progress |
+| `ScalingUp` | Adding pods to the cluster |
+| `ScalingDown` | Removing pods from the cluster |
+| `WaitingForMigration` | Scale-down deferred until data migration completes |
+| `RollingRestart` | Rolling restart in progress (config/image/podSpec change) |
+| `ACLSync` | ACL roles and users are being synchronized |
+| `Paused` | Reconciliation paused by user |
+| `Deleting` | Cluster teardown in progress |
+| `Error` | Unrecoverable error; check `status.lastReconcileError` |
+
+The `status.phaseReason` field provides additional context (e.g., "Rolling restart in progress for rack 1").
+
+### Health
+
+The `status.health` field gives a quick "ready/total" summary:
+
+```bash
+kubectl -n aerospike get asc aerospike-ce-3node -o jsonpath='{.status.health}'
+# Output: 3/3
+```
+
+A value of `2/3` means 2 out of 3 pods are ready. This maps to the `HEALTH` column in `kubectl get asc` output.
+
+### Conditions
+
+The operator maintains six condition types that provide a detailed breakdown of cluster health:
+
+```bash
+kubectl -n aerospike get asc aerospike-ce-3node -o jsonpath='{.status.conditions}' | jq .
+```
+
+| Condition | True When |
+|---|---|
+| `Available` | At least one pod is ready to serve requests |
+| `Ready` | All desired pods are running and ready |
+| `ConfigApplied` | All pods have the desired Aerospike configuration |
+| `ACLSynced` | ACL roles and users match the spec |
+| `MigrationComplete` | No data migrations are pending |
+| `ReconciliationPaused` | `spec.paused` is `true` |
+
+**Example: Checking if a cluster is fully operational**
+
+A cluster is fully healthy when `Ready`, `ConfigApplied`, `MigrationComplete`, and `ACLSynced` (if ACL is configured) are all `True`:
+
+```bash
+kubectl -n aerospike get asc aerospike-ce-3node \
+  -o jsonpath='{range .status.conditions[*]}{.type}={.status}{"\n"}{end}'
+```
+
+Expected healthy output:
+```
+Available=True
+Ready=True
+ConfigApplied=True
+ACLSynced=True
+MigrationComplete=True
+ReconciliationPaused=False
+```
+
+### Aerospike Cluster Size vs Kubernetes Pod Count
+
+The `status.aerospikeClusterSize` field reflects the cluster size as reported by Aerospike's `asinfo` command. This may temporarily differ from `status.size` (the number of ready Kubernetes pods) during:
+
+- Rolling restarts (a pod is being replaced)
+- Network partitions (split-brain scenarios)
+- Pod startup (Aerospike has not yet joined the mesh)
+
+```bash
+kubectl -n aerospike get asc aerospike-ce-3node \
+  -o jsonpath='K8s pods: {.status.size}, Aerospike cluster-size: {.status.aerospikeClusterSize}'
+```
+
+If these values diverge for an extended period, investigate pod connectivity and mesh heartbeat configuration.
 
 ## Secret-Triggered ACL Sync
 

--- a/docs/content/guide/monitoring.md
+++ b/docs/content/guide/monitoring.md
@@ -7,7 +7,7 @@ title: Monitoring
 
 This guide covers per-cluster Prometheus monitoring: the exporter sidecar, ServiceMonitor, PrometheusRule with built-in and custom alert rules, and metric labels.
 
-For **operator-level** monitoring (ServiceMonitor, PrometheusRule, and Grafana dashboard for the operator itself), see the [Install — Observability](install.md#observability) section.
+For **operator-level** monitoring (ServiceMonitor, PrometheusRule, and Grafana dashboard for the operator itself), see the [Install — Monitoring](install.md#monitoring-optional) section.
 
 ---
 

--- a/docs/content/guide/storage.md
+++ b/docs/content/guide/storage.md
@@ -29,6 +29,25 @@ Applied to PVC volumes with `volumeMode: Block`.
 
 Same fields as `filesystemVolumePolicy`. The recommended `initMethod` for block devices is `blkdiscard` (fast, hardware-accelerated) and `blkdiscardWithHeaderCleanup` for `wipeMethod`.
 
+### cleanupThreads
+
+Controls the maximum number of concurrent threads used during volume initialization (`initMethod`) and wipe (`wipeMethod`) operations. Higher values speed up volume preparation at the cost of increased I/O load.
+
+| Value | Behavior |
+|-------|----------|
+| `1` (default) | One volume at a time -- safe, low I/O impact |
+| `2` -- `4` | Moderate parallelism -- good for clusters with multiple volumes |
+| `>4` | Aggressive -- only use with high-throughput storage backends |
+
+```yaml
+storage:
+  cleanupThreads: 2
+```
+
+:::tip
+Increase `cleanupThreads` if you have many volumes per pod and want faster pod startup. Keep it at 1 if your storage backend has limited IOPS or if volume initialization causes I/O contention with running workloads.
+:::
+
 ### localStorageClasses
 
 List of StorageClass names considered "local" storage (e.g., `local-path`, `openebs-hostpath`). Local PVCs are deleted before pod restart to ensure a clean state.

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/guide/monitoring.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/guide/monitoring.md
@@ -7,7 +7,7 @@ title: 모니터링
 
 이 가이드에서는 클러스터별 Prometheus 모니터링 설정을 다룹니다: exporter 사이드카, ServiceMonitor, 기본 및 커스텀 알림 규칙이 포함된 PrometheusRule, 메트릭 라벨.
 
-**오퍼레이터 수준**의 모니터링(오퍼레이터 자체를 위한 ServiceMonitor, PrometheusRule, Grafana 대시보드)은 [설치 — Observability](install.md#observability) 섹션을 참조하세요.
+**오퍼레이터 수준**의 모니터링(오퍼레이터 자체를 위한 ServiceMonitor, PrometheusRule, Grafana 대시보드)은 [설치 — 모니터링](install.md#모니터링-선택사항) 섹션을 참조하세요.
 
 ---
 


### PR DESCRIPTION
## Summary
- Access Control: Role Whitelists, Admin Policy, Password Rotation 문서 추가
- Advanced Config: Pod Customization (sidecars, init containers, securityContext, serviceAccount, imagePullSecrets), Secret/ConfigMap Volumes 문서 추가
- Manage Cluster: Pausing/Resuming 확장, Cluster Status & Conditions 섹션 추가
- Storage: cleanupThreads 설명 추가
- API Reference: health, failedReconcileCount, lastReconcileError, WaitingForMigration 필드 추가
- Broken link 수정: monitoring.md의 잘못된 앵커 참조 수정 (영문/한국어 모두)

## Build verification
Docusaurus 빌드 성공 확인 (영문 + 한국어 locale, broken link 없음)

## Test plan
- [ ] `npm run build --prefix docs` 성공 확인
- [ ] 새로 추가된 문서 내용 검토
- [ ] 수정된 broken link 정상 확인