### PR TITLE
feat(helm)!: remove redundant ui.enabled master switch (chart 0.4.0)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,6 @@ run-local: manifests helm-sync-crds ## Deploy operator + cluster-manager UI into
 	@echo "==> [6/7] Deploying operator and UI (api only) via Helm..."
 	helm upgrade -i aerospike-ce-kubernetes-operator ./charts/aerospike-ce-kubernetes-operator \
 		-n aerospike-operator --create-namespace \
-		--set ui.enabled=true \
 		--set image.tag=latest \
 		--set ui.api.image.repository=$(CLUSTER_MANAGER_API_IMG) \
 		--set ui.api.image.tag=latest \
@@ -204,7 +203,6 @@ reload-cluster-manager: ## Build operator + cluster-manager api image, load into
 	@echo ">>> [3/5] Upgrading Helm release"
 	helm upgrade aerospike-ce-kubernetes-operator ./charts/aerospike-ce-kubernetes-operator \
 		-n $(CLUSTER_MANAGER_NAMESPACE) --reuse-values \
-		--set ui.enabled=true \
 		--set image.tag=latest \
 		--set ui.api.image.repository=$(CLUSTER_MANAGER_API_IMG) \
 		--set ui.api.image.tag=latest \

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Deploy, scale, and perform rolling updates of Aerospike CE clusters via a custom
 - Pod Disruption Budget for safe maintenance
 - Mesh heartbeat auto-configuration
 - Rack-node selection with zone/region affinity and rackLabel scheduling
-- Optional web UI (Aerospike Cluster Manager) deployable via Helm (`ui.enabled=true`)
+- Optional web UI (Aerospike Cluster Manager) deployable via Helm (enabled by default; toggled via `ui.api.enabled` / `ui.web.enabled`)
 
 ### CE Limitations
 

--- a/charts/aerospike-ce-kubernetes-operator/Chart.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: aerospike-ce-kubernetes-operator
 description: Kubernetes Operator for Aerospike Community Edition clusters
 type: application
-version: 0.3.0
-appVersion: "0.3.0"
+version: 0.4.0
+appVersion: "0.4.0"
 kubeVersion: ">=1.26.0-0"
 home: https://github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator
 sources:

--- a/charts/aerospike-ce-kubernetes-operator/README.md
+++ b/charts/aerospike-ce-kubernetes-operator/README.md
@@ -101,11 +101,23 @@ helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/acko \
 
 ### With Cluster Manager UI
 
+The Cluster Manager UI (api + web) is deployed by default. A plain
+`helm install` of the chart already brings both Deployments up:
+
 ```bash
 helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/acko \
-  --version 0.1.0 \
+  --version 0.4.0 \
+  --namespace aerospike-operator --create-namespace
+```
+
+To skip the UI entirely (operator-only install), set both toggles
+to `false`:
+
+```bash
+helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/acko \
+  --version 0.4.0 \
   --namespace aerospike-operator --create-namespace \
-  --set ui.enabled=true
+  --set ui.api.enabled=false --set ui.web.enabled=false
 ```
 
 Access the UI:
@@ -117,25 +129,23 @@ kubectl port-forward svc/<release-name>-acko-ui 3000:3000 -n aerospike-operator
 #### Independent api / web toggles (chart 0.3.0+)
 
 The Cluster Manager ships as two Deployments — `api` (FastAPI) and `web`
-(Next.js). When `ui.enabled=true`, the per-component sub-toggles
-`ui.api.enabled` and `ui.web.enabled` (both defaulting to true) decide
-which Deployments are created. This lets you run API-only or Web-only
-modes without forking the chart.
+(Next.js). The per-component toggles `ui.api.enabled` and
+`ui.web.enabled` (both defaulting to true) decide which Deployments are
+created. This lets you run API-only or Web-only modes without forking
+the chart. (Chart 0.4.0+: the legacy `ui.enabled` master switch was
+removed — use these two toggles directly.)
 
 ```yaml
 # API only — Swagger / CLI / external UI talks to the API directly
 ui:
-  enabled: true
   web:
     enabled: false
 
 # Web only — point the web frontend at an external API instance
 ui:
-  enabled: true
   api:
     enabled: false
   web:
-    enabled: true
     env:
       apiUrl: "https://my-asm-api.example.com"
 ```
