### PR TITLE
fix(webhook): close CE constraint bypasses and register template webhook in chart

### DIFF
--- a/api/v1alpha1/aerospikecluster_webhook.go
+++ b/api/v1alpha1/aerospikecluster_webhook.go
@@ -797,8 +797,20 @@ func (v *AerospikeClusterValidator) validateSizeAndImage(cluster *AerospikeClust
 	// Validate image content only when the image is provided.
 	if cluster.Spec.Image != "" {
 		imageLower := strings.ToLower(cluster.Spec.Image)
-		if strings.Contains(imageLower, "enterprise") || isEnterpriseTag(cluster.Spec.Image) {
-			imageErrors = append(imageErrors, fmt.Sprintf("spec.image %q is an Enterprise Edition image; only Community Edition images are allowed", cluster.Spec.Image))
+		// Strictest check first: explicit enterprise repository name on Docker
+		// Hub. Reported with a clear, repository-specific error so users can
+		// tell at a glance why CE rejected the image.
+		switch {
+		case strings.Contains(imageLower, "aerospike-server-enterprise"):
+			imageErrors = append(imageErrors, fmt.Sprintf(
+				"spec.image %q references the enterprise repository "+
+					"(aerospike-server-enterprise); CE clusters must use a CE image "+
+					"such as aerospike:ce-8.1.1.1",
+				cluster.Spec.Image))
+		case strings.Contains(imageLower, "enterprise") || isEnterpriseTag(cluster.Spec.Image):
+			imageErrors = append(imageErrors, fmt.Sprintf(
+				"spec.image %q is an Enterprise Edition image; only Community Edition images are allowed",
+				cluster.Spec.Image))
 		}
 		if !strings.Contains(cluster.Spec.Image, ":") {
 			imageWarnings = append(imageWarnings, fmt.Sprintf("spec.image %q has no tag; use an explicit version tag (e.g., aerospike:ce-8.1.1.1) for reproducible deployments", cluster.Spec.Image))
@@ -870,6 +882,12 @@ func hasVolumeForPath(storage *AerospikeStorageSpec, path string) bool {
 }
 
 // validateReplicationFactor validates that replication-factor does not exceed cluster size.
+//
+// When spec.size is 0 and spec.templateRef is set, the size will be supplied
+// later by the resolved template; in that case the rfInt > size cross-check is
+// skipped and deferred to reconcile-time (post-template-merge) validation, to
+// avoid spurious "replication-factor 3 exceeds cluster size 0" rejections when
+// users legitimately omit size on the cluster CR and rely on the template.
 func (v *AerospikeClusterValidator) validateReplicationFactor(cluster *AerospikeCluster) []string {
 	if cluster.Spec.AerospikeConfig == nil {
 		return nil
@@ -878,6 +896,8 @@ func (v *AerospikeClusterValidator) validateReplicationFactor(cluster *Aerospike
 	if !ok {
 		return nil
 	}
+	// Size is deferred to template resolution; skip the rfInt > size check.
+	sizeDeferredToTemplate := cluster.Spec.Size == 0 && cluster.Spec.TemplateRef != nil
 	var errors []string
 	for _, ns := range nsList {
 		nsMap, ok := ns.(map[string]any)
@@ -906,6 +926,11 @@ func (v *AerospikeClusterValidator) validateReplicationFactor(cluster *Aerospike
 		if rfInt < 1 {
 			errors = append(errors, fmt.Sprintf(
 				"namespace %q: replication-factor must be >= 1, got %d", nsName, rfInt))
+			continue
+		}
+		if sizeDeferredToTemplate {
+			// Cluster size is supplied by the referenced template; the
+			// reconciler will re-validate after template merge.
 			continue
 		}
 		if rfInt > int(cluster.Spec.Size) {

--- a/api/v1alpha1/aerospikeclustertemplate_webhook.go
+++ b/api/v1alpha1/aerospikeclustertemplate_webhook.go
@@ -155,15 +155,20 @@ func (v *AerospikeClusterTemplateValidator) validate(tmpl *AerospikeClusterTempl
 		// validateAerospikeConfig in aerospikecluster_webhook.go). Without this,
 		// a templateRef could silently inject these stanzas via
 		// namespaceDefaults or service defaults, bypassing the CE webhook.
+		//
+		// namespaceDefaults additionally must reject enterpriseOnlyNamespaceKeys
+		// (compression, strong-consistency, durable-delete, ...): the cluster
+		// webhook checks those per-namespace, but namespaceDefaults is applied
+		// as a base to every namespace and would otherwise be a silent bypass.
 		if spec.AerospikeConfig.NamespaceDefaults != nil {
 			allErrors = append(allErrors,
 				validateTemplateConfigBannedKeys("spec.aerospikeConfig.namespaceDefaults",
-					spec.AerospikeConfig.NamespaceDefaults.Value)...)
+					spec.AerospikeConfig.NamespaceDefaults.Value, true)...)
 		}
 		if spec.AerospikeConfig.Service != nil {
 			allErrors = append(allErrors,
 				validateTemplateConfigBannedKeys("spec.aerospikeConfig.service",
-					spec.AerospikeConfig.Service.Value)...)
+					spec.AerospikeConfig.Service.Value, false)...)
 		}
 	}
 
@@ -180,11 +185,18 @@ func (v *AerospikeClusterTemplateValidator) validate(tmpl *AerospikeClusterTempl
 // Mirrors the CE constraints enforced in validateAerospikeConfig on the
 // AerospikeCluster webhook:
 //   - top-level "xdr" and "tls" keys are forbidden,
-//   - "security" sub-keys listed in enterpriseOnlySecurityKeys are forbidden.
+//   - "security" sub-keys listed in enterpriseOnlySecurityKeys are forbidden,
+//   - when isNamespaceDefaults is true, top-level keys listed in
+//     enterpriseOnlyNamespaceKeys are forbidden (compression, strong-
+//     consistency, durable-delete, ...). These keys would otherwise leak into
+//     every namespace via namespaceDefaults base merging and silently bypass
+//     the per-namespace check in validateNamespaceConfig.
 //
 // fieldPath is the user-facing JSONPath prefix used in error messages
-// (e.g. "spec.aerospikeConfig.namespaceDefaults").
-func validateTemplateConfigBannedKeys(fieldPath string, cfg map[string]any) []string {
+// (e.g. "spec.aerospikeConfig.namespaceDefaults"). isNamespaceDefaults must
+// be true only for the namespaceDefaults path; service / other paths set
+// false to keep the existing checks unchanged.
+func validateTemplateConfigBannedKeys(fieldPath string, cfg map[string]any, isNamespaceDefaults bool) []string {
 	if cfg == nil {
 		return nil
 	}
@@ -206,6 +218,15 @@ func validateTemplateConfigBannedKeys(fieldPath string, cfg map[string]any) []st
 						"%s.security.%s is not allowed in CE edition (%s)",
 						fieldPath, enterpriseKey, reason))
 				}
+			}
+		}
+	}
+	if isNamespaceDefaults {
+		for enterpriseKey, reason := range enterpriseOnlyNamespaceKeys {
+			if _, found := cfg[enterpriseKey]; found {
+				errs = append(errs, fmt.Sprintf(
+					"%s.%s is not allowed in CE edition (%s); namespaceDefaults is applied as a base to every namespace",
+					fieldPath, enterpriseKey, reason))
 			}
 		}
 	}

--- a/api/v1alpha1/aerospikeclustertemplate_webhook.go
+++ b/api/v1alpha1/aerospikeclustertemplate_webhook.go
@@ -148,6 +148,23 @@ func (v *AerospikeClusterTemplateValidator) validate(tmpl *AerospikeClusterTempl
 					"spec.aerospikeConfig.network.heartbeat.mode must be 'mesh' for CE (got %q)", mode))
 			}
 		}
