### PR TITLE
feat: multi-cluster topology + Keycloak OIDC support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,32 +93,35 @@ setup-kind: ## Delete existing Kind cluster and create a fresh one with kind-con
 .PHONY: run-local
 run-local: manifests helm-sync-crds ## Deploy operator + cluster-manager UI into a fresh Kind cluster via Helm
 	@echo ""
-	@echo "==> [0/7] Refreshing Helm sub-chart dependency (CRD bundle)..."
+	@echo "==> [0/8] Refreshing Helm sub-chart dependency (CRD bundle)..."
 	helm dep update charts/aerospike-ce-kubernetes-operator
 	@echo ""
-	@echo "==> [1/7] Creating fresh Kind cluster..."
+	@echo "==> [1/8] Creating fresh Kind cluster..."
 	-@$(KIND) delete cluster --name kind 2>/dev/null || true
 	KIND_EXPERIMENTAL_PROVIDER=$(KIND_PROVIDER) $(KIND) create cluster --config kind-config.yaml --name kind
 	@echo ""
-	@echo "==> [2/7] Building operator image..."
+	@echo "==> [2/8] Building operator image..."
 	$(CONTAINER_TOOL) build --build-arg VERSION=$(VERSION) -t $(IMG) .
 	@echo ""
-	@echo "==> [3/7] Building cluster-manager backend image (FastAPI :8000)..."
+	@echo "==> [3/8] Building cluster-manager backend image (FastAPI :8000)..."
 	$(CONTAINER_TOOL) build --target backend -f aerospike-cluster-manager/Dockerfile -t $(CLUSTER_MANAGER_API_IMG):latest aerospike-cluster-manager/
 	@echo ""
-	@echo "==> [4/7] Loading images into Kind cluster..."
+	@echo "==> [4/8] Loading images into Kind cluster..."
 	$(CONTAINER_TOOL) save $(SAVE_FORMAT_FLAG) $(IMG) -o /tmp/acko-operator.tar
 	$(KIND) load image-archive /tmp/acko-operator.tar --name kind
 	$(CONTAINER_TOOL) save $(SAVE_FORMAT_FLAG) $(CLUSTER_MANAGER_API_IMG):latest -o /tmp/acko-ui-api.tar
 	$(KIND) load image-archive /tmp/acko-ui-api.tar --name kind
 	@rm -f /tmp/acko-operator.tar /tmp/acko-ui-api.tar
 	@echo ""
-	@echo "==> [5/7] Installing cert-manager..."
+	@echo "==> [5/8] Installing cert-manager..."
 	helm install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --set crds.enabled=true
 	@echo "    Waiting for cert-manager webhook..."
 	kubectl wait --for=condition=Available deployment/cert-manager-webhook -n cert-manager --timeout=120s
 	@echo ""
-	@echo "==> [6/7] Deploying operator and UI (api only) via Helm..."
+	@echo "==> [6/8] Installing Keycloak (local OIDC IdP)..."
+	$(MAKE) install-keycloak
+	@echo ""
+	@echo "==> [7/8] Deploying operator and UI (api only) via Helm..."
 	helm upgrade -i aerospike-ce-kubernetes-operator ./charts/aerospike-ce-kubernetes-operator \
 		-n aerospike-operator --create-namespace \
 		--set image.tag=latest \
@@ -127,13 +130,43 @@ run-local: manifests helm-sync-crds ## Deploy operator + cluster-manager UI into
 		--set ui.api.image.pullPolicy=IfNotPresent \
 		--set ui.web.enabled=false
 	@echo ""
-	@echo "==> [7/7] Waiting for operator deployment to be ready..."
+	@echo "==> [8/8] Waiting for operator deployment to be ready..."
 	kubectl -n aerospike-operator wait --for=condition=Available deployment --all --timeout=180s
 	@echo ""
 	@echo "==> ACKO local development stack is running!"
 	@echo "    Operator:    deployed in namespace 'aerospike-operator'"
 	@echo "    Backend API: kubectl port-forward -n aerospike-operator svc/aerospike-ce-kubernetes-operator-ui-api 8000:80"
+	@echo "    Keycloak:    kubectl port-forward -n keycloak svc/keycloak 8080:80 (admin/admin, realm acko)"
 	@echo ""
+
+# install-keycloak — install (or upgrade) Keycloak with the acko realm preloaded.
+# Reusable target shared by run-local and setup-test-e2e.
+# Idempotent: re-running upgrades the chart and re-applies the realm ConfigMap.
+.PHONY: install-keycloak
+install-keycloak: ## Install bitnami/keycloak with the acko realm imported (local OIDC IdP)
+	@echo "    Adding bitnami helm repo..."
+	helm repo add bitnami https://charts.bitnami.com/bitnami 2>/dev/null || true
+	helm repo update bitnami
+	@echo "    Creating namespace 'keycloak' (idempotent)..."
+	kubectl create namespace keycloak --dry-run=client -o yaml | kubectl apply -f -
+	@echo "    Loading acko-realm.json into ConfigMap..."
+	kubectl create configmap acko-realm \
+		--from-file=acko-realm.json=scripts/keycloak/acko-realm.json \
+		-n keycloak --dry-run=client -o yaml | kubectl apply -f -
+	@echo "    helm upgrade --install keycloak..."
+	helm upgrade --install keycloak bitnami/keycloak \
+		--namespace keycloak \
+		--set auth.adminUser=admin \
+		--set auth.adminPassword=admin \
+		--set keycloakConfigCli.enabled=true \
+		--set keycloakConfigCli.existingConfigmap=acko-realm \
+		--set service.type=ClusterIP \
+		--set proxy=edge \
+		--wait --timeout 5m
+	@echo "    Waiting for Keycloak deployment..."
+	kubectl wait --for=condition=Available deployment/keycloak \
+		-n keycloak --timeout=300s
+	@echo "    Keycloak ready: http://keycloak.keycloak.svc.cluster.local/realms/acko"
 
 .PHONY: stop-local
 stop-local: ## Delete the Kind cluster used for local development
@@ -153,6 +186,12 @@ setup-test-e2e: ## Set up a Kind cluster for e2e tests if it does not exist
 			echo "Creating Kind cluster '$(KIND_CLUSTER)' with provider '$(KIND_PROVIDER)'..."; \
 			KIND_EXPERIMENTAL_PROVIDER=$(KIND_PROVIDER) $(KIND) create cluster --config kind-config.yaml --name $(KIND_CLUSTER) ;; \
 	esac
+	@if [ "$(SKIP_KEYCLOAK)" != "true" ]; then \
+		echo "==> Installing Keycloak (local OIDC IdP) for e2e..."; \
+		$(MAKE) install-keycloak; \
+	else \
+		echo "==> Skipping Keycloak install (SKIP_KEYCLOAK=true)"; \
+	fi
 
 .PHONY: test-e2e
 test-e2e: setup-test-e2e manifests generate fmt vet ## Run the e2e tests. Expected an isolated environment using Kind.

--- a/Makefile
+++ b/Makefile
@@ -154,17 +154,22 @@ install-keycloak: ## Install bitnami/keycloak with the acko realm imported (loca
 		--from-file=acko-realm.json=scripts/keycloak/acko-realm.json \
 		-n keycloak --dry-run=client -o yaml | kubectl apply -f -
 	@echo "    helm upgrade --install keycloak..."
+	@# All overrides (bitnamilegacy registries, postgresql tag pin, OIDC
+	@# realm import) live in scripts/keycloak/values-keycloak-local.yaml
+	@# so a single file is the source of truth for both the Makefile and
+	@# any operator who wants to inspect or override values directly.
+	@# Chart version pinned at the CLI level so a future chart upgrade
+	@# doesn't move us to an image tag that bitnamilegacy never archived.
 	helm upgrade --install keycloak bitnami/keycloak \
+		--version 25.2.0 \
 		--namespace keycloak \
-		--set auth.adminUser=admin \
-		--set auth.adminPassword=admin \
-		--set keycloakConfigCli.enabled=true \
-		--set keycloakConfigCli.existingConfigmap=acko-realm \
-		--set service.type=ClusterIP \
-		--set proxy=edge \
+		--values scripts/keycloak/values-keycloak-local.yaml \
 		--wait --timeout 5m
-	@echo "    Waiting for Keycloak deployment..."
-	kubectl wait --for=condition=Available deployment/keycloak \
+	@# bitnami/keycloak deploys a StatefulSet, not a Deployment, so we
+	@# wait on the pod's Ready condition rather than a Deployment's
+	@# Available condition (which would always 404).
+	@echo "    Waiting for Keycloak pod..."
+	kubectl wait --for=condition=Ready pod/keycloak-0 \
 		-n keycloak --timeout=300s
 	@echo "    Keycloak ready: http://keycloak.keycloak.svc.cluster.local/realms/acko"
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ helm install aerospike-operator oci://ghcr.io/aerospike-ce-ecosystem/aerospike-o
   -n aerospike-operator --create-namespace
 ```
 
+> Multi-cluster mode (common cluster + per-environment operator clusters with Keycloak OIDC): see [docs/multi-cluster-keycloak.md](docs/multi-cluster-keycloak.md).
+
 #### Option B: From Local Chart
 
 ```sh

--- a/charts/aerospike-ce-kubernetes-operator/templates/NOTES.txt
+++ b/charts/aerospike-ce-kubernetes-operator/templates/NOTES.txt
@@ -1,4 +1,96 @@
+{{- /* Run all validation gates first; they fail-fast on bad value combos. */ -}}
+{{- include "aerospike-ce-kubernetes-operator.validate" . -}}
 Aerospike CE Kubernetes Operator has been installed.