@@ -219,9 +229,8 @@ You can customize the UI with service annotations, resource defaults, and extra 
 
 ```bash
 helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/acko \
-  --version 0.1.0 \
+  --version 0.4.0 \
   --namespace aerospike-operator --create-namespace \
-  --set ui.enabled=true \
   --set ui.service.type=LoadBalancer \
   --set ui.service.annotations."service\.beta\.kubernetes\.io/aws-load-balancer-type"=nlb \
   --set ui.resources.requests.cpu=200m \
@@ -234,7 +243,6 @@ Extra environment variables can be passed via `ui.extraEnv`:
 
 ```yaml
 ui:
-  enabled: true
   extraEnv:
     - name: LOG_LEVEL
       value: DEBUG
@@ -249,14 +257,13 @@ ui:
 
 ```bash
 helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/acko \
-  --version 0.1.0 \
+  --version 0.4.0 \
   --namespace aerospike-operator --create-namespace \
   --set serviceMonitor.enabled=true \
   --set prometheusRule.enabled=true \
   --set grafanaDashboard.enabled=true \
   --set podDisruptionBudget.enabled=true \
-  --set cilium.enabled=true \
-  --set ui.enabled=true
+  --set cilium.enabled=true
 ```
 
 ### GitOps — ArgoCD example

--- a/charts/aerospike-ce-kubernetes-operator/templates/NOTES.txt
+++ b/charts/aerospike-ce-kubernetes-operator/templates/NOTES.txt
@@ -6,15 +6,25 @@ Ensure acko-crds is installed separately before creating AerospikeCluster resour
   helm install acko-crds oci://ghcr.io/aerospike-ce-ecosystem/charts/acko-crds --version {{ .Chart.Version }}
 {{- end }}
 
-NOTE: 0.3.0 adds independent ui.api.enabled / ui.web.enabled toggles
-(both default to true). API-only and Web-only deployments are now
-first-class. Existing 0.2.0 values produce the same output unchanged.
+NOTE: 0.4.0 removes the redundant `ui.enabled` master switch. The
+per-component `ui.api.enabled` / `ui.web.enabled` toggles are now the
+only UI on/off controls.
+  Migration: replace `ui.enabled: false` with both
+    ui.api.enabled: false
+    ui.web.enabled: false
+  Setting either (or both) to true reinstates the corresponding
+  Deployment plus the shared resources (configmap, serviceaccount,
+  ingress, networkpolicy).
+
+NOTE: 0.3.0 added independent ui.api.enabled / ui.web.enabled toggles
+(both default to true). API-only and Web-only deployments are
+first-class.
 
 NOTE: 0.2.0 introduces a breaking rename of the UI value keys.
   ui.backend.*           -> ui.api.*
   ui.frontend.*          -> REMOVED (legacy frontend deleted)
   ui.frontendRenewal.*   -> ui.web.*
-  ui.frontendRenewal.enabled -> REMOVED (web is always deployed when ui.enabled=true)
+  ui.frontendRenewal.enabled -> REMOVED (web is always deployed when at least one UI toggle is on)
   ui.ingress.target enum: frontend|frontendRenewal|backend -> web|api (default: web)
 Selector labels changed (ui-backend -> ui-api, ui-frontend-renewal -> ui-web).
 When upgrading from 0.1.x, uninstall and reinstall the chart — selector mutation
@@ -92,20 +102,13 @@ Namespace: {{ .Release.Namespace }}
    Kubernetes NetworkPolicy is enabled for the operator.
 {{- end }}
 
-{{- if .Values.ui.enabled }}
+{{- if eq (include "aerospike-ce-kubernetes-operator.ui.anyEnabled" .) "true" }}
 
 ------------------------------------------------------------------------
   Aerospike Cluster Manager (Web UI)
 ------------------------------------------------------------------------
 
 The Aerospike Cluster Manager is ENABLED ({{ if (eq (include "aerospike-ce-kubernetes-operator.ui.api.enabled" .) "true") }}api={{ end }}{{ if and (eq (include "aerospike-ce-kubernetes-operator.ui.api.enabled" .) "true") (eq (include "aerospike-ce-kubernetes-operator.ui.web.enabled" .) "true") }}, {{ end }}{{ if (eq (include "aerospike-ce-kubernetes-operator.ui.web.enabled" .) "true") }}web={{ end }}).
-
-{{- if and (ne (include "aerospike-ce-kubernetes-operator.ui.api.enabled" .) "true") (ne (include "aerospike-ce-kubernetes-operator.ui.web.enabled" .) "true") }}
-
-WARNING: ui.enabled=true but both ui.api.enabled and ui.web.enabled are false.
-No UI components will be deployed. Either set ui.enabled=false to skip the UI
-entirely, or enable at least one of ui.api.enabled / ui.web.enabled.
-{{- end }}
 
 {{- if eq (include "aerospike-ce-kubernetes-operator.ui.web.enabled" .) "true" }}
 {{- if .Values.ui.ingress.enabled }}

