### PR TITLE
feat(api): add AerospikePhaseBackoffActive for clearer circuit-breaker state

### DIFF
--- a/api/v1alpha1/aerospikecluster_types.go
+++ b/api/v1alpha1/aerospikecluster_types.go
@@ -346,7 +346,7 @@ const (
 )
 
 // AerospikePhase represents the current phase of the cluster.
-// +kubebuilder:validation:Enum=InProgress;Completed;Error;ScalingUp;ScalingDown;WaitingForMigration;RollingRestart;ACLSync;Paused;Deleting;ConfigDegraded
+// +kubebuilder:validation:Enum=InProgress;Completed;Error;ScalingUp;ScalingDown;WaitingForMigration;RollingRestart;ACLSync;Paused;Deleting;ConfigDegraded;BackoffActive
 type AerospikePhase string
 
 const (
@@ -376,6 +376,10 @@ const (
 	// leaving some pods with inconsistent configuration. The operator will attempt
 	// cold restart recovery on the next reconcile.
 	AerospikePhaseConfigDegraded AerospikePhase = "ConfigDegraded"
+	// AerospikePhaseBackoffActive indicates the reconciler has hit the
+	// failed-reconcile threshold and is paused in exponential backoff.
+	// The cluster is not actively reconciling until backoff expires.
+	AerospikePhaseBackoffActive AerospikePhase = "BackoffActive"
 )
 
 // RestartReason describes why a pod was restarted by the operator.

--- a/charts/aerospike-ce-kubernetes-operator-crds/templates/aerospikecluster-crd.yaml
+++ b/charts/aerospike-ce-kubernetes-operator-crds/templates/aerospikecluster-crd.yaml
@@ -17377,6 +17377,7 @@ spec:
                     - Paused
                     - Deleting
                     - ConfigDegraded
+                    - BackoffActive
                     type: string
                 type: object
               operatorVersion:
@@ -17405,6 +17406,7 @@ spec:
                 - Paused
                 - Deleting
                 - ConfigDegraded
+                - BackoffActive
                 type: string
               phaseReason:
                 description: |-

--- a/config/crd/bases/acko.io_aerospikeclusters.yaml
+++ b/config/crd/bases/acko.io_aerospikeclusters.yaml
@@ -17376,6 +17376,7 @@ spec:
                     - Paused
                     - Deleting
                     - ConfigDegraded
+                    - BackoffActive
                     type: string
                 type: object
               operatorVersion:
@@ -17404,6 +17405,7 @@ spec:
                 - Paused
                 - Deleting
                 - ConfigDegraded
+                - BackoffActive
                 type: string
               phaseReason:
                 description: |-

--- a/internal/controller/reconciler.go
+++ b/internal/controller/reconciler.go
@@ -178,6 +178,15 @@ func (r *AerospikeClusterReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		r.Recorder.Eventf(cluster, corev1.EventTypeWarning, EventCircuitBreakerActive,
 			"Circuit breaker active after %d consecutive failures, backing off %v. Last error: %s",
 			cluster.Status.FailedReconcileCount, backoff, cluster.Status.LastReconcileError)
+		// Surface backoff state on the CR so users can distinguish it from a
+		// transient InProgress retry. The next successful reconcile restores
+		// the appropriate phase via the regular setPhase calls.
+		backoffReason := fmt.Sprintf("Circuit breaker active after %d consecutive failures; backing off %v",
+			cluster.Status.FailedReconcileCount, backoff)
+		if phaseErr := r.setPhase(ctx, cluster, ackov1alpha1.AerospikePhaseBackoffActive, backoffReason); phaseErr != nil {
+			log.Error(phaseErr, "Failed to set phase to BackoffActive")
+			// Non-fatal: still requeue with backoff so the circuit breaker behavior is preserved.
+		}
 		return ctrl.Result{RequeueAfter: backoff}, nil
 	}
 	metrics.CircuitBreakerActive.WithLabelValues(cluster.Namespace, cluster.Name).Set(0)

--- a/internal/controller/reconciler.go
+++ b/internal/controller/reconciler.go
@@ -169,33 +169,7 @@ func (r *AerospikeClusterReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	// Circuit breaker: if consecutive failures exceed threshold, back off exponentially.
 	if cluster.Status.FailedReconcileCount >= maxFailedReconciles {
-		backoff := calculateBackoff(cluster.Status.FailedReconcileCount)
-		log.Info("Circuit breaker active, backing off",
-			"failedCount", cluster.Status.FailedReconcileCount,
-			"backoff", backoff,
-			"lastError", cluster.Status.LastReconcileError)
-		metrics.CircuitBreakerActive.WithLabelValues(cluster.Namespace, cluster.Name).Set(1)
-		r.Recorder.Eventf(cluster, corev1.EventTypeWarning, EventCircuitBreakerActive,
-			"Circuit breaker active after %d consecutive failures, backing off %v. Last error: %s",
-			cluster.Status.FailedReconcileCount, backoff, cluster.Status.LastReconcileError)
-		// Surface backoff state on the CR so users can distinguish it from a
-		// transient InProgress retry. The next successful reconcile restores
-		// the appropriate phase via the regular setPhase calls.
-		//
-		// Only transition the phase the first time we enter the backoff window;
-		// otherwise every requeue while in backoff would update Status (the
-		// reason string contains the dynamic failure count + backoff duration,
-		// breaking the equality short-circuit in setPhase) and put unnecessary
-		// pressure on the API server.
-		if cluster.Status.Phase != ackov1alpha1.AerospikePhaseBackoffActive {
-			backoffReason := fmt.Sprintf("Circuit breaker active after %d consecutive failures; backing off %v",
-				cluster.Status.FailedReconcileCount, backoff)
-			if phaseErr := r.setPhase(ctx, cluster, ackov1alpha1.AerospikePhaseBackoffActive, backoffReason); phaseErr != nil {
-				log.Error(phaseErr, "Failed to set phase to BackoffActive")
-				// Non-fatal: still requeue with backoff so the circuit breaker behavior is preserved.
-			}
-		}
-		return ctrl.Result{RequeueAfter: backoff}, nil
+		return r.handleCircuitBreakerBackoff(ctx, cluster), nil
 	}
 	metrics.CircuitBreakerActive.WithLabelValues(cluster.Namespace, cluster.Name).Set(0)
 
@@ -265,6 +239,49 @@ func (r *AerospikeClusterReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	}
 
 	return result, nil
+}
+
+// handleCircuitBreakerBackoff is invoked when the circuit breaker has tripped
+// (consecutive failures >= maxFailedReconciles). It records metrics/events,
+// surfaces the BackoffActive phase on the CR (only on first entry to avoid
+// API churn), and returns a requeue Result with exponential backoff.
+//
+// Phase update failures are intentionally swallowed (logged only) so that the
+// circuit-breaker requeue is preserved even when status writes fail.
+func (r *AerospikeClusterReconciler) handleCircuitBreakerBackoff(
+	ctx context.Context,
+	cluster *ackov1alpha1.AerospikeCluster,
+) ctrl.Result {
+	log := logf.FromContext(ctx)
+
+	backoff := calculateBackoff(cluster.Status.FailedReconcileCount)
+	log.Info("Circuit breaker active, backing off",
+		"failedCount", cluster.Status.FailedReconcileCount,
+		"backoff", backoff,
+		"lastError", cluster.Status.LastReconcileError)
+	metrics.CircuitBreakerActive.WithLabelValues(cluster.Namespace, cluster.Name).Set(1)
+	r.Recorder.Eventf(cluster, corev1.EventTypeWarning, EventCircuitBreakerActive,
+		"Circuit breaker active after %d consecutive failures, backing off %v. Last error: %s",
+		cluster.Status.FailedReconcileCount, backoff, cluster.Status.LastReconcileError)
+
+	// Surface backoff state on the CR so users can distinguish it from a
+	// transient InProgress retry. The next successful reconcile restores
+	// the appropriate phase via the regular setPhase calls.
+	//
+	// Only transition the phase the first time we enter the backoff window;
+	// otherwise every requeue while in backoff would update Status (the
+	// reason string contains the dynamic failure count + backoff duration,
+	// breaking the equality short-circuit in setPhase) and put unnecessary
+	// pressure on the API server.
+	if cluster.Status.Phase != ackov1alpha1.AerospikePhaseBackoffActive {
+		backoffReason := fmt.Sprintf("Circuit breaker active after %d consecutive failures; backing off %v",
+			cluster.Status.FailedReconcileCount, backoff)
+		if phaseErr := r.setPhase(ctx, cluster, ackov1alpha1.AerospikePhaseBackoffActive, backoffReason); phaseErr != nil {
+			log.Error(phaseErr, "Failed to set phase to BackoffActive")
+			// Non-fatal: still requeue with backoff so the circuit breaker behavior is preserved.
+		}
+	}
+	return ctrl.Result{RequeueAfter: backoff}
 }
 
 // resolveTemplate handles template resolution, snapshot persistence, and annotation cleanup.

--- a/internal/controller/reconciler.go
+++ b/internal/controller/reconciler.go
@@ -181,11 +181,19 @@ func (r *AerospikeClusterReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		// Surface backoff state on the CR so users can distinguish it from a
 		// transient InProgress retry. The next successful reconcile restores
 		// the appropriate phase via the regular setPhase calls.
-		backoffReason := fmt.Sprintf("Circuit breaker active after %d consecutive failures; backing off %v",
-			cluster.Status.FailedReconcileCount, backoff)
-		if phaseErr := r.setPhase(ctx, cluster, ackov1alpha1.AerospikePhaseBackoffActive, backoffReason); phaseErr != nil {
-			log.Error(phaseErr, "Failed to set phase to BackoffActive")
-			// Non-fatal: still requeue with backoff so the circuit breaker behavior is preserved.
+		//
+		// Only transition the phase the first time we enter the backoff window;
+		// otherwise every requeue while in backoff would update Status (the
+		// reason string contains the dynamic failure count + backoff duration,
+		// breaking the equality short-circuit in setPhase) and put unnecessary
+		// pressure on the API server.
+		if cluster.Status.Phase != ackov1alpha1.AerospikePhaseBackoffActive {
+			backoffReason := fmt.Sprintf("Circuit breaker active after %d consecutive failures; backing off %v",
+				cluster.Status.FailedReconcileCount, backoff)
+			if phaseErr := r.setPhase(ctx, cluster, ackov1alpha1.AerospikePhaseBackoffActive, backoffReason); phaseErr != nil {
+				log.Error(phaseErr, "Failed to set phase to BackoffActive")
+				// Non-fatal: still requeue with backoff so the circuit breaker behavior is preserved.
+			}
 		}
 		return ctrl.Result{RequeueAfter: backoff}, nil
 	}
@@ -400,13 +408,22 @@ func (r *AerospikeClusterReconciler) resetFailedReconcileCount(
 		return err
 	}
 
-	if latest.Status.FailedReconcileCount == 0 && latest.Status.LastReconcileError == "" {
+	wasInBackoff := latest.Status.Phase == ackov1alpha1.AerospikePhaseBackoffActive
+	if latest.Status.FailedReconcileCount == 0 && latest.Status.LastReconcileError == "" && !wasInBackoff {
 		return nil
 	}
 
 	prevCount := latest.Status.FailedReconcileCount
 	latest.Status.FailedReconcileCount = 0
 	latest.Status.LastReconcileError = ""
+	// If the cluster was sitting in BackoffActive, transition it back to
+	// InProgress so the next successful path (or the same reconcile loop's
+	// updateStatusAndPhase) can advance it to Completed without leaving a
+	// stale BackoffActive phase visible to users.
+	if wasInBackoff {
+		latest.Status.Phase = ackov1alpha1.AerospikePhaseInProgress
+		latest.Status.PhaseReason = "Recovering from circuit breaker backoff"
+	}
 	setCondition(latest, ackov1alpha1.ConditionReconcileHealthy, true,
 		"ReconcileSucceeded", "Reconciliation succeeded")
 
@@ -416,6 +433,10 @@ func (r *AerospikeClusterReconciler) resetFailedReconcileCount(
 
 	cluster.Status.FailedReconcileCount = 0
 	cluster.Status.LastReconcileError = ""
+	if wasInBackoff {
+		cluster.Status.Phase = ackov1alpha1.AerospikePhaseInProgress
+		cluster.Status.PhaseReason = "Recovering from circuit breaker backoff"
+	}
 
 	log.Info("Circuit breaker counter reset after successful reconcile", "previousFailedCount", prevCount)
 	if prevCount >= maxFailedReconciles {

--- a/internal/controller/reconciler.go
+++ b/internal/controller/reconciler.go
@@ -695,11 +695,20 @@ func (r *AerospikeClusterReconciler) getRackSize(cluster *ackov1alpha1.Aerospike
 // setPhase re-fetches the latest cluster object and updates its phase and reason.
 // Uses RetryOnConflict to handle transient conflict errors without requiring
 // a full requeue cycle.
+//
+// Also updates the acko_cluster_phase Prometheus gauge whenever Status is
+// mutated, so phase transitions driven by setPhase (e.g. BackoffActive,
+// ScalingUp, RollingRestart) show up in metrics. updateStatusAndPhase
+// already updates the same gauge, so its callers continue to work unchanged.
+// Idempotency: if the phase/reason/pending-pods are already what we want,
+// we skip both the Status().Update AND the metric Set to avoid double-counting
+// from rapid reconciles (e.g. while the circuit breaker is in BackoffActive).
 func (r *AerospikeClusterReconciler) setPhase(ctx context.Context, cluster *ackov1alpha1.AerospikeCluster, phase ackov1alpha1.AerospikePhase, reason string) error {
 	desiredPendingRestartPods := slices.Clone(cluster.Status.PendingRestartPods)
 	nn := types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}
 
 	var latestRV string
+	var statusUpdated bool
 	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		latest, fetchErr := r.refetchCluster(ctx, nn)
 		if fetchErr != nil {
@@ -720,10 +729,19 @@ func (r *AerospikeClusterReconciler) setPhase(ctx context.Context, cluster *acko
 			return err
 		}
 		latestRV = latest.ResourceVersion
+		statusUpdated = true
 		return nil
 	})
 	if err != nil {
 		return err
+	}
+
+	// Update the cluster_phase gauge only when Status was actually mutated.
+	// See PhaseToFloat (internal/metrics/metrics.go) for the source of truth
+	// mapping phase strings to gauge values.
+	if statusUpdated {
+		metrics.ClusterPhase.WithLabelValues(cluster.Namespace, cluster.Name).
+			Set(metrics.PhaseToFloat(string(phase)))
 	}
 
 	// Propagate the updated resource version back to the caller's object

--- a/internal/controller/reconciler_circuit_breaker_test.go
+++ b/internal/controller/reconciler_circuit_breaker_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -13,6 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/metrics"
 	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/utils"
 )
 
@@ -458,6 +460,81 @@ func TestAerospikePhaseBackoffActiveConstantValue(t *testing.T) {
 	if ackov1alpha1.AerospikePhaseBackoffActive != "BackoffActive" {
 		t.Errorf("AerospikePhaseBackoffActive = %q, want %q",
 			ackov1alpha1.AerospikePhaseBackoffActive, "BackoffActive")
+	}
+}
+
+// TestBackoffActivePhaseUpdatesMetric exercises the gap discovered during
+// kind-cluster validation: when the circuit breaker drives the cluster into
+// BackoffActive via setPhase, the acko_cluster_phase gauge must reflect
+// PhaseToFloat("BackoffActive") (=11). Before the fix, setPhase did
+// Status().Update() directly without calling metrics.ClusterPhase.Set,
+// leaving the gauge stuck at whatever the previous phase was — meaning
+// the BackoffActive phase value was unreachable in production metrics.
+func TestBackoffActivePhaseUpdatesMetric(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := ackov1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme() error = %v", err)
+	}
+
+	stored := &ackov1alpha1.AerospikeCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "metric-demo",
+			Namespace:  "default",
+			Finalizers: []string{utils.StorageFinalizer},
+		},
+		Status: ackov1alpha1.AerospikeClusterStatus{
+			Phase:                ackov1alpha1.AerospikePhaseInProgress,
+			PhaseReason:          "Reconciliation started",
+			FailedReconcileCount: maxFailedReconciles,
+			LastReconcileError:   "validation error: bad config",
+		},
+	}
+
+	reconciler := &AerospikeClusterReconciler{
+		Client: fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithStatusSubresource(&ackov1alpha1.AerospikeCluster{}).
+			WithObjects(stored).
+			Build(),
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+	}
+
+	// Reset the gauge to a known non-target value so we can verify the
+	// transition wrote the BackoffActive value (and not just inherited it).
+	metrics.ClusterPhase.WithLabelValues(stored.Namespace, stored.Name).
+		Set(metrics.PhaseToFloat(string(ackov1alpha1.AerospikePhaseInProgress)))
+	t.Cleanup(func() {
+		metrics.ClusterPhase.DeleteLabelValues(stored.Namespace, stored.Name)
+	})
+
+	if _, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: stored.Name, Namespace: stored.Namespace},
+	}); err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+
+	updated := &ackov1alpha1.AerospikeCluster{}
+	if err := reconciler.Get(
+		context.Background(),
+		types.NamespacedName{Name: stored.Name, Namespace: stored.Namespace},
+		updated,
+	); err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if updated.Status.Phase != ackov1alpha1.AerospikePhaseBackoffActive {
+		t.Fatalf("precondition: Phase = %q, want %q (test driver did not hit the circuit-breaker branch)",
+			updated.Status.Phase, ackov1alpha1.AerospikePhaseBackoffActive)
+	}
+
+	gotGauge := testutil.ToFloat64(metrics.ClusterPhase.WithLabelValues(stored.Namespace, stored.Name))
+	wantGauge := metrics.PhaseToFloat(string(ackov1alpha1.AerospikePhaseBackoffActive))
+	if gotGauge != wantGauge {
+		t.Errorf("acko_cluster_phase = %v, want %v (BackoffActive); setPhase must update the gauge",
+			gotGauge, wantGauge)
+	}
+	if wantGauge != 11 {
+		t.Errorf("PhaseToFloat(BackoffActive) = %v, want 11 (regression: enum value drifted)", wantGauge)
 	}
 }
 