+
+------------------------------------------------------------------------
+  Install Mode
+------------------------------------------------------------------------
+
+operator.enabled : {{ include "aerospike-ce-kubernetes-operator.operator.enabled" . }}
+ui.api.enabled   : {{ include "aerospike-ce-kubernetes-operator.ui.api.enabled" . }}
+ui.web.enabled   : {{ include "aerospike-ce-kubernetes-operator.ui.web.enabled" . }}
+multiCluster.enabled : {{ include "aerospike-ce-kubernetes-operator.multiCluster.enabled" . }}
+ui.api.auth.oidc.enabled : {{ include "aerospike-ce-kubernetes-operator.api.oidc.enabled" . }}
+ui.web.auth.oidc.enabled : {{ include "aerospike-ce-kubernetes-operator.web.oidc.enabled" . }}
+
+{{- if ne (include "aerospike-ce-kubernetes-operator.operator.enabled" .) "true" }}
+
+NOTE: operator.enabled=false — the controller-manager, webhook, RBAC, and
+default AerospikeClusterTemplates are NOT rendered. Use this mode for the
+"common" cluster in a multi-cluster topology where dev/prod clusters host
+the operator and the common cluster only serves the web UI.
+
+Recommended preset: values-common.yaml
+{{- end }}
+
+{{- if eq (include "aerospike-ce-kubernetes-operator.multiCluster.enabled" .) "true" }}
+
+------------------------------------------------------------------------
+  Multi-cluster topology
+------------------------------------------------------------------------
+
+A cluster registry has been rendered as ConfigMap
+"{{ include "aerospike-ce-kubernetes-operator.clusterRegistryConfigMapName" . }}"
+and mounted into the web pod at /cluster-registry.json.
+
+Default cluster: {{ default "(unset)" .Values.multiCluster.defaultClusterId }}
+Registered clusters:
+{{- range .Values.multiCluster.clusters }}
+  - {{ .id }} ({{ .displayName | default .id }}) → {{ .apiUrl }}
+{{- end }}
+
+Verify the registry once the web pod is running:
+
+  kubectl port-forward svc/{{ include "aerospike-ce-kubernetes-operator.ui.web.fullname" . }} {{ .Values.ui.web.service.port }}:{{ .Values.ui.web.service.port }} -n {{ .Release.Namespace }}
+  curl http://localhost:{{ .Values.ui.web.service.port }}/cluster-registry.json
+
+End-to-end routing test:
+
+  helm test {{ .Release.Name }} -n {{ .Release.Namespace }}
+
+The test pod (`{{ include "aerospike-ce-kubernetes-operator.ui.fullname" . }}-test-multicluster`)
+fetches /cluster-registry.json and probes each registered apiUrl + /api/health.
+{{- end }}
+
+{{- if or (eq (include "aerospike-ce-kubernetes-operator.api.oidc.enabled" .) "true") (eq (include "aerospike-ce-kubernetes-operator.web.oidc.enabled" .) "true") }}
+
+------------------------------------------------------------------------
+  OIDC (Keycloak) prerequisites
+------------------------------------------------------------------------
+
+This release expects an external OIDC issuer (Keycloak or compatible).
+Before traffic flows you must configure on the IdP side:
+
+  Realm        : matches ui.{api,web}.auth.oidc.issuerUrl path segment
+{{- if eq (include "aerospike-ce-kubernetes-operator.api.oidc.enabled" .) "true" }}
+  API audience : {{ .Values.ui.api.auth.oidc.audience }}
+                  (token `aud` claim must equal this; otherwise rejected)
+{{- if .Values.ui.api.auth.oidc.requiredRoles }}
+  API roles    : at least one of {{ join ", " .Values.ui.api.auth.oidc.requiredRoles }}
+{{- end }}
+{{- end }}
+{{- if eq (include "aerospike-ce-kubernetes-operator.web.oidc.enabled" .) "true" }}
+  SPA client   : {{ .Values.ui.web.auth.oidc.clientId }} (public, PKCE, no secret)
+                  redirectUri = {{ .Values.ui.web.auth.oidc.redirectUri }}
+                  scopes      = {{ join ", " .Values.ui.web.auth.oidc.scopes }}
+  Web OIDC config served at /web-oidc-config.json (ConfigMap
+  "{{ include "aerospike-ce-kubernetes-operator.webOidcConfigMapName" . }}").
+{{- end }}
+
+For local development, a Keycloak realm can be bootstrapped via the
+`scripts/keycloak/` helpers in this repository (see Stream D documentation
+in project-hub for `acko-realm.json`).
+{{- end }}
+
+------------------------------------------------------------------------
+  Default values vs presets
+------------------------------------------------------------------------
+
+  Default values.yaml   : single-cluster install (operator + api + web)
+  values-common.yaml    : web-only ("common" front-door cluster)
+  values-operator.yaml  : api + operator (per-environment dev/prod cluster)
+
+
 {{- if not .Values.crds.install }}
 
 NOTE: CRD installation is disabled (crds.install=false).

--- a/charts/aerospike-ce-kubernetes-operator/templates/_helpers.tpl
+++ b/charts/aerospike-ce-kubernetes-operator/templates/_helpers.tpl
@@ -266,3 +266,100 @@ UI service names (used by web → api routing and by NOTES output).
 {{- define "aerospike-ce-kubernetes-operator.ui.web.serviceName" -}}
 {{- include "aerospike-ce-kubernetes-operator.ui.web.fullname" . -}}
 {{- end }}
+
+{{/*
+=============================================================================
+Operator / multi-cluster / OIDC enablement helpers
+=============================================================================
+Each helper renders the literal string "true" / "false" so callers can guard
+templates with `eq (include "...") "true"`.
+*/}}
+
+{{- define "aerospike-ce-kubernetes-operator.operator.enabled" -}}
+{{- $op := .Values.operator | default dict -}}
+{{- if hasKey $op "enabled" -}}
+{{- $op.enabled -}}
+{{- else -}}
+true
+{{- end -}}
+{{- end }}
+
+{{- define "aerospike-ce-kubernetes-operator.multiCluster.enabled" -}}
+{{- $mc := .Values.multiCluster | default dict -}}
+{{- if hasKey $mc "enabled" -}}
+{{- $mc.enabled -}}
+{{- else -}}
+false
+{{- end -}}
+{{- end }}
+
+{{- define "aerospike-ce-kubernetes-operator.api.oidc.enabled" -}}
+{{- $oidc := dig "api" "auth" "oidc" "enabled" false .Values.ui -}}
+{{- $oidc -}}
+{{- end }}
+
+{{- define "aerospike-ce-kubernetes-operator.web.oidc.enabled" -}}
+{{- $oidc := dig "web" "auth" "oidc" "enabled" false .Values.ui -}}
+{{- $oidc -}}
+{{- end }}
+
+{{/*
+ConfigMap names for the multi-cluster registry and SPA OIDC config.
+*/}}
+{{- define "aerospike-ce-kubernetes-operator.clusterRegistryConfigMapName" -}}
+{{- include "aerospike-ce-kubernetes-operator.fullname" . }}-cluster-registry
+{{- end }}
+
+{{- define "aerospike-ce-kubernetes-operator.webOidcConfigMapName" -}}
+{{- include "aerospike-ce-kubernetes-operator.fullname" . }}-web-oidc-config
+{{- end }}
+
+{{/*
+=============================================================================
+Validation gates (called from templates/_validations.tpl via NOTES.txt)
+=============================================================================
+
+These gates fail-fast at `helm template` / `helm install` time when the
+values combination is contradictory. Each gate is a no-op when its
+preconditions are not met, so the helper is safe to call unconditionally.
+*/}}
+
+{{- define "aerospike-ce-kubernetes-operator.validate.multiClusterVsApiUrl" -}}
+{{- if and (eq (include "aerospike-ce-kubernetes-operator.multiCluster.enabled" .) "true") .Values.ui.web.env.apiUrl -}}
+{{- fail "multiCluster.enabled=true conflicts with ui.web.env.apiUrl: routing is ambiguous. Either disable multi-cluster (and use ui.web.env.apiUrl for a single API) or clear ui.web.env.apiUrl and rely on the cluster registry." -}}
+{{- end -}}
+{{- end }}
+
+{{- define "aerospike-ce-kubernetes-operator.validate.defaultTemplatesNeedCRDs" -}}
+{{- if and .Values.defaultTemplates.enabled (not .Values.crds.install) -}}
+{{- fail "defaultTemplates.enabled=true requires crds.install=true (the AerospikeClusterTemplate CRD must exist before templates can be applied). Either enable crds.install or set defaultTemplates.enabled=false." -}}
+{{- end -}}
+{{- end }}
+
+{{- define "aerospike-ce-kubernetes-operator.validate.apiOidcIssuerUrl" -}}
+{{- if eq (include "aerospike-ce-kubernetes-operator.api.oidc.enabled" .) "true" -}}
+{{- if not .Values.ui.api.auth.oidc.issuerUrl -}}
+{{- fail "ui.api.auth.oidc.enabled=true requires ui.api.auth.oidc.issuerUrl to be set (e.g. https://keycloak.example.com/realms/acko)." -}}
+{{- end -}}
+{{- end -}}
+{{- end }}
+
+{{- define "aerospike-ce-kubernetes-operator.validate.webOidcClientId" -}}
+{{- if eq (include "aerospike-ce-kubernetes-operator.web.oidc.enabled" .) "true" -}}
+{{- if not .Values.ui.web.auth.oidc.clientId -}}
+{{- fail "ui.web.auth.oidc.enabled=true requires ui.web.auth.oidc.clientId to be set (the SPA's public client ID registered in the IdP)." -}}
+{{- end -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Aggregate validation entry-point. Templates can `include` this helper once
+(typically from NOTES.txt or a dedicated _validations partial) to enforce
+all gates uniformly.
+*/}}
+{{- define "aerospike-ce-kubernetes-operator.validate" -}}
+{{- include "aerospike-ce-kubernetes-operator.validate.multiClusterVsApiUrl" . -}}
+{{- include "aerospike-ce-kubernetes-operator.validate.defaultTemplatesNeedCRDs" . -}}
+{{- include "aerospike-ce-kubernetes-operator.validate.apiOidcIssuerUrl" . -}}
+{{- include "aerospike-ce-kubernetes-operator.validate.webOidcClientId" . -}}
+{{- end }}

--- a/charts/aerospike-ce-kubernetes-operator/templates/_helpers.tpl
+++ b/charts/aerospike-ce-kubernetes-operator/templates/_helpers.tpl
@@ -325,8 +325,10 @@ preconditions are not met, so the helper is safe to call unconditionally.
 */}}
 
 {{- define "aerospike-ce-kubernetes-operator.validate.multiClusterVsApiUrl" -}}
+{{- if eq (include "aerospike-ce-kubernetes-operator.ui.web.enabled" .) "true" -}}
 {{- if and (eq (include "aerospike-ce-kubernetes-operator.multiCluster.enabled" .) "true") .Values.ui.web.env.apiUrl -}}
 {{- fail "multiCluster.enabled=true conflicts with ui.web.env.apiUrl: routing is ambiguous. Either disable multi-cluster (and use ui.web.env.apiUrl for a single API) or clear ui.web.env.apiUrl and rely on the cluster registry." -}}
+{{- end -}}
 {{- end -}}
 {{- end }}
 
@@ -337,17 +339,21 @@ preconditions are not met, so the helper is safe to call unconditionally.
 {{- end }}
 
 {{- define "aerospike-ce-kubernetes-operator.validate.apiOidcIssuerUrl" -}}
+{{- if eq (include "aerospike-ce-kubernetes-operator.ui.api.enabled" .) "true" -}}
 {{- if eq (include "aerospike-ce-kubernetes-operator.api.oidc.enabled" .) "true" -}}
 {{- if not .Values.ui.api.auth.oidc.issuerUrl -}}
 {{- fail "ui.api.auth.oidc.enabled=true requires ui.api.auth.oidc.issuerUrl to be set (e.g. https://keycloak.example.com/realms/acko)." -}}
 {{- end -}}
 {{- end -}}
+{{- end -}}
 {{- end }}
 
 {{- define "aerospike-ce-kubernetes-operator.validate.webOidcClientId" -}}
+{{- if eq (include "aerospike-ce-kubernetes-operator.ui.web.enabled" .) "true" -}}
 {{- if eq (include "aerospike-ce-kubernetes-operator.web.oidc.enabled" .) "true" -}}
 {{- if not .Values.ui.web.auth.oidc.clientId -}}
 {{- fail "ui.web.auth.oidc.enabled=true requires ui.web.auth.oidc.clientId to be set (the SPA's public client ID registered in the IdP)." -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 {{- end }}

--- a/charts/aerospike-ce-kubernetes-operator/templates/certificate.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/certificate.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "aerospike-ce-kubernetes-operator.operator.enabled" .) "true" }}
 {{- if and .Values.webhook.enabled .Values.certManager.enabled }}
 {{- if eq .Values.certManager.issuer.type "selfSigned" }}
 apiVersion: cert-manager.io/v1
@@ -52,4 +53,5 @@ spec:
   {{- with .Values.certManager.renewBefore }}
   renewBefore: {{ . }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/aerospike-ce-kubernetes-operator/templates/ciliumnetworkpolicy.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ciliumnetworkpolicy.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "aerospike-ce-kubernetes-operator.operator.enabled" .) "true" }}
 {{- if .Values.cilium.enabled }}
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
@@ -55,4 +56,5 @@ spec:
     # Allow communication with kube-apiserver
     - toEntities:
         - kube-apiserver
+{{- end }}
 {{- end }}

--- a/charts/aerospike-ce-kubernetes-operator/templates/clusterrole-manager.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/clusterrole-manager.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "aerospike-ce-kubernetes-operator.operator.enabled" .) "true" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -151,3 +152,4 @@ rules:
       - patch
       - update
       - watch
