### PR TITLE
feat(helm): add ui.k8s.verifySsl for K8S_VERIFY_SSL

### DIFF
--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/configmap.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/configmap.yaml
@@ -18,5 +18,6 @@ data:
   DB_POOL_OVERFLOW: {{ .Values.ui.env.dbPoolOverflow | quote }}
   DB_POOL_TIMEOUT: {{ .Values.ui.env.dbPoolTimeout | quote }}
   K8S_API_TIMEOUT: {{ .Values.ui.env.k8sApiTimeout | quote }}
+  K8S_VERIFY_SSL: {{ .Values.ui.k8s.verifySsl | quote }}
   ENABLE_POSTGRES: {{ .Values.ui.postgresql.enabled | quote }}
 {{- end }}

--- a/charts/aerospike-ce-kubernetes-operator/values.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/values.yaml
@@ -393,6 +393,10 @@ ui:
   k8s:
     # -- Enable Kubernetes cluster management features (Create Cluster)
     enabled: true
+    # -- Verify TLS certificates when connecting to the Kubernetes API server.
+    # Set to false for clusters with self-signed or non-standard CA certificates
+    # (e.g., Missing Authority Key Identifier).
+    verifySsl: true
 
   # =============================================================================
   # Resources


### PR DESCRIPTION
## Summary
- Add `ui.k8s.verifySsl` (default `true`) to values.yaml
- Expose as `K8S_VERIFY_SSL` in UI configmap
- Allows disabling TLS verification for K8s API on clusters with non-standard CA certs

Depends on: aerospike-ce-ecosystem/aerospike-cluster-manager#188