### PR TITLE
feat: independent UI/API toggles + OTel & logging wiring (chart 0.3.0)

### DIFF
--- a/charts/aerospike-ce-kubernetes-operator/Chart.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: aerospike-ce-kubernetes-operator
 description: Kubernetes Operator for Aerospike Community Edition clusters
 type: application
-version: 0.2.0
-appVersion: "0.2.0"
+version: 0.3.0
+appVersion: "0.3.0"
 kubeVersion: ">=1.26.0-0"
 home: https://github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator
 sources:

--- a/charts/aerospike-ce-kubernetes-operator/README.md
+++ b/charts/aerospike-ce-kubernetes-operator/README.md
@@ -114,6 +114,105 @@ kubectl port-forward svc/<release-name>-acko-ui 3000:3000 -n aerospike-operator
 # Open http://localhost:3000
 ```
 
+#### Independent api / web toggles (chart 0.3.0+)
+
+The Cluster Manager ships as two Deployments — `api` (FastAPI) and `web`
+(Next.js). When `ui.enabled=true`, the per-component sub-toggles
+`ui.api.enabled` and `ui.web.enabled` (both defaulting to true) decide
+which Deployments are created. This lets you run API-only or Web-only
+modes without forking the chart.
+
+```yaml
+# API only — Swagger / CLI / external UI talks to the API directly
+ui:
+  enabled: true
+  web:
+    enabled: false
+
+# Web only — point the web frontend at an external API instance
+ui:
+  enabled: true
+  api:
+    enabled: false
+  web:
+    enabled: true
+    env:
+      apiUrl: "https://my-asm-api.example.com"
+```
+
+#### OpenTelemetry (chart 0.3.0+)
+
+Enable OTel export via SDK-standard env vars surfaced as chart values:
+
+```yaml
+ui:
+  api:
+    otel:
+      enabled: true
+      endpoint: "http://otel-collector.observability.svc.cluster.local:4317"
+      protocol: grpc                                # or http/protobuf
+      sampler: parentbased_traceidratio
+      samplerArg: "1.0"
+      serviceName: aerospike-cluster-manager-api
+      resourceAttributes: "deployment.environment=staging,team=platform"
+      headers: ""
+```
+
+When `ui.api.otel.enabled=false` (default), the deployment sets
+`OTEL_SDK_DISABLED=true` and the API uses NoOp providers — zero overhead.
+
+#### Pluggable log handlers (chart 0.3.0+)
+
+Forward API logs to NELO, Datadog, Loki, Sentry, or any
+`logging.Handler` without rebuilding the upstream image. Either the
+`extraPipPackages` init-container path or a custom image works:
+
+```yaml
+ui:
+  api:
+    extraPipPackages:
+      - "pynelo>=1.0.0"
+    logging:
+      handlers: "pynelo:AsyncNeloHandler"
+    extraEnv:
+      - name: NELO_HOST
+        value: "nelo-collector.svc.cluster.local"
+    extraEnvFrom:
+      - secretRef:
+          name: nelo-token
+```
+
+For more elaborate routing (multiple handlers, formatters, filters), the
+`ui.api.logging.dictConfig` value is written to a ConfigMap, mounted at
+`/etc/asm/logging.yaml`, and applied via `logging.config.dictConfig`:
+
+```yaml
+ui:
+  api:
+    logging:
+      dictConfig:
+        version: 1
+        disable_existing_loggers: false
+        formatters:
+          json:
+            "()": pythonjsonlogger.json.JsonFormatter
+            fmt: "%(asctime)s %(levelname)s %(name)s %(message)s %(otelTraceID)s"
+        handlers:
+          console:
+            class: logging.StreamHandler
+            formatter: json
+        loggers:
+          aerospike_cluster_manager_api:
+            level: INFO
+            handlers: [console]
+            propagate: false
+```
+
+See [docs/observability.md](https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager/blob/main/docs/observability.md)
+and [docs/logging.md](https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager/blob/main/docs/logging.md)
+in the cluster-manager repo for the full reference, including airgap and
+constraint notes.
+
 #### Customizing the UI deployment
 
 You can customize the UI with service annotations, resource defaults, and extra environment variables:

--- a/charts/aerospike-ce-kubernetes-operator/templates/NOTES.txt
+++ b/charts/aerospike-ce-kubernetes-operator/templates/NOTES.txt
@@ -6,6 +6,10 @@ Ensure acko-crds is installed separately before creating AerospikeCluster resour
   helm install acko-crds oci://ghcr.io/aerospike-ce-ecosystem/charts/acko-crds --version {{ .Chart.Version }}
 {{- end }}
 
+NOTE: 0.3.0 adds independent ui.api.enabled / ui.web.enabled toggles
+(both default to true). API-only and Web-only deployments are now
+first-class. Existing 0.2.0 values produce the same output unchanged.
+
 NOTE: 0.2.0 introduces a breaking rename of the UI value keys.
   ui.backend.*           -> ui.api.*
   ui.frontend.*          -> REMOVED (legacy frontend deleted)
@@ -94,8 +98,16 @@ Namespace: {{ .Release.Namespace }}
   Aerospike Cluster Manager (Web UI)
 ------------------------------------------------------------------------
 
-The Aerospike Cluster Manager UI is ENABLED.
+The Aerospike Cluster Manager is ENABLED ({{ if (eq (include "aerospike-ce-kubernetes-operator.ui.api.enabled" .) "true") }}api={{ end }}{{ if and (eq (include "aerospike-ce-kubernetes-operator.ui.api.enabled" .) "true") (eq (include "aerospike-ce-kubernetes-operator.ui.web.enabled" .) "true") }}, {{ end }}{{ if (eq (include "aerospike-ce-kubernetes-operator.ui.web.enabled" .) "true") }}web={{ end }}).
 
+{{- if and (ne (include "aerospike-ce-kubernetes-operator.ui.api.enabled" .) "true") (ne (include "aerospike-ce-kubernetes-operator.ui.web.enabled" .) "true") }}
+
+WARNING: ui.enabled=true but both ui.api.enabled and ui.web.enabled are false.
+No UI components will be deployed. Either set ui.enabled=false to skip the UI
+entirely, or enable at least one of ui.api.enabled / ui.web.enabled.
+{{- end }}
+
+{{- if eq (include "aerospike-ce-kubernetes-operator.ui.web.enabled" .) "true" }}
 {{- if .Values.ui.ingress.enabled }}
 
 Access the UI via Ingress:
@@ -114,10 +126,22 @@ Then open http://localhost:{{ .Values.ui.web.service.port }} in your browser.
 
 {{- end }}
 
+{{- if and (ne (include "aerospike-ce-kubernetes-operator.ui.api.enabled" .) "true") (not .Values.ui.web.env.apiUrl) }}
+
+WARNING: ui.web.enabled=true but ui.api.enabled=false and ui.web.env.apiUrl
+is empty. The web frontend will fail to reach an API. Set
+ui.web.env.apiUrl to your external API endpoint.
+{{- end }}
+
+{{- end }}
+
+{{- if eq (include "aerospike-ce-kubernetes-operator.ui.api.enabled" .) "true" }}
+
 Verify the API is running:
 
   kubectl port-forward svc/{{ include "aerospike-ce-kubernetes-operator.ui.api.fullname" . }} 8000:{{ .Values.ui.api.service.port }} -n {{ .Release.Namespace }}
   curl http://localhost:8000/api/health
+{{- end }}
 
 {{- if .Values.ui.k8s.enabled }}
 

--- a/charts/aerospike-ce-kubernetes-operator/templates/_helpers.tpl
+++ b/charts/aerospike-ce-kubernetes-operator/templates/_helpers.tpl
@@ -228,3 +228,35 @@ UI image helpers (per-component).
 {{- define "aerospike-ce-kubernetes-operator.ui.web.image" -}}
 {{- printf "%s:%s" .Values.ui.web.image.repository (.Values.ui.web.image.tag | toString) -}}
 {{- end }}
+
+{{/*
+UI component enablement.
+
+`ui.enabled` is the master switch (false → no UI resources at all). When
+ui.enabled is true, ui.api.enabled / ui.web.enabled act as independent
+sub-toggles so an operator can deploy API-only (when an external UI talks
+to the FastAPI backend) or Web-only (when ui.web.env.apiUrl points to an
+external API instance).
+
+Defaults: both api.enabled and web.enabled are true, so the existing
+chart 0.2.x deployment behavior is preserved exactly when only ui.enabled
+is set in user values.
+*/}}
+{{- define "aerospike-ce-kubernetes-operator.ui.api.enabled" -}}
+{{- and .Values.ui.enabled .Values.ui.api.enabled -}}
+{{- end }}
+
+{{- define "aerospike-ce-kubernetes-operator.ui.web.enabled" -}}
+{{- and .Values.ui.enabled .Values.ui.web.enabled -}}
+{{- end }}
+
+{{/*
+UI service names (used by web → api routing and by NOTES output).
+*/}}
+{{- define "aerospike-ce-kubernetes-operator.ui.api.serviceName" -}}
+{{- include "aerospike-ce-kubernetes-operator.ui.api.fullname" . -}}
+{{- end }}
+
+{{- define "aerospike-ce-kubernetes-operator.ui.web.serviceName" -}}
+{{- include "aerospike-ce-kubernetes-operator.ui.web.fullname" . -}}
+{{- end }}

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/clusterrole.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.ui.enabled .Values.ui.rbac.create .Values.ui.k8s.enabled }}
+{{- if and (eq (include "aerospike-ce-kubernetes-operator.ui.api.enabled" .) "true") .Values.ui.rbac.create .Values.ui.k8s.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/clusterrolebinding.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.ui.enabled .Values.ui.rbac.create .Values.ui.k8s.enabled }}
+{{- if and (eq (include "aerospike-ce-kubernetes-operator.ui.api.enabled" .) "true") .Values.ui.rbac.create .Values.ui.k8s.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/configmap.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/configmap.yaml
@@ -11,8 +11,11 @@ data:
   LOG_LEVEL: {{ .Values.ui.env.logLevel | quote }}
   LOG_FORMAT: {{ .Values.ui.env.logFormat | quote }}
   K8S_MANAGEMENT_ENABLED: {{ .Values.ui.k8s.enabled | quote }}
-  # ui/proxy.js (and Next.js dev rewrites) consume this to forward /api/* to the API Service.
-  API_URL: {{ printf "http://%s:%d" (include "aerospike-ce-kubernetes-operator.ui.api.fullname" .) (int .Values.ui.api.service.port) | quote }}
+  # ui/proxy.js (and Next.js dev rewrites) consume this to forward /api/* to
+  # the API Service. When ui.web.env.apiUrl is set, the web container talks
+  # to an external API instead of the in-cluster Service — required when
+  # ui.api.enabled=false but ui.web.enabled=true.
+  API_URL: {{ if .Values.ui.web.env.apiUrl }}{{ .Values.ui.web.env.apiUrl | quote }}{{ else }}{{ printf "http://%s:%d" (include "aerospike-ce-kubernetes-operator.ui.api.fullname" .) (int .Values.ui.api.service.port) | quote }}{{ end }}
   WEB_PORT: {{ .Values.ui.web.service.port | quote }}
   API_PORT: {{ .Values.ui.api.service.targetPort | quote }}
   DB_POOL_SIZE: {{ .Values.ui.env.dbPoolSize | quote }}
@@ -26,4 +29,17 @@ data:
   ENABLE_POSTGRES: {{ .Values.ui.postgresql.enabled | quote }}
   DEFAULT_AEROSPIKE_IMAGE: {{ .Values.aerospikeImages.aerospike | quote }}
   DEFAULT_EXPORTER_IMAGE: {{ .Values.aerospikeImages.exporter | quote }}
+{{- end }}
+{{- if and (eq (include "aerospike-ce-kubernetes-operator.ui.api.enabled" .) "true") .Values.ui.api.logging.dictConfig }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "aerospike-ce-kubernetes-operator.ui.api.fullname" . }}-logging
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "aerospike-ce-kubernetes-operator.ui.api.labels" . | nindent 4 }}
+data:
+  logging.yaml: |
+{{ toYaml .Values.ui.api.logging.dictConfig | indent 4 }}
 {{- end }}

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/deployment-api.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/deployment-api.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ui.enabled }}
+{{- if eq (include "aerospike-ce-kubernetes-operator.ui.api.enabled" .) "true" }}
 {{- if and .Values.ui.autoscaling.enabled .Values.ui.postgresql.enabled }}
 {{- fail "ui.autoscaling.enabled and ui.postgresql.enabled cannot both be true. The embedded PostgreSQL sidecar is single-instance only. Disable ui.postgresql.enabled and provide ui.env.databaseUrl for an external database when using HPA." }}
 {{- end }}
@@ -59,6 +59,22 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.ui.terminationGracePeriodSeconds | default 45 }}
+      {{- if .Values.ui.api.extraPipPackages }}
+      initContainers:
+        - name: install-extra-packages
+          image: {{ include "aerospike-ce-kubernetes-operator.ui.api.image" . }}
+          imagePullPolicy: {{ .Values.ui.api.image.pullPolicy }}
+          command:
+            - sh
+            - -c
+            - |
+              set -e
+              pip install --target=/extra-packages --no-cache-dir \
+              {{- range .Values.ui.api.extraPipPackages }} {{ . | quote }}{{- end }}
+          volumeMounts:
+            - name: extra-packages
+              mountPath: /extra-packages
+      {{- end }}
       containers:
         - name: api
           image: {{ include "aerospike-ce-kubernetes-operator.ui.api.image" . }}
@@ -72,10 +88,56 @@ spec:
                 name: {{ include "aerospike-ce-kubernetes-operator.ui.fullname" . }}-config
             - secretRef:
                 name: {{ .Values.ui.postgresql.existingSecret | default (printf "%s-db" (include "aerospike-ce-kubernetes-operator.ui.fullname" .)) }}
-          {{- with .Values.ui.extraEnv }}
-          env:
+            {{- with .Values.ui.api.extraEnvFrom }}
             {{- toYaml . | nindent 12 }}
-          {{- end }}
+            {{- end }}
+          env:
+            {{- if .Values.ui.api.extraPipPackages }}
+            - name: PYTHONPATH
+              value: /extra-packages
+            {{- end }}
+            {{- if .Values.ui.api.otel.enabled }}
+            - name: OTEL_SDK_DISABLED
+              value: "false"
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: {{ required "ui.api.otel.endpoint is required when ui.api.otel.enabled is true" .Values.ui.api.otel.endpoint | quote }}
+            - name: OTEL_EXPORTER_OTLP_PROTOCOL
+              value: {{ .Values.ui.api.otel.protocol | quote }}
+            - name: OTEL_TRACES_SAMPLER
+              value: {{ .Values.ui.api.otel.sampler | quote }}
+            - name: OTEL_TRACES_SAMPLER_ARG
+              value: {{ .Values.ui.api.otel.samplerArg | quote }}
+            - name: OTEL_SERVICE_NAME
+              value: {{ .Values.ui.api.otel.serviceName | quote }}
+            {{- with .Values.ui.api.otel.resourceAttributes }}
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.ui.api.otel.headers }}
+            - name: OTEL_EXPORTER_OTLP_HEADERS
+              value: {{ . | quote }}
+            {{- end }}
+            {{- else }}
+            - name: OTEL_SDK_DISABLED
+              value: "true"
+            {{- end }}
+            {{- with .Values.ui.api.logging.handlers }}
+            - name: LOG_HANDLERS
+              value: {{ . | quote }}
+            {{- end }}
+            {{- if .Values.ui.api.logging.dictConfig }}
+            - name: LOGGING_CONFIG_FILE
+              value: /etc/asm/logging.yaml
+            {{- else if .Values.ui.api.logging.configFile }}
+            - name: LOGGING_CONFIG_FILE
+              value: {{ .Values.ui.api.logging.configFile | quote }}
+            {{- end }}
+            {{- with .Values.ui.api.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .Values.ui.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- with .Values.ui.securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
@@ -100,9 +162,21 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.ui.api.extraVolumeMounts }}
+          {{- if or .Values.ui.api.extraVolumeMounts .Values.ui.api.extraPipPackages .Values.ui.api.logging.dictConfig }}
           volumeMounts:
+            {{- with .Values.ui.api.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- if .Values.ui.api.extraPipPackages }}
+            - name: extra-packages
+              mountPath: /extra-packages
+              readOnly: true
+            {{- end }}
+            {{- if .Values.ui.api.logging.dictConfig }}
+            - name: logging-config
+              mountPath: /etc/asm
+              readOnly: true
+            {{- end }}
           {{- end }}
         {{- if .Values.ui.postgresql.enabled }}
         - name: postgres
@@ -177,7 +251,7 @@ spec:
             - name: data
               mountPath: /var/lib/postgresql/data
         {{- end }}
-      {{- if or .Values.ui.postgresql.enabled .Values.ui.api.extraVolumes }}
+      {{- if or .Values.ui.postgresql.enabled .Values.ui.api.extraVolumes .Values.ui.api.extraPipPackages .Values.ui.api.logging.dictConfig }}
       volumes:
         {{- if .Values.ui.postgresql.enabled }}
         - name: data
@@ -190,6 +264,15 @@ spec:
         {{- end }}
         {{- with .Values.ui.api.extraVolumes }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- if .Values.ui.api.extraPipPackages }}
+        - name: extra-packages
+          emptyDir: {}
+        {{- end }}
+        {{- if .Values.ui.api.logging.dictConfig }}
+        - name: logging-config
+          configMap:
+            name: {{ include "aerospike-ce-kubernetes-operator.ui.api.fullname" . }}-logging
         {{- end }}
       {{- end }}
       {{- with .Values.ui.nodeSelector }}

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/deployment-web.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/deployment-web.yaml
@@ -30,6 +30,10 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ include "aerospike-ce-kubernetes-operator.ui.serviceAccountName" . }}
+      # The web pod is a Next.js frontend with no Kubernetes API access requirement.
+      # Mounting the SA token here would only widen attack surface (the SA itself is
+      # shared with the api pod, which does need it for K8S_MANAGEMENT_ENABLED).
+      automountServiceAccountToken: false
       {{- with .Values.ui.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/deployment-web.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/deployment-web.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ui.enabled }}
+{{- if eq (include "aerospike-ce-kubernetes-operator.ui.web.enabled" .) "true" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/hpa.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/hpa.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.ui.enabled .Values.ui.autoscaling.enabled }}
+{{- if and (eq (include "aerospike-ce-kubernetes-operator.ui.web.enabled" .) "true") .Values.ui.autoscaling.enabled }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/ingress.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/ingress.yaml
@@ -2,8 +2,14 @@
 {{- $target := .Values.ui.ingress.target | default "web" -}}
 {{- $targetServiceName := "" -}}
 {{- if eq $target "api" -}}
+{{- if ne (include "aerospike-ce-kubernetes-operator.ui.api.enabled" .) "true" -}}
+{{- fail "ui.ingress.target=api but ui.api.enabled=false (or ui.enabled=false). Either enable the API or change ui.ingress.target to web." -}}
+{{- end -}}
 {{- $targetServiceName = include "aerospike-ce-kubernetes-operator.ui.api.fullname" . -}}
 {{- else if eq $target "web" -}}
+{{- if ne (include "aerospike-ce-kubernetes-operator.ui.web.enabled" .) "true" -}}
+{{- fail "ui.ingress.target=web but ui.web.enabled=false (or ui.enabled=false). Either enable the web or change ui.ingress.target to api." -}}
+{{- end -}}
 {{- $targetServiceName = include "aerospike-ce-kubernetes-operator.ui.web.fullname" . -}}
 {{- else -}}
 {{- fail (printf "ui.ingress.target must be one of: web, api (got %q)" $target) -}}

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/networkpolicy.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/networkpolicy.yaml
@@ -15,10 +15,14 @@ spec:
     - Egress
   ingress:
     - ports:
+        {{- if eq (include "aerospike-ce-kubernetes-operator.ui.api.enabled" .) "true" }}
         - port: {{ .Values.ui.api.service.targetPort }}
           protocol: TCP
+        {{- end }}
+        {{- if eq (include "aerospike-ce-kubernetes-operator.ui.web.enabled" .) "true" }}
         - port: {{ .Values.ui.web.service.port }}
           protocol: TCP
+        {{- end }}
       {{- with .Values.ui.networkPolicy.ingressFrom }}
       from:
         {{- toYaml . | nindent 8 }}

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/pdb.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/pdb.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.ui.enabled .Values.ui.podDisruptionBudget.enabled }}
+{{- if and (eq (include "aerospike-ce-kubernetes-operator.ui.web.enabled" .) "true") .Values.ui.podDisruptionBudget.enabled }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/pvc.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.ui.enabled .Values.ui.persistence.enabled .Values.ui.postgresql.enabled }}
+{{- if and (eq (include "aerospike-ce-kubernetes-operator.ui.api.enabled" .) "true") .Values.ui.persistence.enabled .Values.ui.postgresql.enabled }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/secret.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/secret.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.ui.enabled (not .Values.ui.postgresql.existingSecret) }}
+{{- if and (eq (include "aerospike-ce-kubernetes-operator.ui.api.enabled" .) "true") (not .Values.ui.postgresql.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/service.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ui.enabled }}
+{{- if eq (include "aerospike-ce-kubernetes-operator.ui.api.enabled" .) "true" }}
 # =============================================================================
 # API Service (port: 80 → targetPort: 8000)
 # =============================================================================
@@ -23,7 +23,11 @@ spec:
       appProtocol: http
   selector:
     {{- include "aerospike-ce-kubernetes-operator.ui.api.selectorLabels" . | nindent 4 }}
+{{- end }}
+{{- if eq (include "aerospike-ce-kubernetes-operator.ui.web.enabled" .) "true" }}
+{{- if eq (include "aerospike-ce-kubernetes-operator.ui.api.enabled" .) "true" }}
 ---
+{{- end }}
 # =============================================================================
 # Web Service (Next.js) — port 3100
 # =============================================================================

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/servicemonitor.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.ui.enabled .Values.ui.metrics.serviceMonitor.enabled }}
+{{- if and (eq (include "aerospike-ce-kubernetes-operator.ui.api.enabled" .) "true") .Values.ui.metrics.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/tests/test-api-connectivity.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/tests/test-api-connectivity.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.ui.enabled .Values.ui.tests.enabled }}
+{{- if and (eq (include "aerospike-ce-kubernetes-operator.ui.api.enabled" .) "true") .Values.ui.tests.enabled }}
 apiVersion: v1
 kind: Pod
 metadata:

--- a/charts/aerospike-ce-kubernetes-operator/values.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/values.yaml
@@ -273,7 +273,13 @@ podLabels: {}
 # =============================================================================
 ui:
   # -- Enable the Aerospike Cluster Manager web UI.
-  # Deploys the 2-Deployment dashboard (api + web) alongside the operator.
+  # Master switch — when false, neither api nor web is deployed regardless of
+  # the per-component `api.enabled` / `web.enabled` toggles below. When true,
+  # those toggles act as independent on/off switches:
+  #   ui.enabled=true,  api.enabled=true,  web.enabled=true   (default) → both
+  #   ui.enabled=true,  api.enabled=true,  web.enabled=false           → API only (use Swagger / external UI)
+  #   ui.enabled=true,  api.enabled=false, web.enabled=true            → Web only (point web.env.apiUrl at an external API)
+  #   ui.enabled=false, *,                  *                           → operator only
   # Access via:
   #   kubectl port-forward svc/<release>-aerospike-ce-kubernetes-operator-ui-web 3100:3100
   enabled: true
@@ -288,6 +294,10 @@ ui:
   # API (FastAPI) — port 8000 internally, Service port 80
   # =============================================================================
   api:
+    # -- Deploy the API component when ui.enabled is also true.
+    # Set to false to deploy only the web frontend (then set
+    # `ui.web.env.apiUrl` to your external API endpoint).
+    enabled: true
     image:
       repository: ghcr.io/aerospike-ce-ecosystem/aerospike-cluster-manager-api
       tag: "latest"
@@ -346,10 +356,98 @@ ui:
     #       readOnly: true
     extraVolumeMounts: []
 
+    # -- Extra environment variables passed to the api container.
+    # Useful for plugin handler configuration (NELO_HOST, NELO_PROJECT_TOKEN, etc.)
+    # Example:
+    #   extraEnv:
+    #     - name: NELO_HOST
+    #       value: "nelo-collector.svc.cluster.local"
+    extraEnv: []
+
+    # -- envFrom entries (configMapRef / secretRef) for bulk env injection.
+    # Example:
+    #   extraEnvFrom:
+    #     - secretRef:
+    #         name: nelo-token
+    extraEnvFrom: []
+
+    # -- Additional Python packages installed by an init container into a
+    # PYTHONPATH-mounted volume so plugin log handlers (pynelo, ddtrace, ...)
+    # can be loaded without rebuilding the upstream image.
+    #
+    # Limitations: requires PyPI egress from the cluster, adds pod-startup
+    # latency, may break with C extensions whose ABI mismatches the runtime
+    # base image (python:3.14-slim by default). For airgap / locked-down
+    # environments, build a custom image (FROM upstream + RUN pip install)
+    # and override `image.repository` instead.
+    extraPipPackages: []
+
+    # =============================================================================
+    # OpenTelemetry — opt-in observability (off by default).
+    # All exporter / sampler / resource configuration goes through OTel SDK
+    # standard environment variables. The chart only surfaces the ones needed
+    # for the typical "send everything to a collector" path; see the OTel SDK
+    # spec for the full list.
+    # =============================================================================
+    otel:
+      # -- Enable OpenTelemetry export. When false the deployment sets
+      # OTEL_SDK_DISABLED=true and the API uses NoOp providers.
+      enabled: false
+      # -- OTLP collector endpoint (gRPC: :4317, HTTP/protobuf: :4318)
+      endpoint: ""
+      # -- "grpc" or "http/protobuf"
+      protocol: grpc
+      # -- OTel SDK standard sampler. Common values:
+      #   "parentbased_traceidratio" — child-of-parent + ratio fallback
+      #   "always_on" / "always_off"
+      sampler: parentbased_traceidratio
+      # -- Sampler argument (ratio for traceidratio variants)
+      samplerArg: "1.0"
+      # -- service.name resource attribute
+      serviceName: aerospike-cluster-manager-api
+      # -- Comma-separated extra resource attributes
+      # Example: "deployment.environment=staging,team=platform"
+      resourceAttributes: ""
+      # -- OTLP headers (auth tokens, etc.)
+      # Example: "api-key=xxxxxxxx,x-tenant=foo"
+      headers: ""
+
+    # =============================================================================
+    # Logging — pluggable handlers via LOG_HANDLERS or full dictConfig.
+    # See aerospike-cluster-manager docs/logging.md for examples.
+    # =============================================================================
+    logging:
+      # -- LOG_HANDLERS env value. Comma-separated list of handler specs:
+      # "module.path:ClassName" or entry-point name registered under
+      # "aerospike_cluster_manager.log_handlers".
+      # Example: "pynelo:AsyncNeloHandler"
+      handlers: ""
+      # -- Path to an externally-mounted dictConfig file (when you mount it
+      # via your own ConfigMap / Volume). Mutually exclusive with
+      # `dictConfig` below.
+      configFile: ""
+      # -- dictConfig payload. When non-empty, the chart writes it to a
+      # ConfigMap, mounts it at /etc/asm/logging.yaml, and sets
+      # LOGGING_CONFIG_FILE accordingly. Example:
+      #   dictConfig:
+      #     version: 1
+      #     handlers:
+      #       console:
+      #         class: logging.StreamHandler
+      #     loggers:
+      #       aerospike_cluster_manager_api:
+      #         level: INFO
+      #         handlers: [console]
+      dictConfig: {}
+
   # =============================================================================
   # Web (Next.js 14 + proxy.js sidecar) — port 3100
   # =============================================================================
   web:
+    # -- Deploy the web component when ui.enabled is also true.
+    # Set to false to deploy only the API backend (use Swagger / CLI tools
+    # against the API Service directly).
+    enabled: true
     image:
       repository: ghcr.io/aerospike-ce-ecosystem/aerospike-cluster-manager-ui
       tag: "latest"
@@ -358,6 +456,12 @@ ui:
       type: ClusterIP
       port: 3100
       annotations: {}
+    # -- Web container env. proxy.js reads API_URL to forward /api/* requests.
+    env:
+      # -- External API URL. When set, web's proxy.js forwards /api/* there
+      # instead of the in-cluster API Service. Required when
+      # `ui.api.enabled=false` so the web frontend has somewhere to talk to.
+      apiUrl: ""
     resources:
       requests:
         cpu: 50m


### PR DESCRIPTION
## Summary

Three additive chart capabilities, all behind defaults that preserve the chart 0.2.0 deployment exactly when no new keys are set.

1. **Independent `ui.api.enabled` / `ui.web.enabled` sub-toggles** under the existing `ui.enabled` master switch (both default true). Combinations:
   - `ui.enabled=true, api.enabled=true, web.enabled=true` → both Deployments (default — same as 0.2.0)
   - `ui.enabled=true, api.enabled=true, web.enabled=false` → API only (Swagger / external UI)
   - `ui.enabled=true, api.enabled=false, web.enabled=true` → Web only (set `ui.web.env.apiUrl` to your external API)
   - `ui.enabled=false, *, *` → operator only

2. **OpenTelemetry env wiring** — `ui.api.otel.{enabled,endpoint,protocol,sampler,samplerArg,serviceName,resourceAttributes,headers}` map directly to OTel SDK standard env vars (`OTEL_EXPORTER_OTLP_*`, `OTEL_TRACES_SAMPLER`, `OTEL_RESOURCE_ATTRIBUTES`, `OTEL_SERVICE_NAME`). When `otel.enabled=false` (default), `OTEL_SDK_DISABLED=true` and the API uses NoOp providers — zero overhead.

3. **Pluggable logging** — `ui.api.logging.{handlers,configFile,dictConfig}` surface `LOG_HANDLERS` / `LOGGING_CONFIG_FILE`. When `dictConfig` is non-empty, the chart writes a ConfigMap and mounts it at `/etc/asm/logging.yaml`. `ui.api.extraPipPackages` triggers an init container that pip-installs into an emptyDir mounted at `/extra-packages` with `PYTHONPATH=/extra-packages`, so plugin handlers (pynelo, ddtrace, ...) load without rebuilding the upstream image. `ui.api.extraEnv` / `extraEnvFrom` for handler self-config (NELO_HOST, NELO_PROJECT_TOKEN, ...).

## Commits

1. `feat(chart): independent ui.api / ui.web toggles + OTel + pluggable logging env wiring` — values.yaml + helpers + all template guards (deployment-api/web, service, configmap, ingress, hpa, pdb, networkpolicy, pvc, secret, RBAC, servicemonitor) + NOTES.txt warnings for split modes
2. `chore(chart): bump 0.2.0 → 0.3.0 + README values examples`

## Test plan

- [x] `helm lint charts/aerospike-ce-kubernetes-operator` passes
- [x] `helm template` against six fixture values files:
  - `default` → 3 Deployments, 4 Services (operator + ui-api + ui-web)
  - `api-only` (`ui.web.enabled=false`) → no web Deployment / Service / PDB / HPA
  - `web-only` (`ui.api.enabled=false` + `web.env.apiUrl=...`) → no api Deployment / Service / PVC / Secret / RBAC; `API_URL=http://external-api.example.com:8000`
  - `otel` → 8 `OTEL_*` env vars on the api container
  - `extra-pip` → `install-extra-packages` init container + `PYTHONPATH=/extra-packages` on api
  - `dictconfig` → ConfigMap `<release>-ui-api-logging` mounted at `/etc/asm`, `LOGGING_CONFIG_FILE=/etc/asm/logging.yaml`
- [x] Default values reproduce existing 0.2.0 output (no breaking change)
- [ ] Reviewer: confirm split-mode `ingress.target` failfast logic matches the desired UX (current behaviour: `helm install` errors when `ingress.target=api` but `api.enabled=false`)
- [ ] Reviewer: confirm `extraPipPackages` init container caveats are clearly documented (PyPI egress required, ABI compatibility, startup latency)

## Companion PR

The cluster-manager API code that consumes the env vars wired here lives at: https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager/pull/262 — same author, same time. This chart should pin to that image's release tag once it's published.