### PR TITLE
ci: run e2e on PR (excl. heavy label) and verify golangci-lint pre-commit

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,7 @@ on:
     paths-ignore:
       - '**/*.md'
       - 'docs/**'
+      - 'charts/**'
       - 'config/samples/**'
       - 'tokei.toml'
       - '.tokeignore'
@@ -18,6 +19,7 @@ on:
     paths-ignore:
       - '**/*.md'
       - 'docs/**'
+      - 'charts/**'
       - 'config/samples/**'
       - 'tokei.toml'
       - '.tokeignore'

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -11,6 +11,10 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'charts/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -8,6 +8,9 @@ on:
         description: 'Ginkgo label filter (e.g. "!heavy")'
         required: false
         default: '!heavy'
+  pull_request:
+    branches:
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
@@ -17,6 +20,8 @@ jobs:
   test-e2e:
     name: Run on Ubuntu
     runs-on: ubuntu-latest
+    # Skip on PRs labeled 'heavy' so large/intentional PRs can opt out of e2e cost.
+    if: github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'heavy')
     steps:
       - name: Clone the code
         uses: actions/checkout@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,4 +22,4 @@ repos:
         language: system
         types: [go]
         pass_filenames: false
-        exclude: '^aerospike-cluster-manager/'
+        # Scoping is enforced by the explicit package list in `entry`; pass_filenames=false makes `exclude` a no-op.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,11 @@ repos:
     hooks:
       - id: golangci-lint
         name: golangci-lint
-        entry: make lint-fix
+        # Build the custom golangci-lint binary (logcheck plugin) via make, then lint
+        # only first-party Go packages — skipping stray Go files under the
+        # aerospike-cluster-manager submodule (e.g. node_modules vendor trees).
+        entry: bash -c 'make golangci-lint && bin/golangci-lint run --fix ./api/... ./cmd/... ./internal/... ./test/...'
         language: system
         types: [go]
         pass_filenames: false
+        exclude: '^aerospike-cluster-manager/'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ make generate           # Generate DeepCopy methods
 make test               # Unit + envtest integration tests (excludes e2e)
 make lint               # golangci-lint
 make lint-fix           # golangci-lint with auto-fix
+pre-commit run golangci-lint --all-files   # run the same lint via the pre-commit hook
 make docker-build       # Build container image (IMG=ghcr.io/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator:latest)
 make install            # Install CRDs into current k8s cluster
 make deploy             # Deploy operator to current k8s cluster


### PR DESCRIPTION
## Summary
- Add `pull_request` trigger to `.github/workflows/test-e2e.yml`, gated by the `heavy` label so opt-out remains possible.
- Repair the golangci-lint pre-commit hook to scope lint to first-party packages (excludes a stray `.go` file in submodule's `node_modules` tree).
- Document the local invocation in CLAUDE.md.

## Test plan
- [ ] Verify e2e workflow triggers on PR opening (without `heavy` label).
- [ ] Apply `heavy` label to a PR and confirm e2e job is skipped.
- [ ] Run `pre-commit run golangci-lint --all-files` locally — passes.
- [ ] CI lint job stays green.