### PR TITLE
fix: harden operator stability across rolling restart, scale-down, and ACL sync

### DIFF
--- a/api/v1alpha1/aerospikecluster_webhook.go
+++ b/api/v1alpha1/aerospikecluster_webhook.go
@@ -73,8 +73,12 @@ func (d *AerospikeClusterDefaulter) Default(ctx context.Context, cluster *Aerosp
 		cluster.Spec.AerospikeConfig.Value = make(map[string]any)
 	}
 
-	d.defaultServiceConfig(cluster)
-	d.defaultNetworkConfig(cluster)
+	if err := d.defaultServiceConfig(cluster); err != nil {
+		return err
+	}
+	if err := d.defaultNetworkConfig(cluster); err != nil {
+		return err
+	}
 	d.defaultMonitoring(cluster)
 	d.defaultHostNetwork(cluster)
 
@@ -82,10 +86,14 @@ func (d *AerospikeClusterDefaulter) Default(ctx context.Context, cluster *Aerosp
 }
 
 // defaultServiceConfig sets defaults in aerospikeConfig.service.
-func (d *AerospikeClusterDefaulter) defaultServiceConfig(cluster *AerospikeCluster) {
+// Returns an error if the "service" key exists but is not a map.
+func (d *AerospikeClusterDefaulter) defaultServiceConfig(cluster *AerospikeCluster) error {
 	config := cluster.Spec.AerospikeConfig.Value
 
-	serviceSection := getOrCreateMapSection(config, "service")
+	serviceSection, err := getOrCreateMapSection(config, "service")
+	if err != nil {
+		return err
+	}
 
 	if _, exists := serviceSection["cluster-name"]; !exists {
 		serviceSection["cluster-name"] = cluster.Name
@@ -96,13 +104,18 @@ func (d *AerospikeClusterDefaulter) defaultServiceConfig(cluster *AerospikeClust
 	}
 
 	config["service"] = serviceSection
+	return nil
 }
 
 // defaultNetworkConfig sets defaults in aerospikeConfig.network.
-func (d *AerospikeClusterDefaulter) defaultNetworkConfig(cluster *AerospikeCluster) {
+// Returns an error if the "network" key (or any sub-section key) exists but is not a map.
+func (d *AerospikeClusterDefaulter) defaultNetworkConfig(cluster *AerospikeCluster) error {
 	config := cluster.Spec.AerospikeConfig.Value
 
-	networkSection := getOrCreateMapSection(config, "network")
+	networkSection, err := getOrCreateMapSection(config, "network")
+	if err != nil {
+		return err
+	}
 
 	// Default values for each network sub-section.
 	networkDefaults := map[string]map[string]any{
@@ -112,7 +125,10 @@ func (d *AerospikeClusterDefaulter) defaultNetworkConfig(cluster *AerospikeClust
 	}
 
 	for name, defs := range networkDefaults {
-		section := getOrCreateMapSection(networkSection, name)
+		section, err := getOrCreateMapSection(networkSection, name)
+		if err != nil {
+			return err
+		}
 		for k, v := range defs {
 			if _, exists := section[k]; !exists {
 				section[k] = v
@@ -122,6 +138,7 @@ func (d *AerospikeClusterDefaulter) defaultNetworkConfig(cluster *AerospikeClust
 	}
 
 	config["network"] = networkSection
+	return nil
 }
 
 // defaultMonitoring sets default values for the monitoring spec when enabled.
@@ -161,15 +178,17 @@ func (d *AerospikeClusterDefaulter) defaultHostNetwork(cluster *AerospikeCluster
 }
 
 // getOrCreateMapSection returns the sub-map at key or creates a new one.
-func getOrCreateMapSection(m map[string]any, key string) map[string]any {
+// Returns an error when the key exists but is not a map (indicating invalid config).
+func getOrCreateMapSection(m map[string]any, key string) (map[string]any, error) {
 	if existing, ok := m[key]; ok {
 		if existingMap, ok := existing.(map[string]any); ok {
-			return existingMap
+			return existingMap, nil
 		}
+		return nil, fmt.Errorf("config key %q has type %T, expected map", key, existing)
 	}
 	newMap := make(map[string]any)
 	m[key] = newMap
-	return newMap
+	return newMap, nil
 }
 
 // +kubebuilder:webhook:path=/validate-acko-io-v1alpha1-aerospikecluster,mutating=false,failurePolicy=fail,sideEffects=None,groups=acko.io,resources=aerospikeclusters,verbs=create;update,versions=v1alpha1,name=vaerospikecluster.kb.io,admissionReviewVersions=v1
@@ -625,6 +644,8 @@ func parseMajorVersion(image string) (int, error) {
 	if !ok {
 		return 0, fmt.Errorf("tag %q does not contain a version", tag)
 	}
+	// Strip leading 'v' to handle tags like "v8.1.1" in addition to "8.1.1".
+	before = strings.TrimPrefix(before, "v")
 	return strconv.Atoi(before)
 }
 

--- a/internal/configgen/generator.go
+++ b/internal/configgen/generator.go
@@ -50,7 +50,11 @@ func generateConfigCore(config map[string]any, writeNetwork networkWriter) (stri
 			if !ok {
 				return "", fmt.Errorf("logging must be a list")
 			}
-			b.WriteString(generateLoggingSection(logs))
+			logStr, err := generateLoggingSection(logs)
+			if err != nil {
+				return "", err
+			}
+			b.WriteString(logStr)
 
 		case SectionSecurity:
 			continue
@@ -159,18 +163,20 @@ func writeMapEntries(b *strings.Builder, m map[string]any, indent int) {
 //   - "console" or "stderr" -- generates a `console { ... }` block
 //   - "syslog" -- generates a `syslog { ... }` block
 //   - anything else -- treated as a file path, generating `file <name> { ... }`
-func generateLoggingSection(logs []any) string {
+//
+// Returns an error when any entry is not a map or is missing the required "name" key.
+func generateLoggingSection(logs []any) (string, error) {
 	var b strings.Builder
 	b.WriteString("logging {\n")
 
-	for _, entry := range logs {
+	for i, entry := range logs {
 		logMap, ok := entry.(map[string]any)
 		if !ok {
-			continue
+			return "", fmt.Errorf("logging entry %d is not a map (got %T)", i, entry)
 		}
 		name, _ := logMap["name"].(string)
 		if name == "" {
-			continue
+			return "", fmt.Errorf("logging entry %d is missing the required \"name\" key", i)
 		}
 
 		// Determine sink type from the name field.
@@ -201,7 +207,7 @@ func generateLoggingSection(logs []any) string {
 	}
 
 	b.WriteString("}\n")
-	return b.String()
+	return b.String(), nil
 }
 
 // formatValue formats a config value for aerospike.conf output.

--- a/internal/controller/aero_info.go
+++ b/internal/controller/aero_info.go
@@ -78,7 +78,7 @@ func IsMigratingOnAnyNode(client *aero.Client) (bool, error) {
 		}
 		stats, err := asinfoCommandOnNode(node, "statistics")
 		if err != nil {
-			return false, fmt.Errorf("statistics command on node %s failed: %w", node.GetName(), err)
+			return true, fmt.Errorf("statistics command on node %s failed: %w", node.GetName(), err)
 		}
 		remaining := parseMigrateStat(stats, "migrate_partitions_remaining")
 		if remaining > 0 {

--- a/internal/controller/events.go
+++ b/internal/controller/events.go
@@ -54,6 +54,9 @@ const (
 	EventReadinessGateSatisfied = "ReadinessGateSatisfied"
 	EventReadinessGateBlocking  = "ReadinessGateBlocking"
 
+	// Migration checks
+	EventMigrationCheckFailed = "MigrationCheckFailed"
+
 	// PVC cleanup
 	EventPVCCleanedUp     = "PVCCleanedUp"
 	EventPVCCleanupFailed = "PVCCleanupFailed"

--- a/internal/controller/reconciler.go
+++ b/internal/controller/reconciler.go
@@ -39,6 +39,16 @@ import (
 const (
 	defaultReconcileRetryInterval = 5 * time.Second
 
+	// restartRequeueInterval is the requeue interval used after a rolling restart
+	// batch. Pod restart (delete + recreate + readiness) typically takes 30-60s,
+	// so polling every 5s is wasteful.
+	restartRequeueInterval = 15 * time.Second
+
+	// migrationRequeueInterval is the requeue interval used when scale-down or
+	// rolling restart is deferred due to active data migrations. Migrations can
+	// take minutes to hours, so polling every 5s creates unnecessary API server load.
+	migrationRequeueInterval = 30 * time.Second
+
 	// podReadyPollInterval is the requeue interval used when reconciliation
 	// completes successfully but not all pods are ready yet. The controller
 	// does not watch pod readiness events directly, so periodic polling is
@@ -435,7 +445,7 @@ func (r *AerospikeClusterReconciler) reconcileCluster(
 		return ctrl.Result{}, err
 	} else if deferred {
 		log.Info("Scale-down deferred due to data migration, requeuing")
-		return ctrl.Result{RequeueAfter: defaultReconcileRetryInterval}, nil
+		return ctrl.Result{RequeueAfter: migrationRequeueInterval}, nil
 	}
 
 	// Clean up removed racks
@@ -490,7 +500,7 @@ func (r *AerospikeClusterReconciler) reconcileCluster(
 				}
 				log.V(1).Info("Conflict setting RollingRestart phase, continuing reconcile", "rack", rack.ID)
 			}
-			return ctrl.Result{RequeueAfter: defaultReconcileRetryInterval}, nil
+			return ctrl.Result{RequeueAfter: restartRequeueInterval}, nil
 		}
 	}
 

--- a/internal/controller/reconciler_acl.go
+++ b/internal/controller/reconciler_acl.go
@@ -215,12 +215,29 @@ func (r *AerospikeClusterReconciler) reconcileUsers(
 		}
 	}
 
-	// Drop orphaned users (protect the admin user the operator connects as)
+	// Drop orphaned users (protect the admin user the operator connects as).
+	// Also protect the previously-configured admin user when the admin user name is
+	// being changed: if we dropped the old admin before the new one is fully operational,
+	// the operator would lose its connection credentials on the next reconcile.
 	adminUser := utils.FindAdminUser(cluster.Spec.AerospikeAccessControl)
+	var prevAdminUser *ackov1alpha1.AerospikeUserSpec
+	if cluster.Status.AppliedSpec != nil {
+		prevAdminUser = utils.FindAdminUser(cluster.Status.AppliedSpec.AerospikeAccessControl)
+	}
 	for _, user := range existingUsers {
 		if !desiredUsers[user.User] {
-			// Protect the connected admin user
+			// Protect the connected admin user.
 			if adminUser != nil && user.User == adminUser.Name {
+				continue
+			}
+			// Protect the previously-configured admin user during a rename to avoid
+			// locking the operator out before the new admin user is established.
+			if prevAdminUser != nil && user.User == prevAdminUser.Name && prevAdminUser.Name != adminUser.Name {
+				log.Info("Skipping drop of previous admin user during rename — ensure new admin is operational before next reconcile",
+					"previousAdmin", prevAdminUser.Name, "newAdmin", adminUser.Name)
+				r.Recorder.Eventf(cluster, corev1.EventTypeWarning, EventACLSyncError,
+					"Admin user rename detected: previous admin %q not dropped yet. Ensure new admin %q is operational, then remove the old user manually.",
+					prevAdminUser.Name, adminUser.Name)
 				continue
 			}
 			log.Info("Dropping orphaned user", "user", user.User)

--- a/internal/controller/reconciler_dynamic_config.go
+++ b/internal/controller/reconciler_dynamic_config.go
@@ -25,46 +25,48 @@ type appliedChange struct {
 }
 
 // tryDynamicConfigUpdate attempts to apply config changes dynamically without
-// restarting pods. Returns true if all changes were applied dynamically and
-// no restart is needed.
+// restarting pods. Returns (true, node, applied) if all changes were applied
+// dynamically and no restart is needed. On failure, the applied changes for
+// that pod are rolled back internally before returning (false, nil, nil).
+// The returned node and applied slice are used by callers for cross-pod rollback.
 func (r *AerospikeClusterReconciler) tryDynamicConfigUpdate(
 	ctx context.Context,
 	cluster *ackov1alpha1.AerospikeCluster,
 	pod *corev1.Pod,
 	oldConfig, newConfig map[string]any,
 	aeroClient *aero.Client,
-) bool {
+) (bool, *aero.Node, []appliedChange) {
 	log := logf.FromContext(ctx).WithValues("pod", pod.Name, "cluster", cluster.Name)
 
 	// Check if dynamic config update is enabled
 	if cluster.Spec.EnableDynamicConfigUpdate == nil || !*cluster.Spec.EnableDynamicConfigUpdate {
-		return false
+		return false, nil, nil
 	}
 
 	// Diff the configs
 	diff := configdiff.Diff(oldConfig, newConfig)
 	if !diff.HasChanges() {
-		return true // No changes at all
+		return true, nil, nil // No changes at all
 	}
 
 	// If there are static changes, dynamic update alone is not sufficient
 	if diff.HasStaticChanges() {
 		log.Info("Config has static changes, dynamic update not sufficient",
 			"staticChanges", len(diff.Static))
-		return false
+		return false, nil, nil
 	}
 
 	// Find the node corresponding to this pod
 	node := findNodeForPod(aeroClient, pod)
 	if node == nil {
 		log.Info("Could not find Aerospike node for pod, skipping dynamic update")
-		return false
+		return false, nil, nil
 	}
 
 	// Pre-flight: validate all changes before applying any
 	if err := validateDynamicChanges(diff.Dynamic); err != nil {
 		log.Error(err, "Pre-flight validation failed for dynamic config changes")
-		return false
+		return false, nil, nil
 	}
 
 	// Apply each dynamic change, tracking successfully applied changes for rollback.
@@ -77,7 +79,7 @@ func (r *AerospikeClusterReconciler) tryDynamicConfigUpdate(
 			r.rollbackDynamicChanges(log, node, applied)
 			log.Info("Rolled back partial dynamic config changes, falling back to cold restart",
 				"appliedBeforeFailure", len(applied))
-			return false
+			return false, nil, nil
 		}
 		log.Info("Applying dynamic config", "command", cmd, "index", i, "total", len(diff.Dynamic))
 
@@ -88,7 +90,7 @@ func (r *AerospikeClusterReconciler) tryDynamicConfigUpdate(
 			r.rollbackDynamicChanges(log, node, applied)
 			log.Info("Rolled back partial dynamic config changes, falling back to cold restart",
 				"appliedBeforeFailure", len(applied))
-			return false
+			return false, nil, nil
 		}
 		if result != "ok" {
 			log.Info("Dynamic config command returned non-ok", "command", cmd, "result", result)
@@ -96,7 +98,7 @@ func (r *AerospikeClusterReconciler) tryDynamicConfigUpdate(
 			r.rollbackDynamicChanges(log, node, applied)
 			log.Info("Rolled back partial dynamic config changes, falling back to cold restart",
 				"appliedBeforeFailure", len(applied))
-			return false
+			return false, nil, nil
 		}
 
 		// Build rollback command using the old value.
@@ -145,7 +147,7 @@ func (r *AerospikeClusterReconciler) tryDynamicConfigUpdate(
 	// Update pod status with dynamic config status
 	r.updateDynamicConfigStatus(ctx, cluster, pod.Name, "Applied")
 
-	return true
+	return true, node, applied
 }
 
 // buildSetConfigCommand builds the asinfo set-config command for a change.

--- a/internal/controller/reconciler_restart.go
+++ b/internal/controller/reconciler_restart.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	aero "github.com/aerospike/aerospike-client-go/v8"
 	appsv1 "k8s.io/api/apps/v1"
@@ -22,6 +23,10 @@ import (
 	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/storage"
 	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/utils"
 )
+
+// maxPodUnstableDuration is the threshold after which a pod stuck in a non-ready
+// state is skipped from the rolling restart to avoid blocking healthy pods.
+const maxPodUnstableDuration = 10 * time.Minute
 
 // reconcileRollingRestart checks if pods need restart due to config changes.
 // Returns true if a restart was triggered (caller should requeue).
@@ -95,6 +100,20 @@ func (r *AerospikeClusterReconciler) reconcileRollingRestart(
 			}
 		}
 
+		// Skip pods that have been in a non-ready state longer than the threshold.
+		// This prevents a stuck pod from blocking healthy pods in the same rack.
+		if ps, ok := cluster.Status.Pods[pod.Name]; ok && ps.UnstableSince != nil {
+			if time.Since(ps.UnstableSince.Time) > maxPodUnstableDuration {
+				log.Info("Pod stuck in non-ready state beyond threshold, skipping restart",
+					"pod", pod.Name, "unstableSince", ps.UnstableSince.Time,
+					"threshold", maxPodUnstableDuration)
+				r.Recorder.Eventf(cluster, corev1.EventTypeWarning, EventRestartFailed,
+					"Pod %s stuck in non-ready state since %v (>%v), skipping restart",
+					pod.Name, ps.UnstableSince.Time, maxPodUnstableDuration)
+				continue
+			}
+		}
+
 		currentHash := ""
 		if pod.Annotations != nil {
 			currentHash = pod.Annotations[utils.ConfigHashAnnotation]
@@ -128,16 +147,9 @@ func (r *AerospikeClusterReconciler) reconcileRollingRestart(
 		}
 	}()
 
-	// If readiness gates are enabled, hold the next batch until all previously
-	// restarted pods in this rack have their "acko.io/aerospike-ready" gate satisfied.
-	// This ensures data migrations finish before the next pod is taken offline.
-	if isReadinessGateEnabled(cluster) {
-		if blocked, blockedPod := anyPodGateUnsatisfied(cluster, rackPods); blocked {
-			log.Info("Readiness gate not yet satisfied, delaying next restart", "pod", blockedPod, "rack", rack.ID)
-			r.Recorder.Eventf(cluster, corev1.EventTypeWarning, EventReadinessGateBlocking,
-				"Rolling restart paused: pod %s readiness gate not yet satisfied (rack %d)", blockedPod, rack.ID)
-			return true, nil
-		}
+	// Hold the next batch when migration or readiness gates are blocking.
+	if r.isBatchBlocked(ctx, cluster, rack.ID, rackPods) {
+		return true, nil
 	}
 
 	// Restart up to batchSize pods, continuing on individual pod failures.
@@ -169,8 +181,19 @@ func (r *AerospikeClusterReconciler) reconcileRollingRestart(
 	return restarted > 0, nil
 }
 
+// podDynamicUpdate tracks a pod that received a successful dynamic config update,
+// along with the node and applied changes needed for cross-pod rollback.
+type podDynamicUpdate struct {
+	podName string
+	node    *aero.Node
+	applied []appliedChange
+}
+
 // restartPodBatch attempts to restart up to batchSize pods, trying dynamic config first.
-// Returns the count of successfully restarted pods and names of failed pods.
+// Dynamic config updates count against the batch size limit. If any pod fails a cold/warm
+// restart after other pods were dynamically updated in the same batch, those dynamic
+// updates are rolled back for consistency.
+// Returns the count of successfully processed pods and names of failed pods.
 func (r *AerospikeClusterReconciler) restartPodBatch(
 	ctx context.Context,
 	cluster *ackov1alpha1.AerospikeCluster,
@@ -186,11 +209,13 @@ func (r *AerospikeClusterReconciler) restartPodBatch(
 	restarted := int32(0)
 	var failedPods []string
 	attempted := int32(0)
+	var dynamicUpdated []podDynamicUpdate
 
 	for _, pod := range podsToRestart {
 		if attempted >= batchSize {
 			break
 		}
+		attempted++
 
 		// 1. Try dynamic config update first (no restart needed)
 		if oldConfig != nil && newConfig != nil {
@@ -201,14 +226,17 @@ func (r *AerospikeClusterReconciler) restartPodBatch(
 					log.V(1).Info("Could not create Aerospike client for dynamic config, will fall back to restart", "error", clientErr)
 				}
 			}
-			if *aeroClient != nil && r.tryDynamicConfigUpdate(ctx, cluster, pod, oldConfig, newConfig, *aeroClient) {
-				log.Info("Dynamic config update succeeded, no restart needed", "pod", pod.Name)
-				continue
+			if *aeroClient != nil {
+				if ok, node, applied := r.tryDynamicConfigUpdate(ctx, cluster, pod, oldConfig, newConfig, *aeroClient); ok {
+					log.Info("Dynamic config update succeeded, no restart needed", "pod", pod.Name)
+					dynamicUpdated = append(dynamicUpdated, podDynamicUpdate{podName: pod.Name, node: node, applied: applied})
+					restarted++
+					continue
+				}
 			}
 		}
 
 		// 2. Restart pod (warm or cold)
-		attempted++
 		if err := r.restartPod(ctx, cluster, pod, sts, desiredHash); err != nil {
 			r.Recorder.Eventf(cluster, corev1.EventTypeWarning, EventRestartFailed,
 				"Failed to restart pod %s: %v", pod.Name, err)
@@ -217,6 +245,18 @@ func (r *AerospikeClusterReconciler) restartPodBatch(
 			continue
 		}
 		restarted++
+	}
+
+	// Cross-pod rollback: if any cold/warm restart failed AND dynamic updates were
+	// applied in this batch, roll back those dynamic changes for consistency.
+	// The failed pods will be retried in the next reconcile and get the correct
+	// config via cold restart.
+	if len(failedPods) > 0 && len(dynamicUpdated) > 0 {
+		log.Info("Rolling back dynamic config updates due to batch restart failures",
+			"dynamicUpdated", len(dynamicUpdated), "failedPods", len(failedPods))
+		for _, du := range dynamicUpdated {
+			r.rollbackDynamicChanges(log, du.node, du.applied)
+		}
 	}
 
 	return restarted, failedPods
@@ -256,8 +296,11 @@ func (r *AerospikeClusterReconciler) restartPod(
 	}
 
 	// Update config hash annotation so next reconcile won't re-restart this pod.
+	// If this fails, return the error so the reconciler requeues rather than
+	// looping back through warm restart on every reconcile (hash mismatch).
 	if err := r.updatePodConfigHash(ctx, pod, desiredHash); err != nil {
 		log.Error(err, "Failed to update pod config hash after warm restart", "pod", pod.Name)
+		return fmt.Errorf("warm restart succeeded but config hash update failed for pod %s: %w", pod.Name, err)
 	}
 	metrics.WarmRestartsTotal.WithLabelValues(cluster.Namespace, cluster.Name).Inc()
 	r.Recorder.Eventf(cluster, corev1.EventTypeNormal, EventPodWarmRestarted,
@@ -537,6 +580,51 @@ func filterUnrestarted(allPending []string, failedPods []string, restarted int32
 		}
 	}
 	return remaining
+}
+
+// isBatchBlocked returns true when the next restart batch should wait:
+//   - readiness gates are enabled and a previously restarted pod has not yet satisfied its gate, OR
+//   - readiness gates are disabled and a migration check confirms migration is active.
+//
+// Connection failures from migration checks are treated as non-blocking (logged as warnings)
+// to avoid deadlocking the restart when the cluster is temporarily unreachable.
+func (r *AerospikeClusterReconciler) isBatchBlocked(
+	ctx context.Context,
+	cluster *ackov1alpha1.AerospikeCluster,
+	rackID int,
+	rackPods []corev1.Pod,
+) bool {
+	log := logf.FromContext(ctx)
+
+	if isReadinessGateEnabled(cluster) {
+		if blocked, blockedPod := anyPodGateUnsatisfied(cluster, rackPods); blocked {
+			log.Info("Readiness gate not yet satisfied, delaying next restart", "pod", blockedPod, "rack", rackID)
+			r.Recorder.Eventf(cluster, corev1.EventTypeWarning, EventReadinessGateBlocking,
+				"Rolling restart paused: pod %s readiness gate not yet satisfied (rack %d)", blockedPod, rackID)
+			return true
+		}
+		return false
+	}
+
+	// Direct migration check when readiness gates are not enabled.
+	migrating, err := r.isMigrationInProgress(ctx, cluster)
+	if err != nil {
+		// Connection failure: log a warning but proceed. The cluster may be
+		// unreachable during the early phase of a rolling restart (e.g. first pod
+		// is still coming up). Blocking here could deadlock the restart.
+		log.V(1).Info("Migration check failed during rolling restart, proceeding with caution",
+			"error", err, "rack", rackID)
+		r.Recorder.Eventf(cluster, corev1.EventTypeWarning, EventMigrationCheckFailed,
+			"Rolling restart rack %d: migration check failed (%v), proceeding", rackID, err)
+		return false
+	}
+	if migrating {
+		log.Info("Data migration in progress, delaying next restart batch", "rack", rackID)
+		r.Recorder.Eventf(cluster, corev1.EventTypeWarning, EventRollingRestartStarted,
+			"Rolling restart paused for rack %d: data migration in progress", rackID)
+		return true
+	}
+	return false
 }
 
 // podOrdinal extracts the ordinal index from a StatefulSet pod name (e.g., "sts-0" → 0).

--- a/internal/controller/reconciler_statefulset.go
+++ b/internal/controller/reconciler_statefulset.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"strconv"
+	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -112,12 +114,16 @@ func (r *AerospikeClusterReconciler) reconcileStatefulSet(
 	if scaleDown {
 		migrating, err := r.isMigrationInProgress(ctx, cluster)
 		if err != nil {
-			// Connection failure is non-fatal: log the error and proceed with
-			// the scale-down. This avoids permanently blocking the operator
-			// when the Aerospike cluster is unreachable (e.g. during initial deploy).
-			log.V(1).Info("Could not check migration status before scale-down, proceeding cautiously",
+			// Connection failure: treat as migrating to avoid scale-down during
+			// an unreachable cluster state (network blip, DNS delay, etc.).
+			// The operator will requeue and retry.
+			log.V(1).Info("Could not check migration status before scale-down, deferring scale-down",
 				"error", err, "rack", rack.ID)
-		} else if migrating {
+			r.Recorder.Eventf(cluster, corev1.EventTypeWarning, EventScaleDownDeferred,
+				"Scale-down deferred for rack %d: migration check failed (%v)", rack.ID, err)
+			return true, nil
+		}
+		if migrating {
 			log.Info("Data migration in progress, deferring scale-down",
 				"rack", rack.ID, "currentReplicas", oldReplicas, "desiredReplicas", rackSize)
 			r.Recorder.Eventf(cluster, corev1.EventTypeWarning, EventScaleDownDeferred,
@@ -328,6 +334,20 @@ func (r *AerospikeClusterReconciler) cleanupRemovedRacks(
 				log.Error(err, "Failed to delete cascade PVCs for removed rack", "statefulset", sts.Name)
 				r.Recorder.Eventf(cluster, corev1.EventTypeWarning, EventPVCCleanupFailed,
 					"Failed to delete cascade PVCs for removed rack %s: %v", sts.Name, err)
+			}
+			// Delete the associated ConfigMap for the removed rack.
+			// The ConfigMap name is derived from the StatefulSet name suffix (rackID).
+			rackIDStr := strings.TrimPrefix(sts.Name, cluster.Name+"-")
+			if rackID, convErr := strconv.Atoi(rackIDStr); convErr == nil {
+				cmName := utils.ConfigMapName(cluster.Name, rackID)
+				cm := &corev1.ConfigMap{}
+				if getErr := r.Get(ctx, types.NamespacedName{Name: cmName, Namespace: cluster.Namespace}, cm); getErr == nil {
+					if delErr := r.Delete(ctx, cm); delErr != nil && !errors.IsNotFound(delErr) {
+						log.Error(delErr, "Failed to delete ConfigMap for removed rack", "configmap", cmName)
+					} else {
+						log.Info("Deleted ConfigMap for removed rack", "configmap", cmName)
+					}
+				}
 			}
 			if err := r.Delete(ctx, sts); err != nil && !errors.IsNotFound(err) {
 				return err

--- a/internal/controller/reconciler_status.go
+++ b/internal/controller/reconciler_status.go
@@ -338,6 +338,8 @@ func buildPodStatus(
 	lastRestartReason := prev.LastRestartReason
 	lastRestartTime := prev.LastRestartTime
 	migratingPartitions := prev.MigratingPartitions
+	dynamicConfigStatus := prev.DynamicConfigStatus
+	initializedVolumes := prev.InitializedVolumes
 
 	// Track pod instability: set UnstableSince on first NotReady, preserve it
 	// while still NotReady, clear it when the pod becomes Ready.
@@ -372,6 +374,8 @@ func buildPodStatus(
 		LastRestartTime:        lastRestartTime,
 		UnstableSince:          unstableSince,
 		MigratingPartitions:    migratingPartitions,
+		DynamicConfigStatus:    dynamicConfigStatus,
+		InitializedVolumes:     initializedVolumes,
 	}
 }
 
@@ -440,6 +444,18 @@ func setCondition(cluster *ackov1alpha1.AerospikeCluster, condType string, statu
 	cluster.Status.Conditions = append(cluster.Status.Conditions, newCond)
 }
 
+// removeCondition removes a condition from the cluster's status conditions slice.
+// No-op if the condition is not present.
+func removeCondition(cluster *ackov1alpha1.AerospikeCluster, condType string) {
+	conditions := cluster.Status.Conditions[:0]
+	for _, c := range cluster.Status.Conditions {
+		if c.Type != condType {
+			conditions = append(conditions, c)
+		}
+	}
+	cluster.Status.Conditions = conditions
+}
+
 // setFineGrainedConditions sets all fine-grained status conditions:
 // ConfigApplied, ReconciliationPaused, ACLSynced, MigrationComplete.
 // Called from updateStatusAndPhase after populateStatus.
@@ -465,7 +481,7 @@ func setFineGrainedConditions(cluster *ackov1alpha1.AerospikeCluster, o StatusUp
 	setCondition(cluster, ackov1alpha1.ConditionReconciliationPaused, o.Paused,
 		"ReconciliationPaused", "Reconciliation is paused by user (spec.paused=true)")
 
-	// ACLSynced — only set if ACL is configured
+	// ACLSynced — only set if ACL is configured; cleared when ACL is removed.
 	if cluster.Spec.AerospikeAccessControl != nil {
 		if o.ACLErr != nil {
 			setCondition(cluster, ackov1alpha1.ConditionACLSynced, false,
@@ -477,16 +493,20 @@ func setFineGrainedConditions(cluster *ackov1alpha1.AerospikeCluster, o StatusUp
 			setCondition(cluster, ackov1alpha1.ConditionACLSynced, false,
 				"ACLSyncPending", "ACL sync skipped: no ready pods available")
 		}
+	} else {
+		// ACL was removed: clear any stale ACLSynced condition to avoid confusion.
+		removeCondition(cluster, ackov1alpha1.ConditionACLSynced)
 	}
 
-	// MigrationComplete — set to False while rolling restart is in progress.
-	// When phase == Completed, updateMigrationStatus → applyMigrationStats will
-	// overwrite this condition with the actual migration state from the Aerospike
-	// cluster. We still set it here so that non-Completed phases (e.g., RollingRestart)
-	// always have a MigrationComplete=False condition.
+	// MigrationComplete — set to False while rolling restart is in progress,
+	// True otherwise as a default. When phase == Completed, updateMigrationStatus
+	// → applyMigrationStats will overwrite this with the actual cluster migration state.
 	if o.RestartInProgress {
 		setCondition(cluster, ackov1alpha1.ConditionMigrationComplete, false,
 			"MigrationComplete", "Rolling restart in progress")
+	} else {
+		setCondition(cluster, ackov1alpha1.ConditionMigrationComplete, true,
+			"MigrationComplete", "No rolling restart in progress")
 	}
 }
 

--- a/internal/storage/pvc.go
+++ b/internal/storage/pvc.go
@@ -155,6 +155,9 @@ func DeletePVCsForStatefulSet(ctx context.Context, c client.Client, namespace, s
 
 	for i := range pvcs {
 		if err := c.Delete(ctx, &pvcs[i]); err != nil {
+			if kerrors.IsNotFound(err) {
+				continue // already deleted (concurrent deletion)
+			}
 			return fmt.Errorf("deleting PVC %s: %w", pvcs[i].Name, err)
 		}
 	}


### PR DESCRIPTION
## Summary

코드베이스 안정성 분석을 통해 발견된 데이터 손실 위험, 상태 관리 버그, 방어적 개선 사항을 3개 Phase로 수정합니다.

### Phase 1 — Critical Safety (데이터 손실 방지)

- **Scale-down 차단 강화**: `IsMigratingOnAnyNode`가 에러 시 `(true, err)`를 반환하도록 변경. Aerospike에 도달 불가 시 scale-down이 차단됨
- **Rolling restart 배치 간 migration 체크**: `isBatchBlocked` 헬퍼를 추가하여 배치 시작 전 마이그레이션 여부 확인. Readiness gate 비활성화 시에도 마이그레이션 인식 재시작 지원
- **Dynamic config 배치 크기 적용 + 크로스 팟 롤백**: dynamic config 성공도 `attempted` 카운트에 포함. 이후 cold restart 실패 시 이전에 dynamic update된 팟들을 롤백

### Phase 2 — Status/Observability 안정성

- **`buildPodStatus` 필드 보존**: `DynamicConfigStatus`, `InitializedVolumes`가 매 상태 업데이트마다 사라지던 버그 수정
- **Warm restart 무한 루프 방지**: `updatePodConfigHash` 실패 시 에러를 반환하여 재시도 유도
- **ACLSynced 조건 정리**: ACL 제거 시 stale `ACLSynced` 조건 자동 삭제 (`removeCondition` 헬퍼)
- **Requeue 주기 개선**: 마이그레이션 5s→30s, 재시작 5s→15s
- **기존 버그 수정**: `RestartInProgress=false` 시 `MigrationComplete=True`로 설정되지 않던 문제

### Phase 3 — 방어적 개선

- **Admin user rename lockout 방지**: admin 이름 변경 시 이전 admin 즉시 삭제 방지 및 경고 이벤트 emit
- **Rack 제거 시 ConfigMap 정리**: orphaned ConfigMap도 함께 삭제
- **PVC NotFound 처리**: 동시 삭제 시 에러 방지
- **`parseMajorVersion` 'v' prefix 처리**: `v8.1.1` 형태 이미지 태그 버전 체크 우회 방지
- **Webhook silent replacement 제거**: `getOrCreateMapSection`이 잘못된 타입 시 에러 반환
- **Logging 설정 오류 에러**: 잘못된 logging 항목 silent skip 대신 에러 반환
- **비정상 팟 타임아웃**: `UnstableSince` 10분 초과 팟은 rolling restart 대상에서 제외

## Test plan

- [x] `make build` — 빌드 성공
- [x] `go test ./...` — 모든 단위 테스트 통과
- [x] `make lint` — lint 0 이슈
- [ ] `make test-e2e` — Kind 클러스터 환경에서 e2e 검증 권장