+{{- end }}

--- a/charts/aerospike-ce-kubernetes-operator/templates/clusterrole-metrics-auth.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/clusterrole-metrics-auth.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "aerospike-ce-kubernetes-operator.operator.enabled" .) "true" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -17,3 +18,4 @@ rules:
       - subjectaccessreviews
     verbs:
       - create
+{{- end }}

--- a/charts/aerospike-ce-kubernetes-operator/templates/clusterrole-metrics-reader.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/clusterrole-metrics-reader.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "aerospike-ce-kubernetes-operator.operator.enabled" .) "true" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -9,3 +10,4 @@ rules:
       - "/metrics"
     verbs:
       - get
+{{- end }}

--- a/charts/aerospike-ce-kubernetes-operator/templates/clusterrolebinding-manager.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/clusterrolebinding-manager.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "aerospike-ce-kubernetes-operator.operator.enabled" .) "true" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -12,3 +13,4 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "aerospike-ce-kubernetes-operator.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/aerospike-ce-kubernetes-operator/templates/clusterrolebinding-metrics-auth.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/clusterrolebinding-metrics-auth.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "aerospike-ce-kubernetes-operator.operator.enabled" .) "true" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -12,3 +13,4 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "aerospike-ce-kubernetes-operator.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/aerospike-ce-kubernetes-operator/templates/default-templates.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/default-templates.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "aerospike-ce-kubernetes-operator.operator.enabled" .) "true" }}
 {{- if .Values.defaultTemplates.enabled }}
 {{- range $name, $spec := $.Values.defaultTemplates.templates }}
 {{- $merged := deepCopy $spec }}
@@ -25,5 +26,6 @@ metadata:
     "helm.sh/hook-weight": "10"
 spec:
   {{- toYaml $merged | nindent 2 }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/aerospike-ce-kubernetes-operator/templates/deployment.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "aerospike-ce-kubernetes-operator.operator.enabled" .) "true" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -103,3 +104,4 @@ spec:
       topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}

--- a/charts/aerospike-ce-kubernetes-operator/templates/grafana-dashboard.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/grafana-dashboard.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "aerospike-ce-kubernetes-operator.operator.enabled" .) "true" }}
 {{- if .Values.grafanaDashboard.enabled }}
 apiVersion: v1
 kind: ConfigMap
@@ -113,4 +114,5 @@ data:
       "title": "Aerospike Operator",
       "uid": "aerospike-operator"
     }
+{{- end }}
 {{- end }}

--- a/charts/aerospike-ce-kubernetes-operator/templates/hpa.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/hpa.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "aerospike-ce-kubernetes-operator.operator.enabled" .) "true" }}
 {{- if .Values.autoscaling.enabled }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
@@ -28,4 +29,5 @@ spec:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/aerospike-ce-kubernetes-operator/templates/mutatingwebhookconfiguration.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/mutatingwebhookconfiguration.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "aerospike-ce-kubernetes-operator.operator.enabled" .) "true" }}
 {{- if .Values.webhook.enabled }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
@@ -30,4 +31,5 @@ webhooks:
         resources:
           - aerospikeclusters
     sideEffects: None
+{{- end }}
 {{- end }}

--- a/charts/aerospike-ce-kubernetes-operator/templates/networkpolicy.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/networkpolicy.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "aerospike-ce-kubernetes-operator.operator.enabled" .) "true" }}
 {{- if .Values.networkPolicy.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -47,4 +48,5 @@ spec:
           protocol: TCP
         - port: 6443
           protocol: TCP
+{{- end }}
 {{- end }}

--- a/charts/aerospike-ce-kubernetes-operator/templates/pdb.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/pdb.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "aerospike-ce-kubernetes-operator.operator.enabled" .) "true" }}
 {{- if .Values.podDisruptionBudget.enabled }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
@@ -15,4 +16,5 @@ spec:
   selector:
     matchLabels:
       {{- include "aerospike-ce-kubernetes-operator.selectorLabels" . | nindent 6 }}
+{{- end }}
 {{- end }}

--- a/charts/aerospike-ce-kubernetes-operator/templates/prometheusrule.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/prometheusrule.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "aerospike-ce-kubernetes-operator.operator.enabled" .) "true" }}
 {{- if .Values.prometheusRule.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
@@ -77,4 +78,5 @@ spec:
             summary: "Aerospike operator pod is restarting frequently"
             description: "The Aerospike operator pod has restarted more than 3 times in the last hour."
         {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/aerospike-ce-kubernetes-operator/templates/role-leader-election.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/role-leader-election.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "aerospike-ce-kubernetes-operator.operator.enabled" .) "true" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -37,3 +38,4 @@ rules:
     verbs:
       - create
       - patch
+{{- end }}

--- a/charts/aerospike-ce-kubernetes-operator/templates/rolebinding-leader-election.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/rolebinding-leader-election.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "aerospike-ce-kubernetes-operator.operator.enabled" .) "true" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -13,3 +14,4 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "aerospike-ce-kubernetes-operator.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/aerospike-ce-kubernetes-operator/templates/service-metrics.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/service-metrics.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "aerospike-ce-kubernetes-operator.operator.enabled" .) "true" }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -13,3 +14,4 @@ spec:
       targetPort: 8443
   selector:
     {{- include "aerospike-ce-kubernetes-operator.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/aerospike-ce-kubernetes-operator/templates/service-webhook.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/service-webhook.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "aerospike-ce-kubernetes-operator.operator.enabled" .) "true" }}
 {{- if .Values.webhook.enabled }}
 apiVersion: v1
 kind: Service
@@ -14,4 +15,5 @@ spec:
       targetPort: {{ .Values.webhook.port }}
   selector:
     {{- include "aerospike-ce-kubernetes-operator.selectorLabels" . | nindent 4 }}
+{{- end }}
 {{- end }}

--- a/charts/aerospike-ce-kubernetes-operator/templates/serviceaccount.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "aerospike-ce-kubernetes-operator.operator.enabled" .) "true" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -9,3 +10,4 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- end }}

--- a/charts/aerospike-ce-kubernetes-operator/templates/servicemonitor.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/servicemonitor.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "aerospike-ce-kubernetes-operator.operator.enabled" .) "true" }}
 {{- if .Values.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -25,4 +26,5 @@ spec:
   selector:
     matchLabels:
       {{- include "aerospike-ce-kubernetes-operator.selectorLabels" . | nindent 6 }}
+{{- end }}
 {{- end }}

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/configmap.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/configmap.yaml
@@ -43,3 +43,36 @@ data:
   logging.yaml: |
 {{ toYaml .Values.ui.api.logging.dictConfig | indent 4 }}
 {{- end }}
+{{- if eq (include "aerospike-ce-kubernetes-operator.multiCluster.enabled" .) "true" }}
+---
+# Multi-cluster registry consumed by the web SPA at /cluster-registry.json.
+# The SPA uses this list to pivot between ACKO API endpoints (one per env).
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "aerospike-ce-kubernetes-operator.clusterRegistryConfigMapName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "aerospike-ce-kubernetes-operator.ui.web.labels" . | nindent 4 }}
+data:
+  cluster-registry.json: |
+    {{- $registry := dict "defaultClusterId" .Values.multiCluster.defaultClusterId "clusters" .Values.multiCluster.clusters }}
+    {{- toJson $registry | nindent 4 }}
+{{- end }}
+{{- if eq (include "aerospike-ce-kubernetes-operator.web.oidc.enabled" .) "true" }}
+---
+# SPA OIDC config consumed by the web pod at /web-oidc-config.json.
+# The web frontend fetches this at boot to configure keycloak-js (issuer,
+# clientId, redirectUri, scopes) without rebuilding the image per env.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "aerospike-ce-kubernetes-operator.webOidcConfigMapName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "aerospike-ce-kubernetes-operator.ui.web.labels" . | nindent 4 }}
+data:
+  web-oidc-config.json: |
+    {{- $oidc := dict "issuerUrl" .Values.ui.web.auth.oidc.issuerUrl "clientId" .Values.ui.web.auth.oidc.clientId "redirectUri" .Values.ui.web.auth.oidc.redirectUri "scopes" .Values.ui.web.auth.oidc.scopes }}
+    {{- toJson $oidc | nindent 4 }}
+{{- end }}

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/deployment-api.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/deployment-api.yaml
@@ -132,6 +132,8 @@ spec:
               value: {{ join "," .Values.ui.api.auth.oidc.requiredRoles | quote }}
             - name: OIDC_JWKS_CACHE_TTL
               value: {{ .Values.ui.api.auth.oidc.jwksCacheTTL | quote }}
+            - name: OIDC_EXCLUDE_PATHS
+              value: {{ join "," .Values.ui.api.auth.oidc.excludePaths | quote }}
             {{- end }}
             {{- with .Values.ui.api.logging.handlers }}
             - name: LOG_HANDLERS

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/deployment-api.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/deployment-api.yaml
@@ -121,6 +121,18 @@ spec:
             - name: OTEL_SDK_DISABLED
               value: "true"
             {{- end }}
+            {{- if eq (include "aerospike-ce-kubernetes-operator.api.oidc.enabled" .) "true" }}
+            - name: OIDC_ENABLED
+              value: "true"
+            - name: OIDC_ISSUER_URL
+              value: {{ required "ui.api.auth.oidc.issuerUrl is required when ui.api.auth.oidc.enabled is true" .Values.ui.api.auth.oidc.issuerUrl | quote }}
+            - name: OIDC_AUDIENCE
+              value: {{ .Values.ui.api.auth.oidc.audience | quote }}
+            - name: OIDC_REQUIRED_ROLES
+              value: {{ join "," .Values.ui.api.auth.oidc.requiredRoles | quote }}
+            - name: OIDC_JWKS_CACHE_TTL
+              value: {{ .Values.ui.api.auth.oidc.jwksCacheTTL | quote }}
+            {{- end }}
             {{- with .Values.ui.api.logging.handlers }}
             - name: LOG_HANDLERS
               value: {{ . | quote }}

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/deployment-web.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/deployment-web.yaml
@@ -78,6 +78,34 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- if or (eq (include "aerospike-ce-kubernetes-operator.multiCluster.enabled" .) "true") (eq (include "aerospike-ce-kubernetes-operator.web.oidc.enabled" .) "true") }}
+          volumeMounts:
+            {{- if eq (include "aerospike-ce-kubernetes-operator.multiCluster.enabled" .) "true" }}
+            - name: cluster-registry
+              mountPath: /app/public/cluster-registry.json
+              subPath: cluster-registry.json
+              readOnly: true
+            {{- end }}
+            {{- if eq (include "aerospike-ce-kubernetes-operator.web.oidc.enabled" .) "true" }}
+            - name: web-oidc-config
+              mountPath: /app/public/web-oidc-config.json
+              subPath: web-oidc-config.json
+              readOnly: true
+            {{- end }}
+          {{- end }}
+      {{- if or (eq (include "aerospike-ce-kubernetes-operator.multiCluster.enabled" .) "true") (eq (include "aerospike-ce-kubernetes-operator.web.oidc.enabled" .) "true") }}
+      volumes:
+        {{- if eq (include "aerospike-ce-kubernetes-operator.multiCluster.enabled" .) "true" }}
+        - name: cluster-registry
+          configMap:
+            name: {{ include "aerospike-ce-kubernetes-operator.clusterRegistryConfigMapName" . }}
+        {{- end }}
+        {{- if eq (include "aerospike-ce-kubernetes-operator.web.oidc.enabled" .) "true" }}
+        - name: web-oidc-config
+          configMap:
+            name: {{ include "aerospike-ce-kubernetes-operator.webOidcConfigMapName" . }}
+        {{- end }}
+      {{- end }}
       {{- with .Values.ui.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/tests/test-multicluster-routing.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/tests/test-multicluster-routing.yaml
@@ -1,0 +1,60 @@
+{{- if and (eq (include "aerospike-ce-kubernetes-operator.multiCluster.enabled" .) "true") .Values.ui.tests.enabled }}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "aerospike-ce-kubernetes-operator.ui.fullname" . }}-test-multicluster
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "aerospike-ce-kubernetes-operator.ui.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 100
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+    - name: registry-probe
+      image: curlimages/curl:8.5.0
+      command:
+        - sh
+        - -c
+        - |
+          set -e
+          REGISTRY_URL="http://{{ include "aerospike-ce-kubernetes-operator.ui.web.fullname" . }}:{{ .Values.ui.web.service.port }}/cluster-registry.json"
+          echo "Fetching cluster registry from $REGISTRY_URL"
+          HTTP_CODE=$(curl -s -o /tmp/registry.json -w "%{http_code}" --max-time 10 "$REGISTRY_URL")
+          if [ "$HTTP_CODE" != "200" ]; then
+            echo "FAIL: cluster-registry.json returned HTTP $HTTP_CODE"
+            exit 1
+          fi
+          echo "cluster-registry.json reachable (HTTP 200)"
+          cat /tmp/registry.json
+          {{- range .Values.multiCluster.clusters }}
+          API_URL="{{ .apiUrl }}/api/health"
+          echo "Probing {{ .id }} -> $API_URL"
+          API_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "$API_URL" || echo "000")
+          if [ "$API_CODE" != "200" ]; then
+            echo "FAIL: cluster {{ .id }} health endpoint returned HTTP $API_CODE"
+            exit 1
+          fi
+          echo "cluster {{ .id }} healthy"
+          {{- end }}
+          echo "multi-cluster routing test passed"
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop:
+            - ALL
+      resources:
+        requests:
+          cpu: 10m
+          memory: 32Mi
+        limits:
+          cpu: 50m
+          memory: 64Mi
+{{- end }}