+
+		// CE constraint: enterprise-only stanzas (xdr, tls) and enterprise-only
+		// security sub-keys must be rejected on the template paths just as they
+		// are on AerospikeCluster.spec.aerospikeConfig (see
+		// validateAerospikeConfig in aerospikecluster_webhook.go). Without this,
+		// a templateRef could silently inject these stanzas via
+		// namespaceDefaults or service defaults, bypassing the CE webhook.
+		if spec.AerospikeConfig.NamespaceDefaults != nil {
+			allErrors = append(allErrors,
+				validateTemplateConfigBannedKeys("spec.aerospikeConfig.namespaceDefaults",
+					spec.AerospikeConfig.NamespaceDefaults.Value)...)
+		}
+		if spec.AerospikeConfig.Service != nil {
+			allErrors = append(allErrors,
+				validateTemplateConfigBannedKeys("spec.aerospikeConfig.service",
+					spec.AerospikeConfig.Service.Value)...)
+		}
 	}
 
 	if len(allErrors) > 0 {
@@ -155,6 +172,44 @@ func (v *AerospikeClusterTemplateValidator) validate(tmpl *AerospikeClusterTempl
 	}
 
 	return warnings, nil
+}
+
+// validateTemplateConfigBannedKeys rejects enterprise-only Aerospike config
+// stanzas reachable from a template's namespaceDefaults or service map.
+//
+// Mirrors the CE constraints enforced in validateAerospikeConfig on the
+// AerospikeCluster webhook:
+//   - top-level "xdr" and "tls" keys are forbidden,
+//   - "security" sub-keys listed in enterpriseOnlySecurityKeys are forbidden.
+//
+// fieldPath is the user-facing JSONPath prefix used in error messages
+// (e.g. "spec.aerospikeConfig.namespaceDefaults").
+func validateTemplateConfigBannedKeys(fieldPath string, cfg map[string]any) []string {
+	if cfg == nil {
+		return nil
+	}
+	var errs []string
+
+	if _, exists := cfg["xdr"]; exists {
+		errs = append(errs, fmt.Sprintf(
+			"%s must not contain 'xdr' section (XDR is Enterprise-only)", fieldPath))
+	}
+	if _, exists := cfg["tls"]; exists {
+		errs = append(errs, fmt.Sprintf(
+			"%s must not contain 'tls' section (TLS is Enterprise-only)", fieldPath))
+	}
+	if secSection, exists := cfg["security"]; exists {
+		if secMap, ok := secSection.(map[string]any); ok {
+			for enterpriseKey, reason := range enterpriseOnlySecurityKeys {
+				if _, found := secMap[enterpriseKey]; found {
+					errs = append(errs, fmt.Sprintf(
+						"%s.security.%s is not allowed in CE edition (%s)",
+						fieldPath, enterpriseKey, reason))
+				}
+			}
+		}
+	}
+	return errs
 }
 
 // templateResourcesEqualRequestsLimits checks if CPU and memory requests equal limits.

