### PR TITLE
fix(controller): resolve reconciler race conditions and rack PVC cleanup ordering

### DIFF
--- a/internal/controller/reconciler.go
+++ b/internal/controller/reconciler.go
@@ -816,10 +816,23 @@ func (r *AerospikeClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 // mapTemplateToCluster maps an AerospikeClusterTemplate change to all clusters
 // that reference it, so the controller can mark them as out-of-sync.
+//
+// IMPORTANT: This handler performs a cluster-wide List of AerospikeCluster
+// resources because AerospikeClusterTemplate is cluster-scoped and any
+// AerospikeCluster in any namespace may reference it. The operator therefore
+// REQUIRES cluster-wide List/Watch RBAC for `aerospikeclusters`
+// (granted by the ClusterRole in
+// charts/aerospike-ce-kubernetes-operator/templates/clusterrole-manager.yaml).
+// If the operator is ever repackaged to be namespace-scoped (Role-only), this
+// handler must be updated to either (a) scope the List to the operator's own
+// namespace via client.InNamespace, or (b) ensure cluster-wide List remains
+// granted; otherwise template change events will silently 403 and dependent
+// clusters will not be enqueued.
 func (r *AerospikeClusterReconciler) mapTemplateToCluster(ctx context.Context, obj client.Object) []reconcile.Request {
 	log := logf.FromContext(ctx)
 
 	// List all AerospikeClusters across all namespaces since templates are cluster-scoped.
+	// See note above: this depends on cluster-wide List RBAC.
 	clusterList := &ackov1alpha1.AerospikeClusterList{}
 	if err := r.List(ctx, clusterList); err != nil {
 		log.Error(err, "Failed to list clusters for template watch", "template", obj.GetName())

--- a/internal/controller/reconciler_restart.go
+++ b/internal/controller/reconciler_restart.go
@@ -374,6 +374,12 @@ func determineRestartReason(
 
 // recordPodRestartStatus records the restart reason/time for the pod via a status patch.
 // Uses MergePatch instead of full Update to reduce conflict risk during concurrent operations.
+//
+// The cluster is re-fetched fresh before constructing the MergePatch base so that
+// the patch ResourceVersion is current. Using the in-flight `cluster` object would
+// risk a stale ResourceVersion when other reconcilers have written status during
+// the in-progress reconcile (mirrors the pattern in markDirtyVolumes /
+// updateDynamicConfigStatus).
 func (r *AerospikeClusterReconciler) recordPodRestartStatus(
 	ctx context.Context,
 	cluster *ackov1alpha1.AerospikeCluster,
@@ -383,16 +389,22 @@ func (r *AerospikeClusterReconciler) recordPodRestartStatus(
 	log := logf.FromContext(ctx)
 	now := metav1.Now()
 
-	patch := client.MergeFrom(cluster.DeepCopy())
-	if cluster.Status.Pods == nil {
-		cluster.Status.Pods = make(map[string]ackov1alpha1.AerospikePodStatus)
+	latest, err := r.refetchCluster(ctx, types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace})
+	if err != nil {
+		log.V(1).Info("Failed to refetch cluster for pod restart status (non-fatal)", "pod", podName, "err", err)
+		return
 	}
-	podStatus := cluster.Status.Pods[podName]
+
+	patch := client.MergeFrom(latest.DeepCopy())
+	if latest.Status.Pods == nil {
+		latest.Status.Pods = make(map[string]ackov1alpha1.AerospikePodStatus)
+	}
+	podStatus := latest.Status.Pods[podName]
 	podStatus.LastRestartReason = &reason
 	podStatus.LastRestartTime = &now
-	cluster.Status.Pods[podName] = podStatus
+	latest.Status.Pods[podName] = podStatus
 
-	if err := r.Status().Patch(ctx, cluster, patch); err != nil {
+	if err := r.Status().Patch(ctx, latest, patch); err != nil {
 		log.V(1).Info("Failed to record pod restart status (non-fatal)", "pod", podName, "err", err)
 	}
 }

--- a/internal/controller/reconciler_statefulset.go
+++ b/internal/controller/reconciler_statefulset.go
@@ -6,6 +6,7 @@ import (
 	"maps"
 	"strconv"
 	"strings"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -13,6 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
@@ -83,6 +85,15 @@ func (r *AerospikeClusterReconciler) reconcileStatefulSet(
 	} else if err != nil {
 		return false, fmt.Errorf("getting StatefulSet %s: %w", stsName, err)
 	}
+
+	// Snapshot the StatefulSet immediately after Get so we can compute a
+	// MergeFrom patch later. Using Update (full object write) on `existing`
+	// after intervening network I/O (migration check, scale-down readiness)
+	// can race against external StatefulSet status updates and 409 — with
+	// MaxConcurrentReconciles=2 those 409s also trip the reconcile circuit
+	// breaker. The MergeFrom patch sends only the fields we changed and is
+	// resilient to concurrent status writes from kube-controller-manager.
+	stsSnapshot := existing.DeepCopy()
 
 	// Update only if replicas or config hash changed
 	oldReplicas := int32(0)
@@ -163,8 +174,12 @@ func (r *AerospikeClusterReconciler) reconcileStatefulSet(
 	// VolumeClaimTemplates are immutable after StatefulSet creation.
 	// Always preserve the existing VCTs; they can only be set during buildStatefulSet.
 	log.Info("Updating StatefulSet", "name", stsName, "targetReplicas", targetReplicas)
-	if err := r.Update(ctx, existing); err != nil {
-		return false, fmt.Errorf("updating StatefulSet %s: %w", stsName, err)
+	// Patch with MergeFrom against the snapshot taken immediately after Get,
+	// so concurrent StatefulSet status updates from kube-controller-manager do
+	// not cause 409 (which would otherwise trip the reconcile circuit breaker
+	// under MaxConcurrentReconciles=2).
+	if err := r.Patch(ctx, existing, client.MergeFrom(stsSnapshot)); err != nil {
+		return false, fmt.Errorf("patching StatefulSet %s: %w", stsName, err)
 	}
 	r.Recorder.Eventf(cluster, corev1.EventTypeNormal, EventStatefulSetUpdated,
 		"StatefulSet %s updated: replicas=%d", stsName, targetReplicas)
@@ -318,39 +333,108 @@ func (r *AerospikeClusterReconciler) cleanupRemovedRacks(
 
 	// Note: when a rack is removed, its per-rack Storage spec is no longer in the CR.
 	// We fall back to the cluster-level storage spec for cascadeDelete resolution.
+	//
+	// Ordering is critical for safety:
+	//   1. Delete the StatefulSet first so pods begin graceful termination.
+	//   2. Wait for all rack pods to terminate. Deleting PVCs while pods are
+	//      still running risks data loss (Aerospike may flush to a backing
+	//      store that is being unmounted) and crashes pods that are still
+	//      accepting transactions.
+	//   3. Only then delete cascade-delete PVCs and the rack ConfigMap.
 	for i := range stsList.Items {
 		sts := &stsList.Items[i]
-		if !currentRackNames[sts.Name] {
-			log.Info("Deleting removed rack StatefulSet", "name", sts.Name)
-			// Delete PVCs for removed rack before deleting the StatefulSet,
-			// but only for volumes that have cascadeDelete enabled.
-			storageSpec := cluster.Spec.Storage
-			if err := storage.DeleteCascadeDeletePVCs(ctx, r.Client, cluster.Namespace, sts.Name, storageSpec); err != nil {
-				log.Error(err, "Failed to delete cascade PVCs for removed rack", "statefulset", sts.Name)
-				r.Recorder.Eventf(cluster, corev1.EventTypeWarning, EventPVCCleanupFailed,
-					"Failed to delete cascade PVCs for removed rack %s: %v", sts.Name, err)
+		if currentRackNames[sts.Name] {
+			continue
+		}
+
+		log.Info("Deleting removed rack StatefulSet", "name", sts.Name)
+		stsName := sts.Name
+
+		// Step 1: Delete the StatefulSet first to start pod termination.
+		if err := r.Delete(ctx, sts); err != nil && !errors.IsNotFound(err) {
+			return err
+		}
+
+		// Step 2: Wait for pods to terminate. Bounded to 30 retries × 1s with
+		// context cancellation honored. If pods are still running after the
+		// timeout we fall through and let the next reconcile retry — better
+		// than indefinitely blocking the reconcile loop.
+		rackIDStr := strings.TrimPrefix(stsName, cluster.Name+"-")
+		rackID, convErr := strconv.Atoi(rackIDStr)
+		if convErr == nil {
+			waitErr := r.waitForRackPodsTerminated(ctx, cluster, rackID, stsName)
+			if waitErr != nil {
+				log.V(1).Info("Pods for removed rack still terminating; deferring PVC and ConfigMap cleanup to next reconcile",
+					"statefulset", stsName, "err", waitErr)
+				continue
 			}
-			// Delete the associated ConfigMap for the removed rack.
-			// The ConfigMap name is derived from the StatefulSet name suffix (rackID).
-			rackIDStr := strings.TrimPrefix(sts.Name, cluster.Name+"-")
-			if rackID, convErr := strconv.Atoi(rackIDStr); convErr == nil {
-				cmName := utils.ConfigMapName(cluster.Name, rackID)
-				cm := &corev1.ConfigMap{}
-				if getErr := r.Get(ctx, types.NamespacedName{Name: cmName, Namespace: cluster.Namespace}, cm); getErr == nil {
-					if delErr := r.Delete(ctx, cm); delErr != nil && !errors.IsNotFound(delErr) {
-						log.Error(delErr, "Failed to delete ConfigMap for removed rack", "configmap", cmName)
-					} else {
-						log.Info("Deleted ConfigMap for removed rack", "configmap", cmName)
-					}
+		}
+
+		// Step 3a: Delete cascade-delete PVCs now that pods are gone.
+		storageSpec := cluster.Spec.Storage
+		if err := storage.DeleteCascadeDeletePVCs(ctx, r.Client, cluster.Namespace, stsName, storageSpec); err != nil {
+			log.Error(err, "Failed to delete cascade PVCs for removed rack", "statefulset", stsName)
+			r.Recorder.Eventf(cluster, corev1.EventTypeWarning, EventPVCCleanupFailed,
+				"Failed to delete cascade PVCs for removed rack %s: %v", stsName, err)
+		}
+
+		// Step 3b: Delete the associated ConfigMap for the removed rack.
+		// The ConfigMap name is derived from the StatefulSet name suffix (rackID).
+		if convErr == nil {
+			cmName := utils.ConfigMapName(cluster.Name, rackID)
+			cm := &corev1.ConfigMap{}
+			if getErr := r.Get(ctx, types.NamespacedName{Name: cmName, Namespace: cluster.Namespace}, cm); getErr == nil {
+				if delErr := r.Delete(ctx, cm); delErr != nil && !errors.IsNotFound(delErr) {
+					log.Error(delErr, "Failed to delete ConfigMap for removed rack", "configmap", cmName)
+				} else {
+					log.Info("Deleted ConfigMap for removed rack", "configmap", cmName)
 				}
-			}
-			if err := r.Delete(ctx, sts); err != nil && !errors.IsNotFound(err) {
-				return err
 			}
 		}
 	}
 
 	return nil
+}
+
+// waitForRackPodsTerminated polls until all pods for the given rack are gone,
+// or until the bounded timeout (30 attempts × 1s) elapses, or until the
+// context is cancelled. Returns nil when all pods have terminated, or an
+// error describing why the wait ended early.
+func (r *AerospikeClusterReconciler) waitForRackPodsTerminated(
+	ctx context.Context,
+	cluster *ackov1alpha1.AerospikeCluster,
+	rackID int,
+	stsName string,
+) error {
+	log := logf.FromContext(ctx)
+
+	const (
+		maxAttempts = 30
+		pollEvery   = 1 * time.Second
+	)
+
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		pods, err := r.listRackPods(ctx, cluster, rackID)
+		if err != nil {
+			// Transient list error: log and keep polling rather than giving up.
+			log.V(1).Info("listRackPods failed while waiting for pod termination",
+				"statefulset", stsName, "attempt", attempt, "err", err)
+		} else if len(pods) == 0 {
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(pollEvery):
+		}
+	}
+
+	return fmt.Errorf("timed out waiting for pods of removed rack %s to terminate", stsName)
 }
 
 // getScaleDownBatchSize returns the effective scale-down batch size.

--- a/internal/controller/reconciler_statefulset.go
+++ b/internal/controller/reconciler_statefulset.go
@@ -359,15 +359,25 @@ func (r *AerospikeClusterReconciler) cleanupRemovedRacks(
 		// context cancellation honored. If pods are still running after the
 		// timeout we fall through and let the next reconcile retry — better
 		// than indefinitely blocking the reconcile loop.
+		//
+		// If the rackID cannot be parsed from the STS name we refuse to
+		// proceed: a partial cleanup that deletes PVCs without first
+		// confirming pods are gone re-introduces the "PVC deleted while pods
+		// alive" hazard. Returning an error lets the reconcile loop retry on
+		// the next pass; a human can also intervene via logs/events.
 		rackIDStr := strings.TrimPrefix(stsName, cluster.Name+"-")
 		rackID, convErr := strconv.Atoi(rackIDStr)
-		if convErr == nil {
-			waitErr := r.waitForRackPodsTerminated(ctx, cluster, rackID, stsName)
-			if waitErr != nil {
-				log.V(1).Info("Pods for removed rack still terminating; deferring PVC and ConfigMap cleanup to next reconcile",
-					"statefulset", stsName, "err", waitErr)
-				continue
-			}
+		if convErr != nil {
+			return fmt.Errorf("cannot derive rackID from StatefulSet name %q (cluster %q): %w; "+
+				"refusing rack cleanup to avoid deleting PVCs while pods may still be running",
+				stsName, cluster.Name, convErr)
+		}
+
+		waitErr := r.waitForRackPodsTerminated(ctx, cluster, rackID, stsName)
+		if waitErr != nil {
+			log.V(1).Info("Pods for removed rack still terminating; deferring PVC and ConfigMap cleanup to next reconcile",
+				"statefulset", stsName, "err", waitErr)
+			continue
 		}
 
 		// Step 3a: Delete cascade-delete PVCs now that pods are gone.
@@ -380,15 +390,13 @@ func (r *AerospikeClusterReconciler) cleanupRemovedRacks(
 
 		// Step 3b: Delete the associated ConfigMap for the removed rack.
 		// The ConfigMap name is derived from the StatefulSet name suffix (rackID).
-		if convErr == nil {
-			cmName := utils.ConfigMapName(cluster.Name, rackID)
-			cm := &corev1.ConfigMap{}
-			if getErr := r.Get(ctx, types.NamespacedName{Name: cmName, Namespace: cluster.Namespace}, cm); getErr == nil {
-				if delErr := r.Delete(ctx, cm); delErr != nil && !errors.IsNotFound(delErr) {
-					log.Error(delErr, "Failed to delete ConfigMap for removed rack", "configmap", cmName)
-				} else {
-					log.Info("Deleted ConfigMap for removed rack", "configmap", cmName)
-				}
+		cmName := utils.ConfigMapName(cluster.Name, rackID)
+		cm := &corev1.ConfigMap{}
+		if getErr := r.Get(ctx, types.NamespacedName{Name: cmName, Namespace: cluster.Namespace}, cm); getErr == nil {
+			if delErr := r.Delete(ctx, cm); delErr != nil && !errors.IsNotFound(delErr) {
+				log.Error(delErr, "Failed to delete ConfigMap for removed rack", "configmap", cmName)
+			} else {
+				log.Info("Deleted ConfigMap for removed rack", "configmap", cmName)
 			}
 		}
 	}

--- a/internal/controller/reconciler_statefulset.go
+++ b/internal/controller/reconciler_statefulset.go
@@ -421,7 +421,7 @@ func (r *AerospikeClusterReconciler) waitForRackPodsTerminated(
 		pollEvery   = 1 * time.Second
 	)
 
-	for attempt := 0; attempt < maxAttempts; attempt++ {
+	for attempt := range maxAttempts {
 		if err := ctx.Err(); err != nil {
 			return err
 		}

--- a/internal/controller/reconciler_status.go
+++ b/internal/controller/reconciler_status.go
@@ -13,6 +13,7 @@ import (
 	aero "github.com/aerospike/aerospike-client-go/v8"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
@@ -126,10 +127,18 @@ func (r *AerospikeClusterReconciler) updateStatusAndPhase(
 
 	// Use RetryOnConflict for the final status write. On conflict, re-fetch the
 	// object and re-apply the computed status to avoid a full requeue cycle.
+	// Non-conflict errors are returned immediately without refetching, since
+	// RetryOnConflict won't retry them anyway and refetching would clobber
+	// concurrent writes by other reconcilers.
 	computedStatus := latest.Status.DeepCopy()
 	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		if err := r.Status().Update(ctx, latest); err != nil {
-			// Re-fetch on conflict and re-apply computed status.
+			// Only refetch on conflict — RetryOnConflict will not retry on
+			// other error types, so a refetch in those paths would be wasted
+			// work and could overwrite legitimate concurrent state changes.
+			if !apierrors.IsConflict(err) {
+				return err
+			}
 			refetched, fetchErr := r.refetchCluster(ctx, namespacedName)
 			if fetchErr != nil {
 				return fetchErr


### PR DESCRIPTION
## Summary
- Five high-confidence reconciliation bugs from the 2026-05-09 multi-agent audit
- **Critical**: prevent potential data loss when racks are removed (PVC ordering)
- **Critical**: stop status regression under concurrent reconciles (MaxConcurrentReconciles=2)

## Bugs Addressed
1. `reconciler_status.go` — RetryOnConflict refetched on every error -> clobbered concurrent writes
2. `reconciler.go` — `mapTemplateToCluster` listed cluster-wide without namespace scope (documented as required for cluster-scoped templates; ClusterRole grants list, so kept cluster-wide with explicit comment)
3. `reconciler_restart.go` — `recordPodRestartStatus` patched with stale ResourceVersion
4. `reconciler_statefulset.go` — full STS Update on stale object spuriously tripped circuit breaker
5. `reconciler_cleanup.go` — PVCs deleted before StatefulSet, crashing live pods

## Test Plan
- [ ] `make test`
- [ ] `make test-e2e` rack removal scenario
- [ ] Manual: trigger concurrent CR updates, confirm status converges
- [ ] Manual: remove a rack while traffic is live, confirm pods drain before PVC delete

## Risk
Medium - touches hot reconcile paths. Reviewers should verify Patch vs Update semantics for STS field updates (no replica count regression).