--- a/internal/controller/reconciler_circuit_breaker_test.go
+++ b/internal/controller/reconciler_circuit_breaker_test.go
@@ -1,10 +1,14 @@
 package controller
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
 )
@@ -223,6 +227,77 @@ func TestValidationErrorSetsMaxFailedReconciles(t *testing.T) {
 	expectedBackoff := calculateBackoff(maxFailedReconciles)
 	if backoff != expectedBackoff {
 		t.Errorf("backoff = %v, want %v", backoff, expectedBackoff)
+	}
+}
+
+func TestCircuitBreakerSetsBackoffActivePhase(t *testing.T) {
+	// When the circuit breaker activates (FailedReconcileCount >= maxFailedReconciles),
+	// setPhase should transition the cluster to AerospikePhaseBackoffActive instead of
+	// leaving a stale InProgress phase.
+	scheme := runtime.NewScheme()
+	if err := ackov1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme() error = %v", err)
+	}
+
+	stored := &ackov1alpha1.AerospikeCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "default",
+		},
+		Status: ackov1alpha1.AerospikeClusterStatus{
+			Phase:                ackov1alpha1.AerospikePhaseInProgress,
+			PhaseReason:          "Reconciliation started",
+			FailedReconcileCount: maxFailedReconciles,
+			LastReconcileError:   "validation error: bad config",
+		},
+	}
+
+	reconciler := &AerospikeClusterReconciler{
+		Client: fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithStatusSubresource(&ackov1alpha1.AerospikeCluster{}).
+			WithObjects(stored).
+			Build(),
+		Scheme: scheme,
+	}
+
+	cluster := stored.DeepCopy()
+	if err := reconciler.setPhase(
+		context.Background(),
+		cluster,
+		ackov1alpha1.AerospikePhaseBackoffActive,
+		"Circuit breaker active after 10 consecutive failures; backing off 4m16s",
+	); err != nil {
+		t.Fatalf("setPhase() error = %v", err)
+	}
+
+	updated := &ackov1alpha1.AerospikeCluster{}
+	if err := reconciler.Get(
+		context.Background(),
+		types.NamespacedName{Name: stored.Name, Namespace: stored.Namespace},
+		updated,
+	); err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+
+	if updated.Status.Phase != ackov1alpha1.AerospikePhaseBackoffActive {
+		t.Errorf("Phase = %q, want %q", updated.Status.Phase, ackov1alpha1.AerospikePhaseBackoffActive)
+	}
+	if updated.Status.PhaseReason == "" {
+		t.Error("PhaseReason should not be empty after BackoffActive transition")
+	}
+	// The circuit breaker counter should still be at the threshold; it is only reset
+	// on the next successful reconcile.
+	if updated.Status.FailedReconcileCount != maxFailedReconciles {
+		t.Errorf("FailedReconcileCount = %d, want %d (counter must persist while backoff is active)",
+			updated.Status.FailedReconcileCount, maxFailedReconciles)
+	}
+}
+
+func TestAerospikePhaseBackoffActiveConstantValue(t *testing.T) {
+	if ackov1alpha1.AerospikePhaseBackoffActive != "BackoffActive" {
+		t.Errorf("AerospikePhaseBackoffActive = %q, want %q",
+			ackov1alpha1.AerospikePhaseBackoffActive, "BackoffActive")
 	}
 }
 

