### PR TITLE
fix(ci): SKIP_KEYCLOAK=true on Go e2e workflow

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -45,6 +45,15 @@ jobs:
         run: kind version
 
       - name: Running Test e2e
+        # SKIP_KEYCLOAK=true skips the bitnami/keycloak helm install in
+        # `setup-test-e2e`. The OIDC IdP is only needed by the
+        # multi-cluster scenarios (run separately under e2e_pytest in
+        # the plugins repo). Pulling bitnamilegacy/keycloak +
+        # bitnamilegacy/postgresql + keycloak-config-cli on a fresh
+        # CI runner repeatedly busted the chart's `--timeout 5m` and
+        # this Go-based e2e suite does not exercise OIDC.
+        env:
+          SKIP_KEYCLOAK: "true"
         run: |
           go mod tidy
           make test-e2e GINKGO_FLAGS="-ginkgo.label-filter=${{ github.event.inputs.ginkgo_label_filter || '!heavy' }}"


### PR DESCRIPTION
## Summary
The Go-based e2e suite (Ginkgo, controller behaviour) does not exercise OIDC, but \`setup-test-e2e\` was running \`make install-keycloak\` unconditionally, pulling bitnamilegacy/keycloak + bitnamilegacy/postgresql + keycloak-config-cli on a cold runner. The chart's \`--wait --timeout 5m\` blew up reliably with \`context deadline exceeded\`, failing PR #240's e2e job (7m13s).

\`Makefile\` already exposes \`SKIP_KEYCLOAK=true\` (introduced in #239 / Stream D) for exactly this case. Setting it on the workflow's \`Running Test e2e\` step skips the IdP install entirely. The OIDC + multi-cluster topology is covered by the plugins repo's \`e2e_pytest/test_multi_cluster.py\`, where the Keycloak install is the actual subject under test.

Refs: ADR-0040, MULTI_CLUSTER_OIDC_FOLLOW_UPS.md

## Test plan
- [ ] Re-run the e2e workflow on a non-cold runner — should bypass install-keycloak (\`==> Skipping Keycloak install (SKIP_KEYCLOAK=true)\` log line) and proceed straight to \`make test-e2e\`.