### PR TITLE
chore(chart): sync Chart.yaml version with operator git tag (1.3.1)

### DIFF
--- a/charts/aerospike-ce-kubernetes-operator-crds/Chart.yaml
+++ b/charts/aerospike-ce-kubernetes-operator-crds/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: aerospike-ce-kubernetes-operator-crds
 description: CustomResourceDefinitions for the Aerospike CE Kubernetes Operator (acko.io group)
 type: application
-version: 0.1.2
-appVersion: "0.1.2"
+version: 1.3.1
+appVersion: "1.3.1"
 kubeVersion: ">=1.26.0-0"
 home: https://github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator
 sources:

--- a/charts/aerospike-ce-kubernetes-operator/Chart.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: aerospike-ce-kubernetes-operator
 description: Kubernetes Operator for Aerospike Community Edition clusters
 type: application
-version: 0.4.0
-appVersion: "0.4.0"
+version: 1.3.1
+appVersion: "1.3.1"
 kubeVersion: ">=1.26.0-0"
 home: https://github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator
 sources:
@@ -19,7 +19,7 @@ maintainers:
     url: https://github.com/aerospike-ce-ecosystem
 dependencies:
   - name: aerospike-ce-kubernetes-operator-crds
-    version: "0.1.2"
+    version: "1.3.1"
     # Local reference for development. CI overrides to OCI registry after pushing aerospike-ce-kubernetes-operator-crds.
     repository: "file://../aerospike-ce-kubernetes-operator-crds"
     condition: crds.install


### PR DESCRIPTION
## Summary
- `aerospike-ce-kubernetes-operator` chart: `0.4.0` → `1.3.1`
- `aerospike-ce-kubernetes-operator-crds` chart: `0.1.2` → `1.3.1`
- operator chart의 crds dependency reference도 `1.3.1`로 동기화

## Why
`publish-chart.yml`은 publish 시점에 git tag 값으로 Chart.yaml `version`/`appVersion`을 sed로 덮어쓰는 구조라, GHCR에 publish된 chart는 항상 operator git tag(`v1.3.1` 등)와 동기화됩니다. 이 정책을 채택하기로 했으니, in-tree `Chart.yaml`도 latest tag와 일치시켜 dev 빌드와 리뷰 시 혼동이 없도록 정리합니다.

향후 chart-only 변경(`feat(helm)!:` 같은) 도 별도의 chart versioning을 두지 않고 operator 다음 release에 함께 반영됩니다.

## Test plan
- [ ] `helm package charts/aerospike-ce-kubernetes-operator` → `aerospike-ce-kubernetes-operator-1.3.1.tgz` 생성 확인
- [ ] 다음 daily-release(예: v1.3.2) 시 publish-chart.yml이 두 Chart.yaml을 1.3.2로 덮어쓰는지 확인