### PR TITLE
refactor(ci): daily-release auto-bumps minor/patch only

### DIFF
--- a/.github/workflows/daily-release.yml
+++ b/.github/workflows/daily-release.yml
@@ -54,16 +54,13 @@ jobs:
           VERSION="${LATEST_TAG#v}"
           IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
 
-          # Analyze commits for conventional commit types
+          # daily-release auto-bumps minor (feat) or patch only.
+          # Major bump is manual: a maintainer tags the new major version themselves.
+          # `feat!:` / `BREAKING CHANGE` markers surface in release notes, not in version.
           COMMITS=$(git log "${LATEST_TAG}..HEAD" --pretty=format:"%s")
-          HAS_BREAKING=$(echo "$COMMITS" | grep -cE '^[a-z]+(\(.+\))?!:|BREAKING CHANGE' || true)
-          HAS_FEAT=$(echo "$COMMITS" | grep -cE '^feat(\(.+\))?:' || true)
+          HAS_FEAT=$(echo "$COMMITS" | grep -cE '^feat(\(.+\))?!?:' || true)
 
-          if [ "$HAS_BREAKING" -gt 0 ]; then
-            MAJOR=$((MAJOR + 1))
-            MINOR=0
-            PATCH=0
-          elif [ "$HAS_FEAT" -gt 0 ]; then
+          if [ "$HAS_FEAT" -gt 0 ]; then
             MINOR=$((MINOR + 1))
             PATCH=0
           else


### PR DESCRIPTION
## Summary
- Daily release workflow no longer triggers automatic major version bumps
- `feat!:` / `BREAKING CHANGE` markers are surfaced in release notes only — no version impact
- Major bumps are now manual: a maintainer tags new major versions themselves

## Why
This repo's daily-release accidentally jumped v1.2.1 → v2.0.0 because of a `feat(helm)!:` chart-only commit (#238). The release was rolled back to v1.3.0 manually. Same logic exists in all 4 ecosystem repos, so the policy change is applied uniformly.

## Test plan
- [ ] Next scheduled run: previous tag + `feat:` commits → minor bump (no major)
- [ ] Next scheduled run: previous tag + `feat!:` commits → still minor bump (no major)
- [ ] Next scheduled run: only `fix:`/`refactor:` commits → patch bump