--- a/charts/aerospike-ce-kubernetes-operator/templates/_helpers.tpl
+++ b/charts/aerospike-ce-kubernetes-operator/templates/_helpers.tpl
@@ -232,22 +232,28 @@ UI image helpers (per-component).
 {{/*
 UI component enablement.
 
-`ui.enabled` is the master switch (false → no UI resources at all). When
-ui.enabled is true, ui.api.enabled / ui.web.enabled act as independent
-sub-toggles so an operator can deploy API-only (when an external UI talks
-to the FastAPI backend) or Web-only (when ui.web.env.apiUrl points to an
-external API instance).
+ui.api.enabled and ui.web.enabled are independent toggles. Set both to
+false to skip the UI entirely (operator-only install). Combinations:
 
-Defaults: both api.enabled and web.enabled are true, so the existing
-chart 0.2.x deployment behavior is preserved exactly when only ui.enabled
-is set in user values.
+  api.enabled=true,  web.enabled=true   (default) → both Deployments
+  api.enabled=true,  web.enabled=false           → API only (Swagger / external UI)
+  api.enabled=false, web.enabled=true            → Web only (point web.env.apiUrl at an external API)
+  api.enabled=false, web.enabled=false           → operator only (no UI resources)
+
+ui.anyEnabled returns "true" when at least one of api/web is on. Used
+to gate UI-shared resources (configmap, serviceaccount, ingress,
+networkpolicy) that are pointless without any UI Deployment.
 */}}
 {{- define "aerospike-ce-kubernetes-operator.ui.api.enabled" -}}
-{{- and .Values.ui.enabled .Values.ui.api.enabled -}}
+{{- .Values.ui.api.enabled -}}
 {{- end }}
 
 {{- define "aerospike-ce-kubernetes-operator.ui.web.enabled" -}}