--- a/charts/aerospike-ce-kubernetes-operator/templates/validatingwebhookconfiguration.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/validatingwebhookconfiguration.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "aerospike-ce-kubernetes-operator.operator.enabled" .) "true" }}
 {{- if .Values.webhook.enabled }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -30,4 +31,5 @@ webhooks:
         resources:
           - aerospikeclusters
     sideEffects: None
+{{- end }}
 {{- end }}

--- a/charts/aerospike-ce-kubernetes-operator/values-common.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/values-common.yaml
@@ -1,0 +1,84 @@
+# =============================================================================
+# Preset: "common" cluster (web-only)
+# =============================================================================
+# Renders only the web SPA + multi-cluster registry + OIDC ConfigMap.
+# Use this preset for the cluster that hosts the unified UI front-door
+# (browser entrypoint) while dev/prod clusters host operator + api separately.
+#
+# Required user overrides:
+#   multiCluster.defaultClusterId
+#   multiCluster.clusters[*].apiUrl
+#   ui.web.auth.oidc.issuerUrl
+#   ui.web.auth.oidc.redirectUri
+#
+# Apply with:
+#   helm install <name> . -f values-common.yaml \
+#     --set multiCluster.defaultClusterId=dev \
+#     --set ui.web.auth.oidc.issuerUrl=https://kc.example.com/realms/acko \
+#     --set ui.web.auth.oidc.redirectUri=https://acko.example.com/
+# =============================================================================
+
+# Operator + CRDs are provided by the dev/prod clusters.
+operator:
+  enabled: false
+
+crds:
+  install: false
+
+defaultTemplates:
+  enabled: false
+
+webhook:
+  enabled: false
+
+# Multi-cluster registry feeds the SPA's cluster selector.
+multiCluster:
+  enabled: true
+  defaultClusterId: ""
+  clusters: []
+  # Example:
+  # clusters:
+  #   - id: dev
+  #     displayName: "Dev"
+  #     apiUrl: "https://dev-api.example.com"
+  #     labels:
+  #       env: dev
+  #   - id: prod
+  #     displayName: "Prod"
+  #     apiUrl: "https://prod-api.example.com"
+  #     labels:
+  #       env: prod
+
+ui:
+  api:
+    # API is hosted on dev/prod clusters; common renders web only.
+    enabled: false
+  web:
+    enabled: true
+    auth:
+      oidc:
+        # OIDC is mandatory for the public-facing common cluster.
+        enabled: true
+        issuerUrl: ""
+        clientId: "acko-spa"
+        redirectUri: ""
+        scopes:
+          - openid
+          - profile
+          - email
+  ingress:
+    enabled: true
+    target: web
+    hosts:
+      - host: acko.example.com
+        paths:
+          - path: /
+            pathType: Prefix
+  # Persistent Postgres / DB sidecar belongs on the api side, not on common.
+  postgresql:
+    enabled: false
+  persistence:
+    enabled: false
+  k8s:
+    # Web-only cluster has no in-cluster ACKO operator to talk to.
+    enabled: false

--- a/charts/aerospike-ce-kubernetes-operator/values-operator.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/values-operator.yaml
@@ -1,0 +1,54 @@
+# =============================================================================
+# Preset: "operator" cluster (api + operator)
+# =============================================================================
+# Renders the controller-manager, CRDs, webhook, and the FastAPI backend
+# with OIDC bearer-token validation. The web SPA is hosted by the "common"
+# cluster (see values-common.yaml).
+#
+# Required user overrides:
+#   ui.api.auth.oidc.issuerUrl
+#   ui.ingress.hosts[*].host    # e.g. dev-api.example.com
+#
+# Apply with:
+#   helm install <name> . -f values-operator.yaml \
+#     --set ui.api.auth.oidc.issuerUrl=https://kc.example.com/realms/acko \
+#     --set ui.ingress.hosts[0].host=dev-api.example.com
+# =============================================================================
+
+operator:
+  enabled: true
+
+crds:
+  install: true
+
+ui:
+  api:
+    enabled: true
+    auth:
+      oidc:
+        # OIDC is mandatory: the api is exposed via Ingress and accessed
+        # cross-cluster from the SPA.
+        enabled: true
+        issuerUrl: ""
+        audience: "acko-api"
+        requiredRoles: []
+        jwksCacheTTL: "10m"
+        excludePaths:
+          - /api/health
+          - /api/openapi.json
+          - /api/docs
+  web:
+    # Web UI is hosted on the common cluster.
+    enabled: false
+  ingress:
+    enabled: true
+    target: api
+    hosts:
+      - host: dev-api.example.com
+        paths:
+          - path: /
+            pathType: Prefix
+
+# multiCluster registry is irrelevant on api-side clusters.
+multiCluster:
+  enabled: false

--- a/charts/aerospike-ce-kubernetes-operator/values.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/values.yaml
@@ -3,6 +3,57 @@
 # =============================================================================
 
 # =============================================================================
+# Operator (controller-manager) deployment toggle
+# =============================================================================
+# Setting `operator.enabled=false` disables every operator-related resource:
+# the controller Deployment, ServiceAccount/RBAC, webhook configurations,
+# cert-manager Certificate, metrics Service/ServiceMonitor, PrometheusRule,
+# Grafana dashboard, HPA, PDB, NetworkPolicy/CiliumNetworkPolicy, and the
+# default AerospikeClusterTemplates. The chart then renders only the UI
+# (api / web) and shared resources you have enabled.
+#
+# Useful for the multi-cluster topology where one "common" cluster hosts only
+# the web frontend and dev/prod clusters host operator + api individually.
+# Default `true` preserves backwards compatibility for single-cluster installs.
+operator:
+  # -- Deploy the controller-manager (operator) and all of its supporting
+  # resources. Disable to render UI-only / web-only installs.
+  enabled: true
+
+# =============================================================================
+# Multi-cluster topology (cluster registry served to the web UI)
+# =============================================================================
+# Provides a static cluster registry to the web frontend so a single SPA can
+# pivot between multiple ACKO API endpoints (typically one per environment).
+# When enabled, a ConfigMap named `<release>-cluster-registry` is rendered
+# with key `cluster-registry.json` and mounted into the web pod so the SPA
+# can fetch it via `/cluster-registry.json` at boot. Mutually exclusive with
+# `ui.web.env.apiUrl` (single-API override) — using both is ambiguous and
+# fails template rendering.
+multiCluster:
+  # -- Enable multi-cluster registry rendering.
+  enabled: false
+  # -- Default cluster ID the SPA selects on first load. Must match one of
+  # the entries in `clusters` below.
+  defaultClusterId: ""
+  # -- List of clusters available to the web UI. Each entry is shipped as-is
+  # in `cluster-registry.json` and is consumed by the SPA's cluster selector.
+  # Schema: { id, displayName, apiUrl, labels{} }
+  # Example:
+  #   clusters:
+  #     - id: dev
+  #       displayName: "Dev"
+  #       apiUrl: "https://dev-api.example.com"
+  #       labels:
+  #         env: dev
+  #     - id: prod
+  #       displayName: "Prod"
+  #       apiUrl: "https://prod-api.example.com"
+  #       labels:
+  #         env: prod
+  clusters: []
+
+# =============================================================================
 # Aerospike Images (used by default templates and UI wizard)
 # =============================================================================
 # Override these for air-gapped environments where Docker Hub is unreachable.
@@ -410,6 +461,41 @@ ui:
       headers: ""
 
     # =============================================================================
+    # OIDC (FastAPI bearer-token validation)
+    # =============================================================================
+    # Enables JWT bearer-token authentication on the FastAPI backend. The
+    # api validates tokens against a Keycloak (or any OIDC-compliant) IdP
+    # using a JWKS cache. The web SPA acquires the token via PKCE and
+    # forwards it as `Authorization: Bearer <token>`.
+    auth:
+      oidc:
+        # -- Enable OIDC bearer-token authentication on the API.
+        # When false the API stays open (current behaviour, BC).
+        enabled: false
+        # -- OIDC issuer URL (used to discover JWKS / token endpoints).
+        # Required when `enabled=true`. Example:
+        #   issuerUrl: "https://keycloak.example.com/realms/acko"
+        issuerUrl: ""
+        # -- Expected `aud` claim. Tokens with a different audience are
+        # rejected.
+        audience: "acko-api"
+        # -- Required role claims. A token must contain at least one of
+        # these in its realm/client roles. Empty list = no role check
+        # (any authenticated user is accepted).
+        # Example: ["acko-admin", "acko-operator"]
+        requiredRoles: []
+        # -- JWKS cache TTL (Go-style duration string). Lower values
+        # tighten key-rotation propagation at the cost of more JWKS HTTP
+        # calls.
+        jwksCacheTTL: "10m"
+        # -- Paths bypassed by the auth middleware. Health/openapi/docs
+        # must remain reachable for liveness probes and Swagger UI.
+        excludePaths:
+          - /api/health
+          - /api/openapi.json
+          - /api/docs
+
+    # =============================================================================
     # Logging — pluggable handlers via LOG_HANDLERS or full dictConfig.
     # See aerospike-cluster-manager docs/logging.md for examples.
     # =============================================================================
@@ -480,6 +566,33 @@ ui:
       initialDelaySeconds: 5
       periodSeconds: 10
       timeoutSeconds: 5
+
+    # =============================================================================
+    # OIDC (web SPA — Authorization Code + PKCE)
+    # =============================================================================
+    # When enabled, the chart writes `web-oidc-config.json` into a ConfigMap
+    # mounted on the web pod so the SPA can fetch it at boot and configure
+    # keycloak-js (or the equivalent OIDC client) without a rebuild.
+    auth:
+      oidc:
+        # -- Enable OIDC login on the web SPA. When false the UI starts in
+        # anonymous mode (current behaviour, BC).
+        enabled: false
+        # -- OIDC issuer URL (same realm as the API). Required when
+        # `enabled=true`.
+        issuerUrl: ""
+        # -- Public client ID registered in Keycloak for the SPA. Defaults
+        # to `acko-spa`.
+        clientId: "acko-spa"
+        # -- Redirect URI registered in the IdP. Typically the web origin
+        # (e.g. https://acko.example.com/). Required when `enabled=true`.
+        redirectUri: ""
+        # -- OAuth2 / OIDC scopes requested at login. `openid` is mandatory
+        # for OIDC; `profile`/`email` are useful for displaying user info.
+        scopes:
+          - openid
+          - profile
+          - email
 
   # =============================================================================
   # Service Account & RBAC

--- a/docs/multi-cluster-keycloak.md
+++ b/docs/multi-cluster-keycloak.md
@@ -266,6 +266,18 @@ Each cluster needs its own ingress host, and each host needs its own TLS certifi
 
 Cross-origin requirements: every API ingress must allow `Origin: https://app.example.com` (the common cluster) in CORS, otherwise the browser fan-out to dev/prod will be blocked. The chart sets this from `multiCluster.clusters[].apiUrl` (and from the web ingress host).
 
+### **MANDATORY**: mask `access_token` in ingress access logs
+
+The SPA opens its event stream as `EventSource` with the access token on the URL (`/api/events/stream?cluster=<id>&access_token=<jwt>`). `EventSource` cannot set custom headers, so the token has to ride on the query string. The FastAPI access log already masks it, but **every ingress controller / load balancer in front of the API must also mask the `access_token` and `id_token` query parameters in its access logs.** Otherwise tokens land in plaintext on whoever rotates the ingress logs.
+
+Examples:
+
+- **nginx-ingress**: set `nginx.ingress.kubernetes.io/configuration-snippet` to redact the params with `set $masked_args $args; if ($masked_args ~* "access_token=[^&]*") { set $masked_args "access_token=***"; }` then reference `$masked_args` in the log format.
+- **Envoy / Istio**: configure a `Lua` `EnvoyFilter` on the request flow that rewrites the `access_token` and `id_token` query values before the access log encoder sees them.
+- **Cloud LB access logs (GCP / AWS)**: tokens *will* be logged. Either disable URL logging on the SSE path, or terminate TLS at an in-cluster proxy that masks before forwarding to the cloud LB.
+
+Long-term, this exposure is tracked as a follow-up ADR (per-stream signed nonce or a transport upgrade that allows header-based subscription auth).
+
 ---
 
 ## Troubleshooting

--- a/docs/multi-cluster-keycloak.md
+++ b/docs/multi-cluster-keycloak.md
@@ -1,0 +1,318 @@
+# Multi-Cluster Topology with Keycloak OIDC
+
+This guide describes how to install ACKO in a **multi-cluster topology**: one **common cluster** that hosts only the web UI (cluster-manager SPA) and one or more **operator clusters** (typically `dev` and `prod`) that each run the API + operator and manage their own local Aerospike clusters. Authentication is delegated to an **external Keycloak realm**, and FastAPI verifies access tokens natively via JWKS.
+
+This is the production topology behind ADR-0040.
+
+---
+
+## Topology
+
+```
+                 +-------------------------------+
+                 |   Browser (developer / SRE)   |
+                 +---------------+---------------+
+                                 |
+              +------------------+------------------+
+              |                  |                  |
+              v                  v                  v
+    +------------------+  +-----------------+  +------------------+
+    |  common cluster  |  |   dev cluster   |  |  prod cluster    |
+    |  (web only)      |  |  (api+operator) |  |  (api+operator)  |
+    |                  |  |                 |  |                  |
+    |  ingress: app.*  |  | ingress: api.   |  | ingress: api.    |
+    |  /cluster-       |  |  dev.*          |  |  prod.*          |
+    |  registry.json   |  |                 |  |                  |
+    +--------+---------+  +--------+--------+  +---------+--------+
+             |                     |                     |
+             |                     v                     v
+             |             +---------------+    +----------------+
+             |             | Aerospike CE  |    | Aerospike CE   |
+             |             | dev cluster   |    | prod cluster   |
+             |             +---------------+    +----------------+
+             |
+             v  (authentication only — not data)
+       +-----------------+
+       |   Keycloak      |    realm: acko
+       |   (external)    |    SPA client: acko-spa (PKCE)
+       +-----------------+    audience: acko-api
+```
+
+Key properties:
+
+- The **browser is the fan-out point**. After loading the SPA from the common cluster, it calls each operator cluster's API ingress directly. There is no proxy hop in the common cluster.
+- The **cluster registry** (which operator clusters exist, what their host names are, what label/role gates them) is shipped from helm values via a ConfigMap mounted into the web pod at `/cluster-registry.json`. There is no runtime registration path.
+- **Authentication** is performed by FastAPI itself: each operator cluster's API verifies the JWT (`audience: acko-api`) against the Keycloak realm's JWKS. There is no shared session storage across clusters.
+- **Authorization** uses Keycloak realm roles. Cluster-scoped roles follow the `acko:<env>` naming convention (`acko:dev`, `acko:prod`).
+
+---
+
+## Prerequisites
+
+| Requirement | Notes |
+|-------------|-------|
+| 1 common Kubernetes cluster | Hosts the web UI |
+| 1+ operator Kubernetes clusters | Each hosts api+operator and one Aerospike CE cluster |
+| Keycloak (production-grade) | External, reachable from the browser AND from each operator cluster's pods |
+| cert-manager on every cluster | Wildcard or per-host TLS via LetsEncrypt is recommended |
+| DNS for each ingress host | `app.example.com`, `api.dev.example.com`, `api.prod.example.com`, etc. |
+| Helm 3.8+ | OCI registry support required |
+
+> **Note**: Local/CI bootstrap of Keycloak via `bitnami/keycloak` is supported for development and e2e but is **not** recommended for production. In production, run Keycloak as a separately managed service.
+
+---
+
+## Step 1 — Set up Keycloak (realm, client, audience mapper)
+
+ACKO uses a **single realm**, a **single SPA client**, and a **single API audience**. Cluster-level isolation is expressed as realm roles, not as separate audiences.
+
+### Required objects
+
+| Object | Value |
+|--------|-------|
+| Realm | `acko` |
+| SPA client | `acko-spa` — public, standard flow + PKCE, no client secret |
+| API audience | `acko-api` — added via a hardcoded audience mapper on `acko-spa` |
+| Roles | `acko:dev`, `acko:prod` (optional, only if you want per-environment gating) |
+
+### Option A — `kcadm.sh` (Keycloak CLI)
+
+```sh
+# Authenticate (replace KEYCLOAK_URL and admin password)
+kcadm.sh config credentials \
+  --server "$KEYCLOAK_URL" \
+  --realm master \
+  --user admin \
+  --password "$KEYCLOAK_ADMIN_PASSWORD"
+
+# Create the realm
+kcadm.sh create realms -s realm=acko -s enabled=true
+
+# Create the SPA public client with PKCE
+kcadm.sh create clients -r acko \
+  -s clientId=acko-spa \
+  -s publicClient=true \
+  -s standardFlowEnabled=true \
+  -s 'attributes."pkce.code.challenge.method"=S256' \
+  -s 'redirectUris=["https://app.example.com/*"]' \
+  -s 'webOrigins=["+"]'
+
+# Add a hardcoded audience mapper so tokens carry aud=acko-api
+SPA_ID=$(kcadm.sh get clients -r acko -q clientId=acko-spa --fields id --format csv --noquotes | tail -n1)
+kcadm.sh create clients/$SPA_ID/protocol-mappers/models -r acko \
+  -s name=acko-api-audience \
+  -s protocol=openid-connect \
+  -s protocolMapper=oidc-audience-mapper \
+  -s 'config."included.custom.audience"=acko-api' \
+  -s 'config."access.token.claim"=true'
+
+# Create cluster-scoped realm roles (optional)
+kcadm.sh create roles -r acko -s name=acko:dev
+kcadm.sh create roles -r acko -s name=acko:prod
+```
+
+### Option B — Terraform Keycloak provider
+
+```hcl
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "keycloak/keycloak"
+      version = "~> 4.4"
+    }
+  }
+}
+
+provider "keycloak" {
+  url       = var.keycloak_url
+  client_id = "admin-cli"
+  username  = var.keycloak_admin
+  password  = var.keycloak_password
+  realm     = "master"
+}
+
+resource "keycloak_realm" "acko" {
+  realm   = "acko"
+  enabled = true
+}
+
+resource "keycloak_openid_client" "spa" {
+  realm_id                     = keycloak_realm.acko.id
+  client_id                    = "acko-spa"
+  access_type                  = "PUBLIC"
+  standard_flow_enabled        = true
+  pkce_code_challenge_method   = "S256"
+  valid_redirect_uris          = ["https://app.example.com/*"]
+  web_origins                  = ["+"]
+}
+
+resource "keycloak_openid_audience_protocol_mapper" "spa_audience" {
+  realm_id                 = keycloak_realm.acko.id
+  client_id                = keycloak_openid_client.spa.id
+  name                     = "acko-api-audience"
+  included_custom_audience = "acko-api"
+  add_to_access_token      = true
+}
+
+resource "keycloak_role" "dev" {
+  realm_id = keycloak_realm.acko.id
+  name     = "acko:dev"
+}
+
+resource "keycloak_role" "prod" {
+  realm_id = keycloak_realm.acko.id
+  name     = "acko:prod"
+}
+```
+
+### Verify the realm
+
+```sh
+curl -s "$KEYCLOAK_URL/realms/acko/.well-known/openid-configuration" | jq '.issuer, .jwks_uri'
+```
+
+You should see the realm issuer and a JWKS URI. Both must be reachable from the browser **and** from every operator cluster's API pod.
+
+---
+
+## Step 2 — Install ACKO on each cluster
+
+> File names and values keys below match the contracts agreed in ADR-0040. Refer to the chart's `values.yaml` for the complete schema.
+
+### Common cluster (web only)
+
+`values-common.yaml`:
+
+```yaml
+operator:
+  enabled: false        # no operator on the common cluster
+ui:
+  api:
+    enabled: false      # no API on the common cluster
+  web:
+    enabled: true
+    auth:
+      oidc:
+        issuerUrl: https://keycloak.example.com/realms/acko
+        clientId: acko-spa
+multiCluster:
+  enabled: true
+  clusters:
+    - name: dev
+      label: Development
+      apiBaseUrl: https://api.dev.example.com
+      requiredRole: acko:dev   # optional — omit for "any authenticated user"
+    - name: prod
+      label: Production
+      apiBaseUrl: https://api.prod.example.com
+      requiredRole: acko:prod
+```
+
+```sh
+helm install acko-web oci://ghcr.io/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator \
+  -n acko-web --create-namespace \
+  -f values-common.yaml
+```
+
+### Operator cluster (dev / prod)
+
+`values-operator.yaml` (per environment — change `name`/issuer/audience as needed):
+
+```yaml
+operator:
+  enabled: true
+ui:
+  api:
+    enabled: true
+    auth:
+      oidc:
+        issuerUrl: https://keycloak.example.com/realms/acko
+        audience: acko-api
+        # JWKS endpoint is auto-derived from the realm's
+        # /.well-known/openid-configuration document.
+  web:
+    enabled: false       # web lives on the common cluster only
+multiCluster:
+  enabled: false         # operator clusters do not host the registry
+```
+
+```sh
+helm install acko oci://ghcr.io/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator \
+  -n acko --create-namespace \
+  -f values-operator.yaml
+```
+
+Repeat for each environment (`dev`, `prod`, …).
+
+---
+
+## Step 3 — DNS and TLS
+
+Each cluster needs its own ingress host, and each host needs its own TLS certificate. The recommended pattern is **cert-manager + LetsEncrypt** with a per-cluster `ClusterIssuer`.
+
+| Cluster | Ingress host | Certificate |
+|---------|-------------|-------------|
+| common  | `app.example.com` | LetsEncrypt via cert-manager |
+| dev     | `api.dev.example.com` | LetsEncrypt via cert-manager |
+| prod    | `api.prod.example.com` | LetsEncrypt via cert-manager |
+
+Cross-origin requirements: every API ingress must allow `Origin: https://app.example.com` (the common cluster) in CORS, otherwise the browser fan-out to dev/prod will be blocked. The chart sets this from `multiCluster.clusters[].apiBaseUrl` (and from the web ingress host).
+
+---
+
+## Troubleshooting
+
+### `401 Unauthorized` from the API
+
+1. The browser must be sending an `Authorization: Bearer <token>` header. Open DevTools → Network and confirm the header is present and the token is not expired.
+2. Decode the token (jwt.io). Check:
+   - `iss` matches the API's configured `issuerUrl`
+   - `aud` includes `acko-api` (this is what the audience mapper does — if it is missing, the mapper is not attached to `acko-spa`)
+3. If the role gate is enabled, check `realm_access.roles[]` includes the cluster-scoped role (`acko:dev` or `acko:prod`).
+
+### `JWKS fetch failed` in API logs
+
+- The API pod cannot reach `https://keycloak.example.com/realms/acko/protocol/openid-connect/certs`. Check:
+  - Egress NetworkPolicy is not blocking outbound HTTPS to the Keycloak host
+  - DNS resolves inside the cluster (`kubectl exec ... -- nslookup keycloak.example.com`)
+  - The Keycloak certificate chain is trusted by the pod (custom CA? mount it into `/etc/ssl/certs`)
+
+### CORS preflight fails on browser fan-out
+
+- The dev/prod API ingress is rejecting `OPTIONS` from `app.example.com`. Verify the API chart values include the common cluster host in `ui.api.cors.allowedOrigins`. If the chart fills this from `multiCluster.clusters[].apiBaseUrl`, double-check the URL has no trailing slash mismatch.
+
+### Cluster registry shows empty list
+
+- The web pod cannot find `/cluster-registry.json`. Verify:
+  - `multiCluster.enabled: true` AND `multiCluster.clusters[]` is non-empty in the common cluster's values
+  - The `cluster-registry` ConfigMap exists in the web namespace (`kubectl get cm cluster-registry`)
+  - The web pod has the ConfigMap mounted as a volume (`kubectl describe pod ...`)
+
+### Token works on dev but not prod (or vice versa)
+
+- Audience is shared (`acko-api`) but cluster-scoped roles are not. Ensure the user has both `acko:dev` and `acko:prod` if they need access to both, or remove the `requiredRole` gate to fall back to "any authenticated user".
+
+---
+
+## Open Items (Future Work)
+
+This guide covers stage 1 only. The following items are tracked in ADR-0040 as future work:
+
+- **Defense in depth via ingress oauth2-proxy / Keycloak gatekeeper** — currently FastAPI does the JWT verification by itself; an ingress-level proxy can be added in front later without breaking this flow.
+- **Realm/client provisioning automation** — Terraform Keycloak provider HCL above is the recommended starting point.
+- **mTLS between proxy and API** — service mesh or cert-manager based.
+- **Cross-cluster metrics/logs federation** — Prometheus federation, Loki multi-tenant.
+- **Multi-Kind e2e (stage 2)** — current e2e simulates the topology in a single Kind cluster via namespaces.
+- **Cross-cluster PostgreSQL connection-profile aggregation** — each operator cluster currently keeps its own DB silo.
+- **Per-cluster audiences (`acko-api-dev`, `acko-api-prod`)** — to harden against token replay across environments.
+
+---
+
+## References
+
+- [ADR-0040](https://aerospike-ce-ecosystem.github.io/project-hub/docs/architecture/adr/2026-05-05-multi-cluster-topology-and-keycloak-oidc) — design rationale
+- [Keycloak Server Administration Guide](https://www.keycloak.org/docs/latest/server_admin/)
+- [Keycloak — Securing Applications Overview](https://www.keycloak.org/securing-apps/overview)
+- [bitnami/keycloak Helm chart](https://github.com/bitnami/charts/tree/main/bitnami/keycloak)
+- [cert-manager](https://cert-manager.io/docs/)
+- [Terraform Keycloak Provider](https://registry.terraform.io/providers/keycloak/keycloak/latest/docs)

--- a/docs/multi-cluster-keycloak.md
+++ b/docs/multi-cluster-keycloak.md
@@ -197,16 +197,24 @@ ui:
         clientId: acko-spa
 multiCluster:
   enabled: true
+  defaultClusterId: dev
   clusters:
-    - name: dev
-      label: Development
-      apiBaseUrl: https://api.dev.example.com
-      requiredRole: acko:dev   # optional — omit for "any authenticated user"
-    - name: prod
-      label: Production
-      apiBaseUrl: https://api.prod.example.com
-      requiredRole: acko:prod
+    - id: dev
+      displayName: Development
+      apiUrl: https://api.dev.example.com
+      labels:
+        env: dev
+    - id: prod
+      displayName: Production
+      apiUrl: https://api.prod.example.com
+      labels:
+        env: prod
 ```
+
+> Note: cluster-scoped role gating (`acko:dev` / `acko:prod`) lives on
+> the API side, not the registry. Configure it per-environment via
+> `ui.api.auth.oidc.requiredRoles` in each operator cluster's
+> `values-operator.yaml` (see below).
 
 ```sh
 helm install acko-web oci://ghcr.io/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator \
@@ -256,7 +264,7 @@ Each cluster needs its own ingress host, and each host needs its own TLS certifi
 | dev     | `api.dev.example.com` | LetsEncrypt via cert-manager |
 | prod    | `api.prod.example.com` | LetsEncrypt via cert-manager |
 
-Cross-origin requirements: every API ingress must allow `Origin: https://app.example.com` (the common cluster) in CORS, otherwise the browser fan-out to dev/prod will be blocked. The chart sets this from `multiCluster.clusters[].apiBaseUrl` (and from the web ingress host).
+Cross-origin requirements: every API ingress must allow `Origin: https://app.example.com` (the common cluster) in CORS, otherwise the browser fan-out to dev/prod will be blocked. The chart sets this from `multiCluster.clusters[].apiUrl` (and from the web ingress host).
 
 ---
 
@@ -279,7 +287,7 @@ Cross-origin requirements: every API ingress must allow `Origin: https://app.exa
 
 ### CORS preflight fails on browser fan-out
 
-- The dev/prod API ingress is rejecting `OPTIONS` from `app.example.com`. Verify the API chart values include the common cluster host in `ui.api.cors.allowedOrigins`. If the chart fills this from `multiCluster.clusters[].apiBaseUrl`, double-check the URL has no trailing slash mismatch.
+- The dev/prod API ingress is rejecting `OPTIONS` from `app.example.com`. Verify the API chart values include the common cluster host in `ui.api.cors.allowedOrigins`. If the chart fills this from `multiCluster.clusters[].apiUrl`, double-check the URL has no trailing slash mismatch.
 
 ### Cluster registry shows empty list
 
@@ -290,7 +298,7 @@ Cross-origin requirements: every API ingress must allow `Origin: https://app.exa
 
 ### Token works on dev but not prod (or vice versa)
 
-- Audience is shared (`acko-api`) but cluster-scoped roles are not. Ensure the user has both `acko:dev` and `acko:prod` if they need access to both, or remove the `requiredRole` gate to fall back to "any authenticated user".
+- Audience is shared (`acko-api`) but cluster-scoped roles are not. Ensure the user has both `acko:dev` and `acko:prod` if they need access to both, or clear `ui.api.auth.oidc.requiredRoles` on the relevant operator cluster to fall back to "any authenticated user".
 
 ---
 

--- a/scripts/keycloak/README.md
+++ b/scripts/keycloak/README.md
@@ -1,0 +1,61 @@
+# scripts/keycloak
+
+Local / e2e Keycloak realm bootstrap. **Not for production.**
+
+## Files
+
+| File | Role |
+|------|------|
+| `values-keycloak-local.yaml` | helm values for `bitnami/keycloak` 25.2.0. Overrides every image to the `bitnamilegacy/*` mirror (since bitnami removed the free tags on 2025-08-28) and points `keycloakConfigCli` at the `acko-realm` ConfigMap. Pair with `--version 25.2.0` on the helm CLI. |
+| `acko-realm.json` | Realm definition imported by `keycloakConfigCli`. |
+| `README.md` | This file. |
+
+## Why a separate values file?
+
+`Makefile install-keycloak` and any operator who wants to tweak the
+local IdP (e.g. enabling smtp, raising postgres pvc size) share a
+single source of truth. The Makefile only owns the chart version pin
+and the namespace; everything else lives in
+`values-keycloak-local.yaml`. To override locally without editing the
+file, drop a sibling `values-keycloak-local.override.yaml` and pass
+both via `helm upgrade -f values-keycloak-local.yaml -f
+values-keycloak-local.override.yaml`.
+
+## `acko-realm.json` — DEV-ONLY
+
+This file is imported by `keycloakConfigCli` (sidecar of bitnami/keycloak)
+during `make run-local` and CI e2e to provision the `acko` realm with the
+clients, roles, audience mapper, and test users that the e2e scenarios
+rely on.
+
+> [!WARNING]
+> **DO NOT apply this realm to a production Keycloak.**
+>
+> - Plaintext credentials: `admin/admin`, `dev-user/dev`, `prod-user/prod`
+> - Wildcard `redirectUris: ["*"]` and `webOrigins: ["*"]`
+> - `directAccessGrantsEnabled: true` on the public SPA client (so e2e
+>   tests can fetch tokens via Resource Owner Password grant — never
+>   enable this on a public-internet-facing IdP).
+> - The `acko-other` client exists solely so e2e can issue tokens with
+>   the wrong audience and assert the API rejects them.
+>
+> For production, follow `aerospike-ce-kubernetes-operator/docs/multi-cluster-keycloak.md`
+> which documents the kcadm and Terraform Keycloak provider paths.
+
+The file lives in two places that must stay in sync:
+
+| Path | Consumer |
+|------|----------|
+| `scripts/keycloak/acko-realm.json` | `make install-keycloak` → ConfigMap `acko-realm` |
+| `test/utils/testdata/acko-realm.json` | Go `//go:embed` for e2e helpers |
+
+`scripts/keycloak/` is the source of truth; `test/utils/testdata/` is a
+copy. See `MULTI_CLUSTER_OIDC_FOLLOW_UPS.md` for the open question about
+collapsing the duplication via `//go:embed` with a relative path.
+
+## Why no top-level `_comment` field in the JSON?
+
+Keycloak's `keycloak-config-cli` uses Jackson with strict schema
+validation, which rejects unknown fields (`UnrecognizedPropertyException`).
+The realm JSON must contain only fields from the official Keycloak
+RealmRepresentation; comments belong here in this README.

--- a/scripts/keycloak/acko-realm.json
+++ b/scripts/keycloak/acko-realm.json
@@ -1,5 +1,4 @@
 {
-  "_comment": "DEV-ONLY — DO NOT APPLY TO PRODUCTION. Plaintext credentials below (admin/admin, dev-user/dev, prod-user/prod) and wildcard redirectUris/webOrigins are intended for local kind clusters and CI e2e only. For production, follow docs/multi-cluster-keycloak.md to provision the realm via kcadm or the Terraform Keycloak provider.",
   "realm": "acko",
   "enabled": true,
   "displayName": "ACKO Local Development",
@@ -147,9 +146,11 @@
     {
       "username": "admin",
       "enabled": true,
+      "email": "admin@acko.local",
       "emailVerified": true,
       "firstName": "Admin",
       "lastName": "User",
+      "requiredActions": [],
       "credentials": [
         {
           "type": "password",
@@ -162,9 +163,11 @@
     {
       "username": "dev-user",
       "enabled": true,
+      "email": "dev-user@acko.local",
       "emailVerified": true,
       "firstName": "Dev",
       "lastName": "User",
+      "requiredActions": [],
       "credentials": [
         {
           "type": "password",
@@ -177,9 +180,11 @@
     {
       "username": "prod-user",
       "enabled": true,
+      "email": "prod-user@acko.local",
       "emailVerified": true,
       "firstName": "Prod",
       "lastName": "User",
+      "requiredActions": [],
       "credentials": [
         {
           "type": "password",

--- a/scripts/keycloak/acko-realm.json
+++ b/scripts/keycloak/acko-realm.json
@@ -1,4 +1,5 @@
 {
+  "_comment": "DEV-ONLY — DO NOT APPLY TO PRODUCTION. Plaintext credentials below (admin/admin, dev-user/dev, prod-user/prod) and wildcard redirectUris/webOrigins are intended for local kind clusters and CI e2e only. For production, follow docs/multi-cluster-keycloak.md to provision the realm via kcadm or the Terraform Keycloak provider.",
   "realm": "acko",
   "enabled": true,
   "displayName": "ACKO Local Development",

--- a/scripts/keycloak/acko-realm.json
+++ b/scripts/keycloak/acko-realm.json
@@ -1,0 +1,192 @@
+{
+  "realm": "acko",
+  "enabled": true,
+  "displayName": "ACKO Local Development",
+  "registrationAllowed": false,
+  "loginWithEmailAllowed": false,
+  "duplicateEmailsAllowed": false,
+  "resetPasswordAllowed": false,
+  "editUsernameAllowed": false,
+  "bruteForceProtected": false,
+  "accessTokenLifespan": 3600,
+  "ssoSessionIdleTimeout": 7200,
+  "ssoSessionMaxLifespan": 36000,
+  "roles": {
+    "realm": [
+      {
+        "name": "acko:dev",
+        "description": "ACKO developer cluster role (dev environment)",
+        "composite": false,
+        "clientRole": false
+      },
+      {
+        "name": "acko:prod",
+        "description": "ACKO production cluster role (prod environment)",
+        "composite": false,
+        "clientRole": false
+      }
+    ]
+  },
+  "clientScopes": [
+    {
+      "name": "acko-api-audience",
+      "description": "Adds aud=acko-api to access tokens",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "name": "acko-api-audience-mapper",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.client.audience": "acko-api",
+            "id.token.claim": "false",
+            "access.token.claim": "true"
+          }
+        }
+      ]
+    }
+  ],
+  "clients": [
+    {
+      "clientId": "acko-spa",
+      "name": "ACKO SPA (Cluster Manager Web)",
+      "description": "Public PKCE client used by the cluster-manager UI and e2e direct-grant",
+      "enabled": true,
+      "publicClient": true,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "protocol": "openid-connect",
+      "redirectUris": ["*"],
+      "webOrigins": ["*"],
+      "attributes": {
+        "pkce.code.challenge.method": "S256",
+        "post.logout.redirect.uris": "+"
+      },
+      "defaultClientScopes": [
+        "web-origins",
+        "profile",
+        "roles",
+        "email",
+        "acko-api-audience"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ],
+      "protocolMappers": [
+        {
+          "name": "acko-api-audience-mapper",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.client.audience": "acko-api",
+            "id.token.claim": "false",
+            "access.token.claim": "true"
+          }
+        },
+        {
+          "name": "realm roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "multivalued": "true",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "realm_access.roles",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "clientId": "acko-other",
+      "name": "Other audience client (negative test)",
+      "description": "Issues tokens with aud=acko-other so e2e can verify audience rejection",
+      "enabled": true,
+      "publicClient": true,
+      "standardFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "protocol": "openid-connect",
+      "redirectUris": ["*"],
+      "webOrigins": ["*"],
+      "defaultClientScopes": [
+        "web-origins",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "protocolMappers": [
+        {
+          "name": "acko-other-audience-mapper",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.client.audience": "acko-other",
+            "id.token.claim": "false",
+            "access.token.claim": "true"
+          }
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "username": "admin",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Admin",
+      "lastName": "User",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "admin",
+          "temporary": false
+        }
+      ],
+      "realmRoles": ["acko:dev", "acko:prod"]
+    },
+    {
+      "username": "dev-user",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Dev",
+      "lastName": "User",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "dev",
+          "temporary": false
+        }
+      ],
+      "realmRoles": ["acko:dev"]
+    },
+    {
+      "username": "prod-user",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Prod",
+      "lastName": "User",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "prod",
+          "temporary": false
+        }
+      ],
+      "realmRoles": ["acko:prod"]
+    }
+  ]
+}

--- a/scripts/keycloak/values-keycloak-local.yaml
+++ b/scripts/keycloak/values-keycloak-local.yaml
@@ -1,0 +1,61 @@
+# scripts/keycloak/values-keycloak-local.yaml
+#
+# DEV-ONLY helm values for `bitnami/keycloak`, consumed by
+# `make run-local` and `make install-keycloak`. Pair with
+# `--version 25.2.0` on the helm CLI to avoid chart upgrades
+# pointing at image tags the legacy mirror never archived.
+#
+# Why every image is overridden to `bitnamilegacy/*`:
+#
+#   Bitnami removed `docker.io/bitnami/*` free images on
+#   2025-08-28. The chart's default values still point at the
+#   now-empty repo, so a fresh install fails with ErrImagePull.
+#   We override every image (keycloak / postgresql /
+#   keycloak-config-cli) to the frozen `bitnamilegacy/*` mirror
+#   until we migrate off bitnami. The legacy mirror is itself
+#   "no longer updated, may be removed in the future" — see
+#   `MULTI_CLUSTER_OIDC_FOLLOW_UPS.md` P0.0 for the migration
+#   tracking entry.
+#
+# `postgresql.image.tag` is pinned to `-r4` because the legacy
+# mirror does not contain the chart's default `-r0` build.
+#
+# `global.security.allowInsecureImages: true` bypasses the chart's
+# secure-image guard which would otherwise refuse a non-bitnami
+# repository as the source.
+
+global:
+  security:
+    allowInsecureImages: true
+
+image:
+  registry: docker.io
+  repository: bitnamilegacy/keycloak
+
+postgresql:
+  image:
+    registry: docker.io
+    repository: bitnamilegacy/postgresql
+    tag: 17.6.0-debian-12-r4
+
+keycloakConfigCli:
+  enabled: true
+  image:
+    registry: docker.io
+    repository: bitnamilegacy/keycloak-config-cli
+  # `acko-realm` ConfigMap is created by the `install-keycloak`
+  # Makefile target from `scripts/keycloak/acko-realm.json` before
+  # `helm upgrade --install` runs.
+  existingConfigmap: acko-realm
+
+auth:
+  adminUser: admin
+  adminPassword: admin
+
+service:
+  type: ClusterIP
+
+# Keycloak 26 listens behind a reverse proxy in `proxy=edge` mode.
+# Required so the issuer URL is computed from the X-Forwarded-Host
+# header rather than the in-cluster Service hostname.
+proxy: edge

--- a/test/utils/testdata/acko-realm.json
+++ b/test/utils/testdata/acko-realm.json
@@ -1,5 +1,4 @@
 {
-  "_comment": "DEV-ONLY — DO NOT APPLY TO PRODUCTION. Plaintext credentials below (admin/admin, dev-user/dev, prod-user/prod) and wildcard redirectUris/webOrigins are intended for local kind clusters and CI e2e only. For production, follow docs/multi-cluster-keycloak.md to provision the realm via kcadm or the Terraform Keycloak provider.",
   "realm": "acko",
   "enabled": true,
   "displayName": "ACKO Local Development",
@@ -147,9 +146,11 @@
     {
       "username": "admin",
       "enabled": true,
+      "email": "admin@acko.local",
       "emailVerified": true,
       "firstName": "Admin",
       "lastName": "User",
+      "requiredActions": [],
       "credentials": [
         {
           "type": "password",
@@ -162,9 +163,11 @@
     {
       "username": "dev-user",
       "enabled": true,
+      "email": "dev-user@acko.local",
       "emailVerified": true,
       "firstName": "Dev",
       "lastName": "User",
+      "requiredActions": [],
       "credentials": [
         {
           "type": "password",
@@ -177,9 +180,11 @@
     {
       "username": "prod-user",
       "enabled": true,
+      "email": "prod-user@acko.local",
       "emailVerified": true,
       "firstName": "Prod",
       "lastName": "User",
+      "requiredActions": [],
       "credentials": [
         {
           "type": "password",

--- a/test/utils/testdata/acko-realm.json
+++ b/test/utils/testdata/acko-realm.json
@@ -1,4 +1,5 @@
 {
+  "_comment": "DEV-ONLY — DO NOT APPLY TO PRODUCTION. Plaintext credentials below (admin/admin, dev-user/dev, prod-user/prod) and wildcard redirectUris/webOrigins are intended for local kind clusters and CI e2e only. For production, follow docs/multi-cluster-keycloak.md to provision the realm via kcadm or the Terraform Keycloak provider.",
   "realm": "acko",
   "enabled": true,
   "displayName": "ACKO Local Development",

--- a/test/utils/testdata/acko-realm.json
+++ b/test/utils/testdata/acko-realm.json
@@ -1,0 +1,192 @@
+{
+  "realm": "acko",
+  "enabled": true,
+  "displayName": "ACKO Local Development",
+  "registrationAllowed": false,
+  "loginWithEmailAllowed": false,
+  "duplicateEmailsAllowed": false,
+  "resetPasswordAllowed": false,
+  "editUsernameAllowed": false,
+  "bruteForceProtected": false,
+  "accessTokenLifespan": 3600,
+  "ssoSessionIdleTimeout": 7200,
+  "ssoSessionMaxLifespan": 36000,
+  "roles": {
+    "realm": [
+      {
+        "name": "acko:dev",
+        "description": "ACKO developer cluster role (dev environment)",
+        "composite": false,
+        "clientRole": false
+      },
+      {
+        "name": "acko:prod",
+        "description": "ACKO production cluster role (prod environment)",
+        "composite": false,
+        "clientRole": false
+      }
+    ]
+  },
+  "clientScopes": [
+    {
+      "name": "acko-api-audience",
+      "description": "Adds aud=acko-api to access tokens",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "name": "acko-api-audience-mapper",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.client.audience": "acko-api",
+            "id.token.claim": "false",
+            "access.token.claim": "true"
+          }
+        }
+      ]
+    }
+  ],
+  "clients": [
+    {
+      "clientId": "acko-spa",
+      "name": "ACKO SPA (Cluster Manager Web)",
+      "description": "Public PKCE client used by the cluster-manager UI and e2e direct-grant",
+      "enabled": true,
+      "publicClient": true,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "protocol": "openid-connect",
+      "redirectUris": ["*"],
+      "webOrigins": ["*"],
+      "attributes": {
+        "pkce.code.challenge.method": "S256",
+        "post.logout.redirect.uris": "+"
+      },
+      "defaultClientScopes": [
+        "web-origins",
+        "profile",
+        "roles",
+        "email",
+        "acko-api-audience"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ],
+      "protocolMappers": [
+        {
+          "name": "acko-api-audience-mapper",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.client.audience": "acko-api",
+            "id.token.claim": "false",
+            "access.token.claim": "true"
+          }
+        },
+        {
+          "name": "realm roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "multivalued": "true",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "realm_access.roles",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "clientId": "acko-other",
+      "name": "Other audience client (negative test)",
+      "description": "Issues tokens with aud=acko-other so e2e can verify audience rejection",
+      "enabled": true,
+      "publicClient": true,
+      "standardFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "protocol": "openid-connect",
+      "redirectUris": ["*"],
+      "webOrigins": ["*"],
+      "defaultClientScopes": [
+        "web-origins",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "protocolMappers": [
+        {
+          "name": "acko-other-audience-mapper",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.client.audience": "acko-other",
+            "id.token.claim": "false",
+            "access.token.claim": "true"
+          }
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "username": "admin",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Admin",
+      "lastName": "User",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "admin",
+          "temporary": false
+        }
+      ],
+      "realmRoles": ["acko:dev", "acko:prod"]
+    },
+    {
+      "username": "dev-user",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Dev",
+      "lastName": "User",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "dev",
+          "temporary": false
+        }
+      ],
+      "realmRoles": ["acko:dev"]
+    },
+    {
+      "username": "prod-user",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Prod",
+      "lastName": "User",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "prod",
+          "temporary": false
+        }
+      ],
+      "realmRoles": ["acko:prod"]
+    }
+  ]
+}

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -19,7 +19,9 @@ limitations under the License.
 package utils
 
 import (
+	_ "embed"
 	"fmt"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -36,7 +38,21 @@ const (
 	defaultKindBinary  = "kind"
 	defaultKindCluster = "kind"
 	podmanRuntime      = "podman"
+
+	keycloakNamespace      = "keycloak"
+	keycloakReleaseName    = "keycloak"
+	keycloakRealmConfigMap = "acko-realm"
+	keycloakChartRef       = "bitnami/keycloak"
+	keycloakRepoName       = "bitnami"
+	keycloakRepoURL        = "https://charts.bitnami.com/bitnami"
 )
+
+// ackoRealmJSON is the static Keycloak realm export used by the local/e2e
+// IdP. Bitnami's keycloak-config-cli imports it on startup. See
+// scripts/keycloak/acko-realm.json (Stream D contract C-5).
+//
+//go:embed testdata/acko-realm.json
+var ackoRealmJSON []byte
 
 func warnError(err error) {
 	_, _ = fmt.Fprintf(GinkgoWriter, "warning: %v\n", err)
@@ -165,6 +181,159 @@ func IsCertManagerCRDsInstalled() bool {
 	}
 
 	return false
+}
+
+// InstallKeycloak installs the bitnami/keycloak helm chart with the acko realm
+// preloaded via keycloak-config-cli. Idempotent: re-running upgrades the
+// release. Designed to mirror the Makefile `install-keycloak` target so e2e
+// tests and `make run-local` behave identically.
+func InstallKeycloak() error {
+	if _, err := exec.LookPath("helm"); err != nil {
+		return fmt.Errorf("helm binary not found on PATH: %w", err)
+	}
+
+	// helm repo add (ignore "already exists" errors)
+	cmd := exec.Command("helm", "repo", "add", keycloakRepoName, keycloakRepoURL)
+	if out, err := cmd.CombinedOutput(); err != nil &&
+		!strings.Contains(string(out), "already exists") {
+		return fmt.Errorf("helm repo add: %w (%s)", err, string(out))
+	}
+	cmd = exec.Command("helm", "repo", "update", keycloakRepoName)
+	if _, err := Run(cmd); err != nil {
+		return fmt.Errorf("helm repo update: %w", err)
+	}
+
+	// Ensure namespace
+	if err := applyDryRunResource(
+		[]string{"kubectl", "create", "namespace", keycloakNamespace, "--dry-run=client", "-o", "yaml"},
+	); err != nil {
+		return fmt.Errorf("create namespace %q: %w", keycloakNamespace, err)
+	}
+
+	// Write realm JSON to a temp file then turn into ConfigMap. We use
+	// `--from-file=acko-realm.json=<path>` so the ConfigMap key is exactly
+	// `acko-realm.json` regardless of the temp filename.
+	tmp, err := os.CreateTemp("", "acko-realm-*.json")
+	if err != nil {
+		return fmt.Errorf("temp realm file: %w", err)
+	}
+	defer func() { _ = os.Remove(tmp.Name()) }()
+	if _, err := tmp.Write(ackoRealmJSON); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write realm json: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close realm json: %w", err)
+	}
+
+	if err := applyDryRunResource([]string{
+		"kubectl", "create", "configmap", keycloakRealmConfigMap,
+		"--from-file=acko-realm.json=" + tmp.Name(),
+		"-n", keycloakNamespace,
+		"--dry-run=client", "-o", "yaml",
+	}); err != nil {
+		return fmt.Errorf("apply realm configmap: %w", err)
+	}
+
+	// helm upgrade --install keycloak
+	helmArgs := []string{
+		"upgrade", "--install", keycloakReleaseName, keycloakChartRef,
+		"--namespace", keycloakNamespace,
+		"--set", "auth.adminUser=admin",
+		"--set", "auth.adminPassword=admin",
+		"--set", "keycloakConfigCli.enabled=true",
+		"--set", "keycloakConfigCli.existingConfigmap=" + keycloakRealmConfigMap,
+		"--set", "service.type=ClusterIP",
+		"--set", "proxy=edge",
+		"--wait", "--timeout", "5m",
+	}
+	cmd = exec.Command("helm", helmArgs...)
+	if _, err := Run(cmd); err != nil {
+		return fmt.Errorf("helm install keycloak: %w", err)
+	}
+
+	cmd = exec.Command("kubectl", "wait", "deployment.apps/keycloak",
+		"--for", "condition=Available",
+		"--namespace", keycloakNamespace,
+		"--timeout", "5m",
+	)
+	if _, err := Run(cmd); err != nil {
+		return fmt.Errorf("wait keycloak deployment: %w", err)
+	}
+
+	return WaitForKeycloakReady()
+}
+
+// UninstallKeycloak removes the local keycloak release and its namespace.
+// Best-effort; intended for AfterSuite cleanup paths.
+func UninstallKeycloak() {
+	cmd := exec.Command("helm", "uninstall", keycloakReleaseName, "-n", keycloakNamespace)
+	if _, err := Run(cmd); err != nil {
+		warnError(err)
+	}
+	cmd = exec.Command("kubectl", "delete", "namespace", keycloakNamespace, "--ignore-not-found")
+	if _, err := Run(cmd); err != nil {
+		warnError(err)
+	}
+}
+
+// WaitForKeycloakReady polls Keycloak's well-known OIDC endpoint until it
+// returns HTTP 200. Uses an in-cluster `kubectl exec` so this works whether
+// or not a port-forward is set up — important because BeforeSuite runs
+// before any test fixtures.
+func WaitForKeycloakReady() error {
+	const wellKnown = "http://localhost/realms/acko/.well-known/openid-configuration"
+	for i := range 60 {
+		cmd := exec.Command("kubectl", "exec", "-n", keycloakNamespace,
+			"deployment/keycloak", "--",
+			"curl", "-sS", "-o", "/dev/null", "-w", "%{http_code}", wellKnown)
+		out, err := cmd.CombinedOutput()
+		if err == nil && strings.TrimSpace(string(out)) == "200" {
+			return nil
+		}
+		_, _ = fmt.Fprintf(GinkgoWriter,
+			"keycloak realm not ready yet, retrying (%d/60): rc=%v out=%q\n",
+			i+1, err, strings.TrimSpace(string(out)))
+		time.Sleep(2 * time.Second)
+	}
+	return fmt.Errorf("keycloak realm 'acko' did not become ready within 120s")
+}
+
+// PingKeycloakHTTP is exposed for any caller that already has a port-forward
+// or NodePort and just needs to verify the realm is up over HTTP. Returns nil
+// on the first 200 within 60s.
+func PingKeycloakHTTP(baseURL string) error {
+	url := strings.TrimRight(baseURL, "/") + "/realms/acko/.well-known/openid-configuration"
+	client := &http.Client{Timeout: 5 * time.Second}
+	for i := range 30 {
+		resp, err := client.Get(url)
+		if err == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return nil
+			}
+		}
+		_, _ = fmt.Fprintf(GinkgoWriter, "keycloak HTTP %s not 200 yet (%d/30)\n", url, i+1)
+		time.Sleep(2 * time.Second)
+	}
+	return fmt.Errorf("keycloak %s did not return 200 within 60s", url)
+}
+
+// applyDryRunResource runs the given `kubectl create ... --dry-run=client -o yaml`
+// command, then pipes the resulting YAML into `kubectl apply -f -`. This is
+// the idempotent apply pattern used throughout the e2e suite.
+func applyDryRunResource(generateCmd []string) error {
+	gen := exec.Command(generateCmd[0], generateCmd[1:]...) // nolint:gosec
+	yamlOut, err := gen.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%s: %w (%s)", strings.Join(generateCmd, " "), err, string(yamlOut))
+	}
+	apply := exec.Command("kubectl", "apply", "-f", "-")
+	apply.Stdin = strings.NewReader(string(yamlOut))
+	if _, err := Run(apply); err != nil {
+		return fmt.Errorf("kubectl apply (%s): %w", generateCmd[2], err)
+	}
+	return nil
 }
 
 // LoadImageToKindClusterWithName loads a local container image to the kind cluster.


### PR DESCRIPTION
## Summary
- Adds multi-cluster topology to the helm chart: `operator.enabled` toggle gating 22 controller-side templates, `multiCluster.{enabled,clusters[]}` static registry emitted as ConfigMap mounted at `/app/public/cluster-registry.json` (Next.js standalone), `values-common.yaml` and `values-operator.yaml` presets, helm test pod for routing smoke.
- Wires Keycloak OIDC: `ui.api.auth.oidc.*` injects `OIDC_*` env into API Deployment for FastAPI native JWT verification (single realm, audience `acko-api`, optional `acko:dev`/`acko:prod` role gating); `ui.web.auth.oidc.*` emits `web-oidc-config.json` ConfigMap for the SPA's PKCE init.
- Bootstraps Keycloak in local/e2e: `make run-local` and `make setup-test-e2e` install bitnami/keycloak with `keycloakConfigCli` auto-importing `scripts/keycloak/acko-realm.json` (realm + client + audience mapper + roles + test users). `SKIP_KEYCLOAK=true` escape hatch for non-OIDC e2e. Go helpers in `test/utils/utils.go` mirror the cert-manager helper pattern.
- Adds operator guide (`docs/multi-cluster-keycloak.md`) covering kcadm/Terraform realm setup, per-cluster install, TLS guidance, troubleshooting.

Default-mode helm template snapshot diff = 0 — full backward compatibility.

Cross-repo PRs (cluster-manager api+ui, plugins e2e_pytest, project-hub ADR-0040) follow separately under the same effort.

## Test plan
- [ ] \`helm lint charts/aerospike-ce-kubernetes-operator\`
- [ ] \`helm template -f charts/aerospike-ce-kubernetes-operator/values-common.yaml charts/aerospike-ce-kubernetes-operator\` → only web Deployment + 3 ConfigMaps; no operator/CRD/webhook
- [ ] \`helm template -f charts/aerospike-ce-kubernetes-operator/values-operator.yaml charts/aerospike-ce-kubernetes-operator\` → api+operator Deployments, no web, OIDC env injected
- [ ] \`helm template charts/aerospike-ce-kubernetes-operator\` (default) → snapshot diff vs main = 0
- [ ] \`make -n install-keycloak\` resolves; \`go vet ./test/...\` and \`go build -tags=e2e ./test/...\` pass
- [ ] Manual: \`make run-local\` brings up cert-manager + Keycloak + chart
- [ ] Manual: visit Keycloak (port-forward) → realm \`acko\` + client \`acko-spa\` exist; \`/realms/acko/.well-known/openid-configuration\` returns 200