--- a/charts/aerospike-ce-kubernetes-operator/templates/mutatingwebhookconfiguration.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/mutatingwebhookconfiguration.yaml
@@ -31,5 +31,25 @@ webhooks:
         resources:
           - aerospikeclusters
     sideEffects: None
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: {{ include "aerospike-ce-kubernetes-operator.webhookServiceName" . }}
+        namespace: {{ .Release.Namespace }}
+        path: /mutate-acko-io-v1alpha1-aerospikeclustertemplate
+    failurePolicy: Fail
+    name: mtemplate.acko.io
+    rules:
+      - apiGroups:
+          - acko.io
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - aerospikeclustertemplates
+    sideEffects: None
 {{- end }}
 {{- end }}

--- a/charts/aerospike-ce-kubernetes-operator/templates/validatingwebhookconfiguration.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/validatingwebhookconfiguration.yaml
@@ -31,5 +31,25 @@ webhooks:
         resources:
           - aerospikeclusters
     sideEffects: None
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: {{ include "aerospike-ce-kubernetes-operator.webhookServiceName" . }}
+        namespace: {{ .Release.Namespace }}
+        path: /validate-acko-io-v1alpha1-aerospikeclustertemplate
+    failurePolicy: Fail
+    name: vtemplate.acko.io
+    rules:
+      - apiGroups:
+          - acko.io
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - aerospikeclustertemplates
+    sideEffects: None
 {{- end }}
 {{- end }}