--- a/internal/controller/reconciler_circuit_breaker_test.go
+++ b/internal/controller/reconciler_circuit_breaker_test.go
@@ -8,9 +8,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/utils"
 )
 
 func TestCalculateBackoff(t *testing.T) {
@@ -230,10 +233,11 @@ func TestValidationErrorSetsMaxFailedReconciles(t *testing.T) {
 	}
 }
 
-func TestCircuitBreakerSetsBackoffActivePhase(t *testing.T) {
-	// When the circuit breaker activates (FailedReconcileCount >= maxFailedReconciles),
-	// setPhase should transition the cluster to AerospikePhaseBackoffActive instead of
-	// leaving a stale InProgress phase.
+// TestCircuitBreakerReconcileSetsBackoffActivePhase drives the actual
+// Reconcile() entry point with a CR seeded at the failure threshold and
+// asserts that the circuit-breaker branch fires and transitions the phase
+// to BackoffActive (rather than leaving a stale InProgress).
+func TestCircuitBreakerReconcileSetsBackoffActivePhase(t *testing.T) {
 	scheme := runtime.NewScheme()
 	if err := ackov1alpha1.AddToScheme(scheme); err != nil {
 		t.Fatalf("AddToScheme() error = %v", err)
@@ -241,8 +245,9 @@ func TestCircuitBreakerSetsBackoffActivePhase(t *testing.T) {
 
 	stored := &ackov1alpha1.AerospikeCluster{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "demo",
-			Namespace: "default",
+			Name:       "demo",
+			Namespace:  "default",
+			Finalizers: []string{utils.StorageFinalizer},
 		},
 		Status: ackov1alpha1.AerospikeClusterStatus{
 			Phase:                ackov1alpha1.AerospikePhaseInProgress,
@@ -258,17 +263,18 @@ func TestCircuitBreakerSetsBackoffActivePhase(t *testing.T) {
 			WithStatusSubresource(&ackov1alpha1.AerospikeCluster{}).
 			WithObjects(stored).
 			Build(),
-		Scheme: scheme,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
 	}
 
-	cluster := stored.DeepCopy()
-	if err := reconciler.setPhase(
-		context.Background(),
-		cluster,
-		ackov1alpha1.AerospikePhaseBackoffActive,
-		"Circuit breaker active after 10 consecutive failures; backing off 4m16s",
-	); err != nil {
-		t.Fatalf("setPhase() error = %v", err)
+	res, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: stored.Name, Namespace: stored.Namespace},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+	if res.RequeueAfter <= 0 {
+		t.Errorf("Reconcile() RequeueAfter = %v, want > 0 (circuit breaker should requeue with backoff)", res.RequeueAfter)
 	}
 
 	updated := &ackov1alpha1.AerospikeCluster{}
@@ -291,6 +297,160 @@ func TestCircuitBreakerSetsBackoffActivePhase(t *testing.T) {
 	if updated.Status.FailedReconcileCount != maxFailedReconciles {
 		t.Errorf("FailedReconcileCount = %d, want %d (counter must persist while backoff is active)",
 			updated.Status.FailedReconcileCount, maxFailedReconciles)
+	}
+}
+
+// TestCircuitBreakerBackoffPhaseIsIdempotent guards the optimization at
+// reconciler.go where setPhase is only called on the *transition* into
+// BackoffActive — not on every requeue while in backoff. Without this guard
+// each requeue would write Status (the reason string contains the dynamic
+// failure count + backoff duration, breaking the equality short-circuit in
+// setPhase) and pressure the API server.
+func TestCircuitBreakerBackoffPhaseIsIdempotent(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := ackov1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme() error = %v", err)
+	}
+
+	stored := &ackov1alpha1.AerospikeCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "demo",
+			Namespace:  "default",
+			Finalizers: []string{utils.StorageFinalizer},
+		},
+		Status: ackov1alpha1.AerospikeClusterStatus{
+			Phase:                ackov1alpha1.AerospikePhaseBackoffActive,
+			PhaseReason:          "Circuit breaker active after 10 consecutive failures; backing off 4m16s",
+			FailedReconcileCount: maxFailedReconciles,
+			LastReconcileError:   "validation error: bad config",
+		},
+	}
+
+	reconciler := &AerospikeClusterReconciler{
+		Client: fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithStatusSubresource(&ackov1alpha1.AerospikeCluster{}).
+			WithObjects(stored).
+			Build(),
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+	}
+
+	// Capture the resourceVersion before the requeue.
+	before := &ackov1alpha1.AerospikeCluster{}
+	if err := reconciler.Get(
+		context.Background(),
+		types.NamespacedName{Name: stored.Name, Namespace: stored.Namespace},
+		before,
+	); err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	beforeRV := before.ResourceVersion
+
+	if _, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: stored.Name, Namespace: stored.Namespace},
+	}); err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+
+	after := &ackov1alpha1.AerospikeCluster{}
+	if err := reconciler.Get(
+		context.Background(),
+		types.NamespacedName{Name: stored.Name, Namespace: stored.Namespace},
+		after,
+	); err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+
+	// If the reconciler had called Status().Update on the requeue, the fake
+	// client would have bumped the resourceVersion. The idempotency fix means
+	// we should observe the same resourceVersion.
+	if after.ResourceVersion != beforeRV {
+		t.Errorf("ResourceVersion changed (%q -> %q): reconciler issued a Status().Update while already in BackoffActive; setPhase should only fire on transition",
+			beforeRV, after.ResourceVersion)
+	}
+	if after.Status.Phase != ackov1alpha1.AerospikePhaseBackoffActive {
+		t.Errorf("Phase = %q, want %q (should remain BackoffActive)", after.Status.Phase, ackov1alpha1.AerospikePhaseBackoffActive)
+	}
+}
+
+// TestBackoffActivePhaseClearsOnSuccessfulReconcile ensures that once a
+// cluster is sitting in BackoffActive, a successful "recovery" path
+// (resetFailedReconcileCount) clears the counter and transitions the phase
+// off of BackoffActive (back to InProgress) so a subsequent
+// updateStatusAndPhase can advance it to Completed without leaving a stale
+// BackoffActive phase visible to users.
+func TestBackoffActivePhaseClearsOnSuccessfulReconcile(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := ackov1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme() error = %v", err)
+	}
+
+	stored := &ackov1alpha1.AerospikeCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "demo",
+			Namespace:  "default",
+			Finalizers: []string{utils.StorageFinalizer},
+			Generation: 1,
+		},
+		Status: ackov1alpha1.AerospikeClusterStatus{
+			Phase:                ackov1alpha1.AerospikePhaseBackoffActive,
+			PhaseReason:          "Circuit breaker active after 10 consecutive failures; backing off 4m16s",
+			FailedReconcileCount: maxFailedReconciles,
+			LastReconcileError:   "validation error: bad config",
+			ObservedGeneration:   1,
+		},
+	}
+
+	reconciler := &AerospikeClusterReconciler{
+		Client: fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithStatusSubresource(&ackov1alpha1.AerospikeCluster{}).
+			WithObjects(stored).
+			Build(),
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+	}
+
+	cluster := stored.DeepCopy()
+	if err := reconciler.resetFailedReconcileCount(context.Background(), cluster); err != nil {
+		t.Fatalf("resetFailedReconcileCount() error = %v", err)
+	}
+
+	updated := &ackov1alpha1.AerospikeCluster{}
+	if err := reconciler.Get(
+		context.Background(),
+		types.NamespacedName{Name: stored.Name, Namespace: stored.Namespace},
+		updated,
+	); err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+
+	if updated.Status.FailedReconcileCount != 0 {
+		t.Errorf("FailedReconcileCount = %d, want 0", updated.Status.FailedReconcileCount)
+	}
+	if updated.Status.LastReconcileError != "" {
+		t.Errorf("LastReconcileError = %q, want empty", updated.Status.LastReconcileError)
+	}
+	if updated.Status.Phase == ackov1alpha1.AerospikePhaseBackoffActive {
+		t.Errorf("Phase = %q, should not remain BackoffActive after successful reset",
+			updated.Status.Phase)
+	}
+	// The successful recovery transitions back to InProgress; the next
+	// updateStatusAndPhase call in the same reconcile loop advances it to
+	// Completed. We don't try to drive a full successful reconcile here
+	// (which would require many sub-reconciler dependencies), so we just
+	// assert the post-reset phase.
+	if updated.Status.Phase != ackov1alpha1.AerospikePhaseInProgress {
+		t.Errorf("Phase = %q, want %q after recovery from BackoffActive",
+			updated.Status.Phase, ackov1alpha1.AerospikePhaseInProgress)
+	}
+	// Also propagated to the in-memory cluster object passed in.
+	if cluster.Status.FailedReconcileCount != 0 {
+		t.Errorf("in-memory FailedReconcileCount = %d, want 0", cluster.Status.FailedReconcileCount)
+	}
+	if cluster.Status.Phase != ackov1alpha1.AerospikePhaseInProgress {
+		t.Errorf("in-memory Phase = %q, want %q", cluster.Status.Phase, ackov1alpha1.AerospikePhaseInProgress)
 	}
 }
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -6,12 +6,15 @@ import (
 )
 
 var (
-	// ClusterPhase reports the current phase of each AerospikeCluster.
-	// Values: 0=Unknown, 1=InProgress, 2=Completed, 3=Error
+	// ClusterPhase reports the current phase of each AerospikeCluster as a
+	// numeric gauge. The full string-to-float mapping is defined by
+	// PhaseToFloat in this package (see below) — keep that function as the
+	// single source of truth instead of enumerating phases in the Help text,
+	// which goes stale every time a phase is added.
 	ClusterPhase = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "acko_cluster_phase",
-			Help: "Current phase of the AerospikeCluster (0=Unknown, 1=InProgress, 2=Completed, 3=Error)",
+			Help: "Current phase of the AerospikeCluster as a numeric code; see metrics.PhaseToFloat for the full string-to-value mapping.",
 		},
 		[]string{"namespace", "name"},
 	)

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -191,6 +191,8 @@ func PhaseToFloat(phase string) float64 {
 		return 9
 	case "Deleting":
 		return 10
+	case "BackoffActive":
+		return 11
 	default:
 		return 0
 	}

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -22,6 +22,7 @@ func TestPhaseToFloat(t *testing.T) {
 		{"ACLSync", 8},
 		{"Paused", 9},
 		{"Deleting", 10},
+		{"BackoffActive", 11},
 		{"", 0},
 		{"Unknown", 0},
 	}


### PR DESCRIPTION
## Summary
- Add `AerospikePhaseBackoffActive` constant to `api/v1alpha1`.
- Reconciler sets this phase when `FailedReconcileCount >= maxFailedReconciles` (instead of leaving stale `InProgress`); the next successful reconcile restores the appropriate phase.
- CRD `phase` enum extended with `BackoffActive` (manifests regenerated).
- Unit tests cover the transition and constant value.

## Test plan
- [ ] `make test-unit` — passes (verified locally).
- [ ] `make test-integration` — passes (verified locally).
- [ ] Deploy to kind cluster, simulate repeated reconcile failure (e.g., bad config), observe `kubectl get aerospikecluster -o yaml` shows `status.phase: BackoffActive`.
- [ ] Recovery: clear failure → next reconcile transitions phase back.