### PR TITLE
feat(webhook): add network port uniqueness validation and rack batch size warning

### DIFF
--- a/api/v1alpha1/aerospikecluster_webhook.go
+++ b/api/v1alpha1/aerospikecluster_webhook.go
@@ -329,11 +329,18 @@ func (v *AerospikeClusterValidator) validate(cluster *AerospikeCluster) (admissi
 		warnings = append(warnings, storageWarnings...)
 	}
 
+	// Validate network port uniqueness
+	if cluster.Spec.AerospikeConfig != nil {
+		portErrors := v.validateNetworkPortUniqueness(cluster)
+		allErrors = append(allErrors, portErrors...)
+	}
+
 	// Validate replication-factor, work directory, batch size, max unavailable, and operations
 	rfErrors := v.validateReplicationFactor(cluster)
 	allErrors = append(allErrors, rfErrors...)
 	warnings = append(warnings, v.validateWorkDirectory(cluster)...)
 	warnings = append(warnings, v.validateBatchSize(cluster)...)
+	warnings = append(warnings, v.validateRackBatchSize(cluster)...)
 	warnings = append(warnings, v.validateMaxUnavailable(cluster)...)
 	if len(cluster.Spec.Operations) > 0 {
 		allErrors = append(allErrors, v.validateOperations(cluster.Spec.Operations)...)
@@ -1110,4 +1117,83 @@ func (v *AerospikeClusterValidator) validateMonitoring(m *AerospikeMonitoringSpe
 	}
 
 	return errors, warnings
+}
+
+// validateNetworkPortUniqueness checks that service, heartbeat, and fabric ports are distinct.
+func (v *AerospikeClusterValidator) validateNetworkPortUniqueness(cluster *AerospikeCluster) []string {
+	netCfg, ok := cluster.Spec.AerospikeConfig.Value["network"].(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	type portEntry struct {
+		name string
+		port int
+	}
+
+	extractPort := func(section map[string]any) (int, bool) {
+		raw, exists := section["port"]
+		if !exists {
+			return 0, false
+		}
+		switch v := raw.(type) {
+		case int:
+			return v, true
+		case float64:
+			return int(v), true
+		case int64:
+			return int(v), true
+		}
+		return 0, false
+	}
+
+	var ports []portEntry
+	for _, sub := range []string{"service", "heartbeat", "fabric"} {
+		subCfg, ok := netCfg[sub].(map[string]any)
+		if !ok {
+			continue
+		}
+		if port, ok := extractPort(subCfg); ok {
+			ports = append(ports, portEntry{name: sub, port: port})
+		}
+	}
+
+	var errors []string
+	for i := 0; i < len(ports); i++ {
+		for j := i + 1; j < len(ports); j++ {
+			if ports[i].port == ports[j].port {
+				errors = append(errors, fmt.Sprintf(
+					"network port conflict: %s.port and %s.port are both %d",
+					ports[i].name, ports[j].name, ports[i].port))
+			}
+		}
+	}
+	return errors
+}
+
+// validateRackBatchSize warns when a rack-level percentage batch size resolves to 0 pods.
+func (v *AerospikeClusterValidator) validateRackBatchSize(cluster *AerospikeCluster) admission.Warnings {
+	if cluster.Spec.RackConfig == nil || cluster.Spec.RackConfig.RollingUpdateBatchSize == nil {
+		return nil
+	}
+	bs := cluster.Spec.RackConfig.RollingUpdateBatchSize
+	if bs.Type != intstr.String {
+		return nil
+	}
+	s := bs.StrVal
+	numStr, ok := strings.CutSuffix(s, "%")
+	if !ok {
+		return nil
+	}
+	num, err := strconv.Atoi(numStr)
+	if err != nil {
+		return nil
+	}
+	resolved := int(cluster.Spec.Size) * num / 100
+	if resolved == 0 {
+		return admission.Warnings{fmt.Sprintf(
+			"rackConfig.rollingUpdateBatchSize %q resolves to 0 pods for cluster size %d; effective batch size will be clamped to 1",
+			s, cluster.Spec.Size)}
+	}
+	return nil
 }

--- a/api/v1alpha1/webhook_test.go
+++ b/api/v1alpha1/webhook_test.go
@@ -4177,3 +4177,241 @@ func TestValidate_CE8ImageAccepted(t *testing.T) {
 		t.Errorf("expected no error for CE 8 image, got: %v", err)
 	}
 }