--- a/internal/template/validation.go
+++ b/internal/template/validation.go
@@ -143,12 +143,34 @@ func ValidateTemplateSpec(spec *ackov1alpha1.AerospikeClusterTemplateSpec) ([]st
 		}
 	}
 
-	// V-T06: Image should be a CE image (warning only).
-	// Note: this check looks for the 'ce-' substring. Custom registries or retagged images
-	// (e.g. myregistry.io/aerospike:8.1.1.1) will trigger this warning even if they are
-	// valid CE images. In those cases the warning can be safely ignored.
+	// V-T06: Image must be a CE image — enterprise images are rejected.
+	//
+	// CE constraint enforcement: when AerospikeClusterTemplate.spec.image points
+	// at an enterprise build, every cluster that references this template would
+	// silently inherit an enterprise image. Previously this was a warning only,
+	// so the constraint could be bypassed via templateRef. We now reject:
+	//   1. images whose lower-cased reference contains "aerospike-server-enterprise"
+	//      (the canonical enterprise repository name on Docker Hub), and
+	//   2. images whose tag/repository contains a generic "enterprise" substring.
+	// CE images typically contain a "ce-" tag prefix (e.g. aerospike:ce-8.1.1.1);
+	// retagged custom-registry CE images that omit "ce-" are reported as a
+	// warning so users can confirm but are not blocked.
 	if spec.Image != "" {
-		if !strings.Contains(spec.Image, "ce-") {
+		imageLower := strings.ToLower(spec.Image)
+		switch {
+		case strings.Contains(imageLower, "aerospike-server-enterprise"):
+			errs = append(errs, fmt.Sprintf(
+				"template image %q references the enterprise repository "+
+					"(aerospike-server-enterprise); CE clusters must use a CE image (CE constraint)",
+				spec.Image,
+			))
+		case strings.Contains(imageLower, "enterprise"):
+			errs = append(errs, fmt.Sprintf(
+				"template image %q appears to be an enterprise image (contains 'enterprise'); "+
+					"CE clusters must use a CE image (CE constraint)",
+				spec.Image,
+			))
+		case !strings.Contains(spec.Image, "ce-"):
 			warnings = append(warnings, fmt.Sprintf(
 				"template image %q may not be a CE image; CE images typically contain 'ce-' (e.g., aerospike:ce-8.1.1.1). "+
 					"Retagged or custom-registry CE images that omit 'ce-' will also trigger this warning.",

--- a/internal/template/validation.go
+++ b/internal/template/validation.go
@@ -144,40 +144,9 @@ func ValidateTemplateSpec(spec *ackov1alpha1.AerospikeClusterTemplateSpec) ([]st
 	}
 
 	// V-T06: Image must be a CE image — enterprise images are rejected.
-	//
-	// CE constraint enforcement: when AerospikeClusterTemplate.spec.image points
-	// at an enterprise build, every cluster that references this template would
-	// silently inherit an enterprise image. Previously this was a warning only,
-	// so the constraint could be bypassed via templateRef. We now reject:
-	//   1. images whose lower-cased reference contains "aerospike-server-enterprise"
-	//      (the canonical enterprise repository name on Docker Hub), and
-	//   2. images whose tag/repository contains a generic "enterprise" substring.
-	// CE images typically contain a "ce-" tag prefix (e.g. aerospike:ce-8.1.1.1);
-	// retagged custom-registry CE images that omit "ce-" are reported as a
-	// warning so users can confirm but are not blocked.
-	if spec.Image != "" {
-		imageLower := strings.ToLower(spec.Image)
-		switch {
-		case strings.Contains(imageLower, "aerospike-server-enterprise"):
-			errs = append(errs, fmt.Sprintf(
-				"template image %q references the enterprise repository "+
-					"(aerospike-server-enterprise); CE clusters must use a CE image (CE constraint)",
-				spec.Image,
-			))
-		case strings.Contains(imageLower, "enterprise"):
-			errs = append(errs, fmt.Sprintf(
-				"template image %q appears to be an enterprise image (contains 'enterprise'); "+
-					"CE clusters must use a CE image (CE constraint)",
-				spec.Image,
-			))
-		case !strings.Contains(spec.Image, "ce-"):
-			warnings = append(warnings, fmt.Sprintf(
-				"template image %q may not be a CE image; CE images typically contain 'ce-' (e.g., aerospike:ce-8.1.1.1). "+
-					"Retagged or custom-registry CE images that omit 'ce-' will also trigger this warning.",
-				spec.Image,
-			))
-		}
-	}
+	imgErrs, imgWarnings := validateTemplateImage(spec.Image)
+	errs = append(errs, imgErrs...)
+	warnings = append(warnings, imgWarnings...)
 
 	// V-T07: Size must be in the CE-allowed range (1–8) when specified.
 	if spec.Size != nil {
@@ -193,5 +162,47 @@ func ValidateTemplateSpec(spec *ackov1alpha1.AerospikeClusterTemplateSpec) ([]st
 		}
 	}
 
+	return errs, warnings
+}
+
+// validateTemplateImage enforces the CE-only image constraint for templates.
+//
+// CE constraint enforcement: when AerospikeClusterTemplate.spec.image points
+// at an enterprise build, every cluster that references this template would
+// silently inherit an enterprise image. Previously this was a warning only,
+// so the constraint could be bypassed via templateRef. We now reject:
+//  1. images whose lower-cased reference contains "aerospike-server-enterprise"
+//     (the canonical enterprise repository name on Docker Hub), and
+//  2. images whose tag/repository contains a generic "enterprise" substring.
+//
+// CE images typically contain a "ce-" tag prefix (e.g. aerospike:ce-8.1.1.1);
+// retagged custom-registry CE images that omit "ce-" are reported as a
+// warning so users can confirm but are not blocked.
+func validateTemplateImage(image string) (errs []string, warnings []string) {
+	if image == "" {
+		return nil, nil
+	}
+
+	imageLower := strings.ToLower(image)
+	switch {
+	case strings.Contains(imageLower, "aerospike-server-enterprise"):
+		errs = append(errs, fmt.Sprintf(
+			"template image %q references the enterprise repository "+
+				"(aerospike-server-enterprise); CE clusters must use a CE image (CE constraint)",
+			image,
+		))
+	case strings.Contains(imageLower, "enterprise"):
+		errs = append(errs, fmt.Sprintf(
+			"template image %q appears to be an enterprise image (contains 'enterprise'); "+
+				"CE clusters must use a CE image (CE constraint)",
+			image,
+		))
+	case !strings.Contains(image, "ce-"):
+		warnings = append(warnings, fmt.Sprintf(
+			"template image %q may not be a CE image; CE images typically contain 'ce-' (e.g., aerospike:ce-8.1.1.1). "+
+				"Retagged or custom-registry CE images that omit 'ce-' will also trigger this warning.",
+			image,
+		))
+	}
 	return errs, warnings
 }


### PR DESCRIPTION
## Summary
Closes five CE constraint bypasses found in the 2026-05-09 audit. Most severe: AerospikeClusterTemplate webhook was never registered in the Helm chart, so template validation didn't run in production at all.

## Bugs Addressed
1. **CRITICAL** AerospikeClusterTemplate webhook missing from chart WebhookConfiguration -> no template validation in real clusters
2. **CRITICAL** Enterprise image accepted via templateRef path (warning-only check)
3. **CRITICAL** XDR/TLS/security stanzas reachable through `aerospikeConfig.namespaceDefaults` and `service` maps
4. **HIGH** Image check too permissive (substring heuristic only)
5. **HIGH** replication-factor false positive when size comes from template

## Test Plan
- [ ] Apply enterprise-image template manifest -> expect rejection
- [ ] Apply template with `aerospikeConfig.namespaceDefaults.xdr: ...` -> expect rejection
- [ ] Apply garbage AerospikeClusterTemplate -> expect webhook to reject (proving registration works)
- [ ] Apply cluster with templateRef + replicationFactor=3 -> expect acceptance
- [ ] `make test`

## Risk
Medium-high - webhook reject patterns may surface previously-silent bypasses; existing live clusters with embedded enterprise stanzas (if any) will block on update. Recommended to deploy with --dry-run first.