-{{- and .Values.ui.enabled .Values.ui.web.enabled -}}
+{{- .Values.ui.web.enabled -}}
+{{- end }}
+
+{{- define "aerospike-ce-kubernetes-operator.ui.anyEnabled" -}}
+{{- or .Values.ui.api.enabled .Values.ui.web.enabled -}}
 {{- end }}
 
 {{/*

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/configmap.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ui.enabled }}
+{{- if eq (include "aerospike-ce-kubernetes-operator.ui.anyEnabled" .) "true" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/ingress.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/ingress.yaml
@@ -1,14 +1,14 @@
-{{- if and .Values.ui.enabled .Values.ui.ingress.enabled }}
+{{- if and (eq (include "aerospike-ce-kubernetes-operator.ui.anyEnabled" .) "true") .Values.ui.ingress.enabled }}
 {{- $target := .Values.ui.ingress.target | default "web" -}}
 {{- $targetServiceName := "" -}}
 {{- if eq $target "api" -}}
 {{- if ne (include "aerospike-ce-kubernetes-operator.ui.api.enabled" .) "true" -}}
-{{- fail "ui.ingress.target=api but ui.api.enabled=false (or ui.enabled=false). Either enable the API or change ui.ingress.target to web." -}}
+{{- fail "ui.ingress.target=api but ui.api.enabled=false. Either enable the API or change ui.ingress.target to web." -}}
 {{- end -}}
 {{- $targetServiceName = include "aerospike-ce-kubernetes-operator.ui.api.fullname" . -}}
 {{- else if eq $target "web" -}}
 {{- if ne (include "aerospike-ce-kubernetes-operator.ui.web.enabled" .) "true" -}}
-{{- fail "ui.ingress.target=web but ui.web.enabled=false (or ui.enabled=false). Either enable the web or change ui.ingress.target to api." -}}
+{{- fail "ui.ingress.target=web but ui.web.enabled=false. Either enable the web or change ui.ingress.target to api." -}}
 {{- end -}}
 {{- $targetServiceName = include "aerospike-ce-kubernetes-operator.ui.web.fullname" . -}}
 {{- else -}}

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/networkpolicy.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/networkpolicy.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.ui.enabled .Values.ui.networkPolicy.enabled }}
+{{- if and (eq (include "aerospike-ce-kubernetes-operator.ui.anyEnabled" .) "true") .Values.ui.networkPolicy.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/serviceaccount.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.ui.enabled .Values.ui.serviceAccount.create }}
+{{- if and (eq (include "aerospike-ce-kubernetes-operator.ui.anyEnabled" .) "true") .Values.ui.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/aerospike-ce-kubernetes-operator/values.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/values.yaml
@@ -272,17 +272,14 @@ podLabels: {}
 # provide ui.env.databaseUrl).
 # =============================================================================
 ui:
-  # -- Enable the Aerospike Cluster Manager web UI.
-  # Master switch — when false, neither api nor web is deployed regardless of
-  # the per-component `api.enabled` / `web.enabled` toggles below. When true,
-  # those toggles act as independent on/off switches:
-  #   ui.enabled=true,  api.enabled=true,  web.enabled=true   (default) → both
-  #   ui.enabled=true,  api.enabled=true,  web.enabled=false           → API only (use Swagger / external UI)
-  #   ui.enabled=true,  api.enabled=false, web.enabled=true            → Web only (point web.env.apiUrl at an external API)
-  #   ui.enabled=false, *,                  *                           → operator only
+  # -- Aerospike Cluster Manager web UI deployment toggles.
+  # ui.api.enabled and ui.web.enabled are independent. Combinations:
+  #   api.enabled=true,  web.enabled=true   (default) → both Deployments
+  #   api.enabled=true,  web.enabled=false           → API only (Swagger / external UI)
+  #   api.enabled=false, web.enabled=true            → Web only (point web.env.apiUrl at an external API)
+  #   api.enabled=false, web.enabled=false           → operator only (no UI resources)
   # Access via:
   #   kubectl port-forward svc/<release>-aerospike-ce-kubernetes-operator-ui-web 3100:3100
-  enabled: true
 
   # -- Number of replicas for each UI Deployment (api / web)
   replicaCount: 1
@@ -294,7 +291,7 @@ ui:
   # API (FastAPI) — port 8000 internally, Service port 80
   # =============================================================================
   api:
-    # -- Deploy the API component when ui.enabled is also true.
+    # -- Deploy the API (FastAPI) component.
     # Set to false to deploy only the web frontend (then set
     # `ui.web.env.apiUrl` to your external API endpoint).
     enabled: true
@@ -444,7 +441,7 @@ ui:
   # Web (Next.js 14 + proxy.js sidecar) — port 3100
   # =============================================================================
   web:
-    # -- Deploy the web component when ui.enabled is also true.
+    # -- Deploy the web (Next.js) component.
     # Set to false to deploy only the API backend (use Swagger / CLI tools
     # against the API Service directly).
     enabled: true

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -21,7 +21,7 @@ Production environments often separate the **management cluster** (where the ope
    - Network connectivity requirements between clusters
 
 2. **Management Cluster Setup**
-   - Install ACKO operator with `ui.enabled=true`
+   - Install ACKO operator (UI is on by default; toggle via `ui.api.enabled` / `ui.web.enabled`)
    - Configure RBAC for cross-cluster access
    - kubeconfig / ServiceAccount token management for remote clusters
 

--- a/docs/content/configuration/templates.md
+++ b/docs/content/configuration/templates.md
@@ -445,7 +445,7 @@ kubectl get aerospikeclustertemplate
 
 ## Managing Templates via Cluster Manager UI
 
-When the Cluster Manager UI is enabled (`ui.enabled=true` and `ui.k8s.enabled=true`), templates can be managed from the web interface:
+When the Cluster Manager UI is enabled (default; requires `ui.k8s.enabled=true` for K8s management), templates can be managed from the web interface:
 
 - **Create** -- guided wizard for all template fields
 - **View** -- detail page showing resolved spec and referencing clusters

--- a/docs/content/getting-started/cluster-manager-ui.md
+++ b/docs/content/getting-started/cluster-manager-ui.md
@@ -11,11 +11,16 @@ title: Cluster Manager UI
 
 ## Installation
 
+The Cluster Manager UI (api + web Deployments) is enabled by default in
+chart 0.4.0+. A plain install brings everything up:
+
 ```bash
 helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kubernetes-operator \
-  --namespace aerospike-operator --create-namespace \
-  --set ui.enabled=true
+  --namespace aerospike-operator --create-namespace
 ```
+
+To skip the UI entirely, set both component toggles to false:
+`--set ui.api.enabled=false --set ui.web.enabled=false`.
 
 :::note RBAC permissions
 When `ui.rbac.create=true` (the default), the ClusterRole created by the Helm chart includes full access to `horizontalpodautoscalers` resources in the `autoscaling` API group. This permission is required for the UI to create, view, and delete HPAs.
@@ -521,7 +526,8 @@ After modifying a template, existing clusters that reference it are not automati
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `ui.enabled` | Enable the UI | `false` |
+| `ui.api.enabled` | Deploy the Cluster Manager API (FastAPI). Combine with `ui.web.enabled=false` for both-off (operator-only). | `true` |
+| `ui.web.enabled` | Deploy the Cluster Manager web (Next.js). Combine with `ui.api.enabled=false` for both-off (operator-only). | `true` |
 | `ui.replicaCount` | UI replica count | `1` |
 | `ui.image.repository` | UI container image | `ghcr.io/aerospike-ce-ecosystem/aerospike-cluster-manager` |
 | `ui.image.tag` | Image tag | `latest` |
@@ -578,7 +584,6 @@ Tune the connection pool for the embedded PostgreSQL sidecar or an external Post
 ```bash
 helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kubernetes-operator \
   --namespace aerospike-operator --create-namespace \
-  --set ui.enabled=true \
   --set ui.env.dbPoolSize=10 \
   --set ui.env.dbPoolOverflow=20 \
   --set ui.env.dbPoolTimeout=60
@@ -607,7 +612,6 @@ Configure the timeout for UI requests to the Kubernetes API server:
 # Enable structured JSON logging (recommended when integrating with Loki, Elasticsearch, etc.)
 helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kubernetes-operator \
   --namespace aerospike-operator --create-namespace \
-  --set ui.enabled=true \
   --set ui.env.logFormat=json \
   --set ui.env.logLevel=INFO
 ```
@@ -625,7 +629,6 @@ The ServiceMonitor uses the default Prometheus path `/metrics`. No separate `pat
 ```bash
 helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kubernetes-operator \
   --namespace aerospike-operator --create-namespace \
-  --set ui.enabled=true \
   --set ui.metrics.serviceMonitor.enabled=true \
   --set ui.metrics.serviceMonitor.labels.release=prometheus
 ```

--- a/docs/content/getting-started/install.md
+++ b/docs/content/getting-started/install.md
@@ -87,7 +87,7 @@ make run-local
 4. Build Cluster Manager image
 5. Load both images into the Kind cluster
 6. Install cert-manager
-7. Deploy operator + UI via `helm upgrade -i` with `ui.enabled=true`
+7. Deploy operator + UI via `helm upgrade -i` (UI is on by default)
 
 Once complete, access the UI:
 

--- a/docs/content/operations/troubleshooting.md
+++ b/docs/content/operations/troubleshooting.md
@@ -217,7 +217,7 @@ The operator will clear the annotation after performing the reconciliation. This
 
 **Reset via Aerospike Cluster Manager UI:**
 
-When the integrated UI is enabled (`ui.enabled: true` in Helm values), the Reconciliation Health dashboard shows a **Reset Circuit Breaker** button that triggers the annotation-based reset with a single click.
+When the integrated UI is enabled (default; requires `ui.web.enabled=true`), the Reconciliation Health dashboard shows a **Reset Circuit Breaker** button that triggers the annotation-based reset with a single click.
 
 ## Debugging Commands
 

--- a/docs/content/quickstart.md
+++ b/docs/content/quickstart.md
@@ -69,7 +69,6 @@ helm install cert-manager jetstack/cert-manager \
 helm install aerospike-ce-kubernetes-operator \
   oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kubernetes-operator \
   -n aerospike-operator --create-namespace \
-  --set ui.enabled=true \
   --wait
 ```
 

--- a/docs/content/reference/helm-values.md
+++ b/docs/content/reference/helm-values.md
@@ -149,7 +149,8 @@ The Aerospike Cluster Manager is a full-stack web dashboard deployed alongside t
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `ui.enabled` | bool | `true` | Enable the Aerospike Cluster Manager web UI. |
+| `ui.api.enabled` | bool | `true` | Deploy the Cluster Manager API (FastAPI) component. Set to false together with `ui.web.enabled=false` to skip the UI entirely. |
+| `ui.web.enabled` | bool | `true` | Deploy the Cluster Manager web (Next.js) component. Set to false together with `ui.api.enabled=false` to skip the UI entirely. |
 | `ui.replicaCount` | int | `1` | Number of UI replicas. |
 | `ui.image.repository` | string | `ghcr.io/aerospike-ce-ecosystem/aerospike-cluster-manager` | UI container image repository. |
 | `ui.image.tag` | string | `"latest"` | UI container image tag. UI is versioned independently from the operator. |

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/configuration/templates.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/configuration/templates.md
@@ -405,7 +405,7 @@ kubectl get aerospikeclustertemplate
 
 ## Cluster Manager UI를 통한 템플릿 관리
 
-Cluster Manager UI가 활성화된 경우 (`ui.enabled=true` 및 `ui.k8s.enabled=true`), 웹 인터페이스에서 템플릿을 관리할 수 있습니다:
+Cluster Manager UI가 활성화된 경우 (기본 활성화. K8s 관리 기능에는 `ui.k8s.enabled=true` 필요), 웹 인터페이스에서 템플릿을 관리할 수 있습니다:
 
 - **생성** -- 모든 템플릿 필드를 위한 가이드 마법사
 - **조회** -- 해석된 스펙과 참조 클러스터를 보여주는 상세 페이지

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/getting-started/cluster-manager-ui.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/getting-started/cluster-manager-ui.md
@@ -13,13 +13,16 @@ UI에는 클러스터 연결 프로파일을 저장하기 위한 PostgreSQL 사�
 
 ## 설치
 
-오퍼레이터 설치 시 UI를 활성화합니다.
+차트 0.4.0+에서는 Cluster Manager UI(api + web Deployment)가 기본으로
+배포됩니다. 별도 플래그 없이 설치하면 모두 함께 올라옵니다.
 
 ```bash
 helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kubernetes-operator \
-  --namespace aerospike-operator --create-namespace \
-  --set ui.enabled=true
+  --namespace aerospike-operator --create-namespace
 ```
+
+UI를 완전히 끄려면 두 컴포넌트 토글을 모두 false로 설정합니다:
+`--set ui.api.enabled=false --set ui.web.enabled=false`.
 
 :::note RBAC 권한
 `ui.rbac.create=true`(기본값)일 때, Helm 차트가 생성하는 ClusterRole에는 `autoscaling` API 그룹의 `horizontalpodautoscalers` 리소스에 대한 전체 접근 권한이 포함됩니다. 이 권한은 UI에서 HPA를 생성, 조회, 삭제하는 데 필요합니다.
@@ -57,7 +60,6 @@ kubectl -n aerospike-operator port-forward svc/<릴리스명>-aerospike-ce-kuber
 ```bash
 helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kubernetes-operator \
   --namespace aerospike-operator --create-namespace \
-  --set ui.enabled=true \
   --set ui.ingress.enabled=true \
   --set ui.ingress.className=nginx \
   --set "ui.ingress.hosts[0].host=aerospike-admin.example.com" \
@@ -71,7 +73,8 @@ helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kuber
 
 | 파라미터 | 설명 | 기본값 |
 |----------|------|--------|
-| `ui.enabled` | 클러스터 매니저 UI 활성화 | `false` |
+| `ui.api.enabled` | Cluster Manager API (FastAPI) 컴포넌트 배포. `ui.web.enabled=false`와 함께 false로 설정하면 UI를 완전히 끔 (operator-only). | `true` |
+| `ui.web.enabled` | Cluster Manager web (Next.js) 컴포넌트 배포. `ui.api.enabled=false`와 함께 false로 설정하면 UI를 완전히 끔 (operator-only). | `true` |
 | `ui.replicaCount` | UI 레플리카 수 | `1` |
 | `ui.image.repository` | UI 컨테이너 이미지 | `ghcr.io/aerospike-ce-ecosystem/aerospike-cluster-manager` |
 | `ui.image.tag` | 이미지 태그 (비어 있으면 Chart appVersion 사용) | `""` |
@@ -316,7 +319,6 @@ Aerospike 클러스터에 등록된 사용자 정의 함수(Lua 모듈)를 업�
 ```bash
 helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kubernetes-operator \
   --namespace aerospike-operator --create-namespace \
-  --set ui.enabled=true \
   --set ui.postgresql.enabled=false \
   --set ui.env.databaseUrl="postgresql://user:pass@db-host:5432/aerospike_manager"
 ```
@@ -353,7 +355,6 @@ UI Pod에 대한 트래픽을 제한합니다.
 ```bash
 helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kubernetes-operator \
   --namespace aerospike-operator --create-namespace \
-  --set ui.enabled=true \
   --set ui.networkPolicy.enabled=true
 ```
 
@@ -366,7 +367,6 @@ UI, 모니터링, Ingress를 모두 활성화하여 오퍼레이터를 배포합
 ```bash
 helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kubernetes-operator \
   --namespace aerospike-operator --create-namespace \
-  --set ui.enabled=true \
   --set ui.ingress.enabled=true \
   --set ui.ingress.className=nginx \
   --set "ui.ingress.hosts[0].host=aerospike-admin.example.com" \

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/getting-started/install.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/getting-started/install.md
@@ -383,7 +383,7 @@ Aerospike CE Kubernetes Operator와 Aerospike Cluster Manager는 함께 동작�
 - **오퍼레이터** (`aerospike-ce-kubernetes-operator`): `AerospikeCluster`와 `AerospikeClusterTemplate` 커스텀 리소스를 감시하고 원하는 상태를 조정하는 Kubernetes 컨트롤러입니다 -- StatefulSet, Service, ConfigMap을 생성하고 롤링 업데이트, 스케일링, 랙 관리를 수행합니다.
 - **클러스터 매니저** (`aerospike-cluster-manager`): Aerospike 클러스터(데이터 작업, 모니터링)와 Kubernetes API(CRD를 통한 클러스터 라이프사이클)를 모두 다루는 GUI를 제공하는 웹 애플리케이션(Next.js 프론트엔드 + FastAPI 백엔드)입니다.
 
-Helm 차트에서 `ui.enabled=true`를 설정하면 클러스터 매니저가 오퍼레이터와 동일한 네임스페이스에 별도 Deployment로 배포됩니다. 클러스터 매니저는 다음과 통신합니다:
+Helm 차트 0.4.0+에서는 클러스터 매니저가 기본으로 오퍼레이터와 동일한 네임스페이스에 별도 Deployment로 배포됩니다 (`ui.api.enabled` / `ui.web.enabled`로 개별 토글 가능). 클러스터 매니저는 다음과 통신합니다:
 1. **Aerospike 클러스터** — 데이터 작업(레코드 탐색, AQL, 인덱스 관리, UDF 관리)을 위해 Aerospike 와이어 프로토콜로 직접 통신
 2. **Kubernetes API** — 클러스터 라이프사이클 작업(`AerospikeCluster` CR의 생성, 스케일, 편집, 삭제)을 위해 통신하며, 이후 오퍼레이터가 조정
 
@@ -391,13 +391,14 @@ Helm 차트에서 `ui.enabled=true`를 설정하면 클러스터 매니저가 �
 
 ### UI 활성화
 
-Helm 설치 명령에 `--set ui.enabled=true`를 추가합니다:
+UI는 기본 활성화이므로 별도 플래그 없이 설치하면 함께 올라옵니다:
 
 ```bash
 helm install aerospike-ce-kubernetes-operator oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kubernetes-operator \
-  -n aerospike-operator --create-namespace \
-  --set ui.enabled=true
+  -n aerospike-operator --create-namespace
 ```
+
+UI를 끄려면 `--set ui.api.enabled=false --set ui.web.enabled=false`.
 
 ### Port-Forward로 접근
 
@@ -421,7 +422,6 @@ kubectl -n aerospike-operator port-forward svc/<release>-aerospike-operator-ui 3
 ```bash
 helm install aerospike-ce-kubernetes-operator oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kubernetes-operator \
   -n aerospike-operator --create-namespace \
-  --set ui.enabled=true \
   --set ui.ingress.enabled=true \
   --set ui.ingress.className=nginx \
   --set "ui.ingress.hosts[0].host=aerospike-admin.example.com" \
@@ -433,7 +433,8 @@ helm install aerospike-ce-kubernetes-operator oci://ghcr.io/aerospike-ce-ecosyst
 
 | 파라미터 | 기본값 | 설명 |
 |---------|--------|------|
-| `ui.enabled` | `false` | Cluster Manager UI 활성화 |
+| `ui.api.enabled` | `true` | Cluster Manager API (FastAPI) 컴포넌트 배포. `ui.web.enabled=false`와 함께 false로 설정하면 UI 전체 비활성. |
+| `ui.web.enabled` | `true` | Cluster Manager web (Next.js) 컴포넌트 배포. `ui.api.enabled=false`와 함께 false로 설정하면 UI 전체 비활성. |
 | `ui.replicaCount` | `1` | UI 레플리카 수 |
 | `ui.service.type` | `ClusterIP` | 서비스 타입 (`ClusterIP`, `NodePort`, `LoadBalancer`) |
 | `ui.service.frontendPort` | `3000` | Frontend(Next.js) 포트 |
@@ -452,7 +453,6 @@ helm install aerospike-ce-kubernetes-operator oci://ghcr.io/aerospike-ce-ecosyst
 ```bash
 helm install aerospike-ce-kubernetes-operator oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kubernetes-operator \
   -n aerospike-operator --create-namespace \
-  --set ui.enabled=true \
   --set ui.postgresql.enabled=false \
   --set ui.env.databaseUrl="postgresql://user:pass@db-host:5432/aerospike_manager"
 ```

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/quickstart.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/quickstart.md
@@ -69,7 +69,6 @@ helm install cert-manager jetstack/cert-manager \
 helm install aerospike-ce-kubernetes-operator \
   oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kubernetes-operator \
   -n aerospike-operator --create-namespace \
-  --set ui.enabled=true \
   --wait
 ```
 

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/reference/helm-values.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/reference/helm-values.md
@@ -142,7 +142,8 @@ Aerospike Cluster Manager는 오퍼레이터와 함께 배포되는 풀스택 �
 
 | 키 | 타입 | 기본값 | 설명 |
 |-----|------|---------|-------------|
-| `ui.enabled` | bool | `false` | Aerospike Cluster Manager 웹 UI 활성화. |
+| `ui.api.enabled` | bool | `true` | Cluster Manager API (FastAPI) 컴포넌트 배포. `ui.web.enabled=false`와 함께 false로 설정하면 UI를 완전히 끔. |
+| `ui.web.enabled` | bool | `true` | Cluster Manager web (Next.js) 컴포넌트 배포. `ui.api.enabled=false`와 함께 false로 설정하면 UI를 완전히 끔. |
 | `ui.replicaCount` | int | `1` | UI 레플리카 수. |
 | `ui.image.repository` | string | `ghcr.io/aerospike-ce-ecosystem/aerospike-cluster-manager` | UI 컨테이너 이미지 리포지토리. |
 | `ui.image.tag` | string | `"latest"` | UI 컨테이너 이미지 태그. UI는 오퍼레이터와 독립적으로 버전 관리. |


### PR DESCRIPTION
## Summary

- Remove the redundant `ui.enabled` master switch from the helm chart. The per-component `ui.api.enabled` / `ui.web.enabled` toggles introduced in 0.3.0 already cover every meaningful state, and the master switch let users land in nonsensical configs (e.g. `ui.enabled=true` with both api/web off — chart only emitted a warning).
- Add `ui.anyEnabled` helper (= `api.enabled || web.enabled`) and re-gate the four shared resources (configmap, serviceaccount, ingress, networkpolicy) on it. The two Deployments and per-component resources keep their existing `ui.api.enabled` / `ui.web.enabled` gating.
- Chart version bump 0.3.0 → 0.4.0 (SemVer pre-1.0 minor for breaking change).

## Migration (existing 0.3.x users)

```yaml
# before
ui:
  enabled: false

# after
ui:
  api:
    enabled: false
  web:
    enabled: false
```

Default behavior (`api` + `web` both on) is unchanged — a plain `helm install` still brings the full UI up.

The 0.4.0 release-notes block in `templates/NOTES.txt` shows users this migration on every install/upgrade.

## Files touched (23)

- Chart core: `Chart.yaml`, `values.yaml`, `templates/_helpers.tpl`, `templates/NOTES.txt`
- Re-gated to `ui.anyEnabled`: `templates/ui/{configmap,serviceaccount,ingress,networkpolicy}.yaml`
- Repo glue: `Makefile` (run-local + cluster-manager-dev targets dropped redundant `--set ui.enabled=true`)
- Docs (EN + KO mirrors): `README.md`, `charts/.../README.md`, `docs/content/{quickstart,reference/helm-values,configuration/templates,operations/troubleshooting,getting-started/install,getting-started/cluster-manager-ui}.md`, `docs/i18n/ko/...` (5 files), `docs/TODO.md`

## Test plan

- [x] `helm lint charts/aerospike-ce-kubernetes-operator` — passes
- [x] `helm template` against four toggle combinations:
  - **default (api+web)**: 2 Deployments + ConfigMap + ServiceAccount + 2 Services + ClusterRole/Binding + Secret + PVC + test pod ✓
  - **api-only** (`ui.web.enabled=false`): deployment-api + 1 Service + shared resources, no web Deployment ✓
  - **web-only** (`ui.api.enabled=false`): deployment-web + 1 Service + ConfigMap + ServiceAccount, no api/PG/RBAC ✓
  - **both-off** (`ui.api.enabled=false ui.web.enabled=false`): zero `templates/ui/` resources rendered — operator-only mode works ✓
- [ ] Smoke test on Kind cluster with `make run-local` after merge
- [ ] Verify NOTES.txt migration block renders correctly via `helm install --dry-run`