### PR TITLE
fix(helm): add missing rolebindings/roles RBAC to operator ClusterRole

### DIFF
--- a/charts/aerospike-ce-kubernetes-operator/templates/clusterrole-manager.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/clusterrole-manager.yaml
@@ -138,3 +138,16 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - rolebindings
+      - roles
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch


### PR DESCRIPTION
## Summary
- Helm chart's manager ClusterRole was missing `rbac.authorization.k8s.io` → `rolebindings`, `roles` permissions
- Caused operator reconcile to hang at `InProgress` after headless service creation (StatefulSet/Pod never created)
- Restores parity with `config/rbac/role.yaml` (kustomize source already had these rules)

## Root Cause
Operator logs showed repeated `Failed to watch` errors:
```
rolebindings.rbac.authorization.k8s.io is forbidden:
User "system:serviceaccount:aerospike-operator:aerospike-ce-kubernetes-operator"
cannot list resource "rolebindings" in API group "rbac.authorization.k8s.io"
```
The RoleBinding watch (used for ACL reconciliation) failed to start, blocking subsequent reconcile steps.

## Test plan
- [x] \`make run-local\` — fresh Kind cluster deploy with patched chart
- [x] \`kubectl get clusterrole ...-manager -o yaml\` shows \`rolebindings\`/\`roles\` rules
- [x] Operator logs have zero \`forbidden\` errors after startup
- [x] \`kubectl apply\` a minimal AerospikeCluster → reaches \`Completed\` phase with healthy pod (verified: \`HEALTH 1/1\`, \`AVAILABLE True\`, Pod \`Running\`)