### PR TITLE
fix(helm): expose K8S_CA_FILE + backend extraVolumes (#225)

### DIFF
--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/configmap.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/configmap.yaml
@@ -20,6 +20,9 @@ data:
   DB_POOL_TIMEOUT: {{ .Values.ui.env.dbPoolTimeout | quote }}
   K8S_API_TIMEOUT: {{ .Values.ui.env.k8sApiTimeout | quote }}
   K8S_VERIFY_SSL: {{ .Values.ui.k8s.verifySsl | quote }}
+  {{- with .Values.ui.k8s.caFile }}
+  K8S_CA_FILE: {{ . | quote }}
+  {{- end }}
   ENABLE_POSTGRES: {{ .Values.ui.postgresql.enabled | quote }}
   DEFAULT_AEROSPIKE_IMAGE: {{ .Values.aerospikeImages.aerospike | quote }}
   DEFAULT_EXPORTER_IMAGE: {{ .Values.aerospikeImages.exporter | quote }}

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/deployment-backend.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/deployment-backend.yaml
@@ -100,6 +100,10 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.ui.backend.extraVolumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         {{- if .Values.ui.postgresql.enabled }}
         - name: postgres
           image: "{{ .Values.ui.postgresql.image.repository }}:{{ .Values.ui.postgresql.image.tag }}"
@@ -172,7 +176,10 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /var/lib/postgresql/data
+        {{- end }}
+      {{- if or .Values.ui.postgresql.enabled .Values.ui.backend.extraVolumes }}
       volumes:
+        {{- if .Values.ui.postgresql.enabled }}
         - name: data
           {{- if .Values.ui.persistence.enabled }}
           persistentVolumeClaim:
@@ -181,6 +188,10 @@ spec:
           emptyDir: {}
           {{- end }}
         {{- end }}
+        {{- with .Values.ui.backend.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
       {{- with .Values.ui.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/aerospike-ce-kubernetes-operator/values.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/values.yaml
@@ -327,6 +327,24 @@ ui:
       periodSeconds: 5
       timeoutSeconds: 3
       failureThreshold: 30
+    # -- Extra volumes attached to the backend pod. Use together with
+    # `extraVolumeMounts` and `ui.k8s.caFile` to mount a custom CA bundle for
+    # K8s API verification on clusters whose API-server cert lacks the
+    # Authority Key Identifier extension. Example:
+    #   extraVolumes:
+    #     - name: k8s-api-ca
+    #       secret:
+    #         secretName: my-k8s-api-ca
+    #         items:
+    #           - key: ca.crt
+    #             path: ca.crt
+    extraVolumes: []
+    # -- Extra volume mounts on the backend container. Example:
+    #   extraVolumeMounts:
+    #     - name: k8s-api-ca
+    #       mountPath: /etc/ssl/k8s
+    #       readOnly: true
+    extraVolumeMounts: []
 
   # =============================================================================
   # Frontend (legacy Next.js) — port 3000
@@ -500,6 +518,13 @@ ui:
     # Set to false for clusters with self-signed or non-standard CA certificates
     # (e.g., Missing Authority Key Identifier).
     verifySsl: true
+    # -- Path inside the backend container to a custom CA bundle (PEM) used to
+    # verify the K8s API-server certificate. Required on clusters whose
+    # API-server cert is signed by a CA that lacks the Authority Key Identifier
+    # extension — CPython 3.13+ rejects such chains by default. Mount the CA
+    # via `ui.backend.extraVolumes` / `ui.backend.extraVolumeMounts`.
+    # Example: "/etc/ssl/k8s/ca.crt"
+    caFile: ""
 
   # =============================================================================
   # Security Context


### PR DESCRIPTION
## Summary
- Adds `ui.k8s.caFile` and `ui.backend.extraVolumes` / `ui.backend.extraVolumeMounts` so operators can mount a custom CA bundle for K8s API verification.
- Conditionally injects `K8S_CA_FILE` env into the UI ConfigMap (only when set).
- Restructures backend Deployment to emit the `volumes:` block whenever postgres OR `backend.extraVolumes` is configured (previously postgres-gated only — adding extraVolumes alone produced no volumes block).

## Background
Issue #225 second footgun: backend pods cannot reach in-cluster K8s API on clusters whose API-server cert is signed by a CA without the Authority Key Identifier extension, because CPython 3.13+ became strict about AKI (python/cpython#110524). The chart had no switch to mount a custom CA — only `K8S_VERIFY_SSL=false`, which corp policy often forbids.

The cluster-manager image side (`K8S_CA_FILE` support in backend, runtime `BACKEND_URL` proxy in frontend-renewal that fixes the *first* footgun in #225) ships in a separate aerospike-cluster-manager PR. The submodule pointer + image tag bumps will follow once that PR lands.

## Test plan
- [x] `helm lint` passes (pre-existing 63-char Service name warning unchanged)
- [x] `helm template` default values: no `K8S_CA_FILE`, no extra volume rendered
- [x] `helm template` with `ui.k8s.caFile` + extraVolumes + postgres ON: `K8S_CA_FILE` injected; backend volumeMount; both `data` and `k8s-api-ca` rendered under `volumes:`
- [x] `helm template` with `ui.k8s.caFile` + extraVolumes + postgres OFF: backend volumeMount; only `k8s-api-ca` under `volumes:`
- [x] `helm template` with postgres OFF + no extraVolumes: no `volumes:` block emitted at all

Refs aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator#225