+
+// --- Network port uniqueness validation tests ---
+
+func TestValidate_NetworkPortConflict_ServiceAndHeartbeat(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+	cluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:  3,
+			Image: "aerospike:ce-8.1.1.1",
+			AerospikeConfig: &AerospikeConfigSpec{
+				Value: map[string]any{
+					"network": map[string]any{
+						"service":   map[string]any{"port": 3000},
+						"heartbeat": map[string]any{"port": 3000, "mode": "mesh"},
+						"fabric":    map[string]any{"port": 3001},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := v.validate(cluster)
+	if err == nil {
+		t.Fatal("expected error for port conflict, got nil")
+	}
+	if !strings.Contains(err.Error(), "network port conflict") {
+		t.Errorf("expected 'network port conflict' error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "service.port and heartbeat.port") {
+		t.Errorf("expected error to mention service and heartbeat, got: %v", err)
+	}
+}
+
+func TestValidate_NetworkPortConflict_AllThreeSame(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+	cluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:  3,
+			Image: "aerospike:ce-8.1.1.1",
+			AerospikeConfig: &AerospikeConfigSpec{
+				Value: map[string]any{
+					"network": map[string]any{
+						"service":   map[string]any{"port": 3000},
+						"heartbeat": map[string]any{"port": 3000, "mode": "mesh"},
+						"fabric":    map[string]any{"port": 3000},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := v.validate(cluster)
+	if err == nil {
+		t.Fatal("expected error for all ports same, got nil")
+	}
+	// Should report multiple conflicts
+	errStr := err.Error()
+	count := strings.Count(errStr, "network port conflict")
+	if count < 2 {
+		t.Errorf("expected at least 2 port conflict errors when all 3 ports are same, got %d in: %v", count, err)
+	}
+}
+
+func TestValidate_NetworkPortConflict_Float64Ports(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+	// JSON unmarshaling produces float64 for numbers
+	cluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:  3,
+			Image: "aerospike:ce-8.1.1.1",
+			AerospikeConfig: &AerospikeConfigSpec{
+				Value: map[string]any{
+					"network": map[string]any{
+						"service":   map[string]any{"port": float64(3000)},
+						"heartbeat": map[string]any{"port": float64(3000), "mode": "mesh"},
+						"fabric":    map[string]any{"port": float64(3001)},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := v.validate(cluster)
+	if err == nil {
+		t.Fatal("expected error for port conflict with float64 ports, got nil")
+	}
+	if !strings.Contains(err.Error(), "network port conflict") {
+		t.Errorf("expected 'network port conflict' error, got: %v", err)
+	}
+}
+
+func TestValidate_NetworkPortUniqueness_DistinctPorts(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+	cluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:  3,
+			Image: "aerospike:ce-8.1.1.1",
+			AerospikeConfig: &AerospikeConfigSpec{
+				Value: map[string]any{
+					"network": map[string]any{
+						"service":   map[string]any{"port": 3000},
+						"heartbeat": map[string]any{"port": 3002, "mode": "mesh"},
+						"fabric":    map[string]any{"port": 3001},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := v.validate(cluster)
+	if err != nil {
+		t.Errorf("expected no error for distinct ports, got: %v", err)
+	}
+}
+
+func TestValidate_NetworkPortUniqueness_NoNetworkSection(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+	cluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:  3,
+			Image: "aerospike:ce-8.1.1.1",
+			AerospikeConfig: &AerospikeConfigSpec{
+				Value: map[string]any{},
+			},
+		},
+	}
+
+	_, err := v.validate(cluster)
+	if err != nil {
+		t.Errorf("expected no error when network section is absent, got: %v", err)
+	}
+}
+
+// --- Rack batch size percentage warning tests ---
+
+func TestValidate_RackBatchSize_PercentageResolvesToZero(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+	bs := intstr.FromString("10%")
+	cluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:  5,
+			Image: "aerospike:ce-8.1.1.1",
+			RackConfig: &RackConfig{
+				Racks:                  []Rack{{ID: 1}},
+				RollingUpdateBatchSize: &bs,
+			},
+		},
+	}
+
+	warnings, err := v.validate(cluster)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	found := false
+	for _, w := range warnings {
+		if strings.Contains(w, "resolves to 0 pods") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected warning about batch size resolving to 0, got warnings: %v", warnings)
+	}
+}
+
+func TestValidate_RackBatchSize_PercentageResolvesToNonZero(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+	bs := intstr.FromString("50%")
+	cluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:  8,
+			Image: "aerospike:ce-8.1.1.1",
+			RackConfig: &RackConfig{
+				Racks:                  []Rack{{ID: 1}},
+				RollingUpdateBatchSize: &bs,
+			},
+		},
+	}
+
+	warnings, err := v.validate(cluster)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, w := range warnings {
+		if strings.Contains(w, "resolves to 0 pods") {
+			t.Errorf("unexpected rack batch size warning: %v", w)
+		}
+	}
+}
+
+func TestValidate_RackBatchSize_IntegerValue(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+	bs := intstr.FromInt32(2)
+	cluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:  5,
+			Image: "aerospike:ce-8.1.1.1",
+			RackConfig: &RackConfig{
+				Racks:                  []Rack{{ID: 1}},
+				RollingUpdateBatchSize: &bs,
+			},
+		},
+	}
+
+	warnings, err := v.validate(cluster)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, w := range warnings {
+		if strings.Contains(w, "resolves to 0 pods") {
+			t.Errorf("unexpected rack batch size warning for integer value: %v", w)
+		}
+	}
+}
+
+func TestValidate_RackBatchSize_NilRackConfig(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+	cluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:  3,
+			Image: "aerospike:ce-8.1.1.1",
+		},
+	}
+
+	warnings, err := v.validate(cluster)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, w := range warnings {
+		if strings.Contains(w, "resolves to 0 pods") {
+			t.Errorf("unexpected rack batch size warning when rackConfig is nil: %v", w)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- **Network port overlap validation**: Rejects CRs where any two of `network.service.port`, `network.heartbeat.port`, and `network.fabric.port` are equal, preventing runtime mesh formation failures that were previously undetectable at admission time
- **Rack batch size percentage warning**: Warns when `rackConfig.rollingUpdateBatchSize` percentage resolves to 0 pods for the current cluster size (e.g., `"10%"` with 5 nodes), since the runtime silently clamps to 1

Closes #210

## Test plan
- [x] `go build ./...` — passes
- [x] `go vet ./...` — passes
- [x] `make test-unit` — all tests pass (9 new tests added)
- [ ] `make lint` — pre-existing Go version mismatch in CI env, not related to this change
- [ ] E2E tests (`make test-e2e`) — port conflict rejection scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)