### PR TITLE
fix(helm): properly handle storageClassName for UI PostgreSQL PVC

### DIFF
--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/pvc.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/pvc.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   accessModes:
     - {{ .Values.ui.persistence.accessMode }}
-  {{- if .Values.ui.persistence.storageClassName }}
+  {{- if not (kindIs "invalid" .Values.ui.persistence.storageClassName) }}
   storageClassName: {{ .Values.ui.persistence.storageClassName | quote }}
   {{- end }}
   resources:

--- a/charts/aerospike-ce-kubernetes-operator/values.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/values.yaml
@@ -377,8 +377,11 @@ ui:
   persistence:
     # -- Enable persistent storage for the embedded PostgreSQL database
     enabled: true
-    # -- Storage class name (empty = default)
-    storageClassName: ""
+    # -- Storage class name for the PostgreSQL PVC.
+    # null  = use cluster default StorageClass
+    # ""    = disable dynamic provisioning (use pre-provisioned PV)
+    # "name" = use the specified StorageClass (e.g., "rbd-ssd-user", "gp3")
+    storageClassName: null
     # -- Access mode
     accessMode: ReadWriteOnce
     # -- Volume size


### PR DESCRIPTION
## Summary
- PVC 템플릿에서 `null` vs `""` vs 명시적 값을 구분하도록 개선
- `null` (기본값) → storageClassName 생략 → 클러스터 default SC 사용
- `""` → `storageClassName: ""` 명시 → 동적 프로비저닝 비활성화
- `"rbd-ssd-user"` 등 → 해당 SC 사용

default SC가 없는 클러스터에서 PVC가 Pending 상태로 빠지는 문제의 근본 원인 개선.

## Test plan
- [ ] `storageClassName: null` (기본) → default SC가 있는 클러스터에서 PVC Bound 확인
- [ ] `--set ui.persistence.storageClassName=rbd-ssd-user` → 해당 SC로 PVC 생성 확인