### PR TITLE
fix(chart): tighten image tags, RBAC, memory, and HA defaults

### DIFF
--- a/charts/aerospike-ce-kubernetes-operator/templates/_helpers.tpl
+++ b/charts/aerospike-ce-kubernetes-operator/templates/_helpers.tpl
@@ -220,13 +220,15 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 
 {{/*
 UI image helpers (per-component).
+Tag defaults to .Chart.AppVersion when ui.api.image.tag / ui.web.image.tag is
+empty, so users get a concrete pinned tag out of the box rather than ":latest".
 */}}
 {{- define "aerospike-ce-kubernetes-operator.ui.api.image" -}}
-{{- printf "%s:%s" .Values.ui.api.image.repository (.Values.ui.api.image.tag | toString) -}}
+{{- printf "%s:%s" .Values.ui.api.image.repository (default .Chart.AppVersion .Values.ui.api.image.tag | toString) -}}
 {{- end }}
 
 {{- define "aerospike-ce-kubernetes-operator.ui.web.image" -}}
-{{- printf "%s:%s" .Values.ui.web.image.repository (.Values.ui.web.image.tag | toString) -}}
+{{- printf "%s:%s" .Values.ui.web.image.repository (default .Chart.AppVersion .Values.ui.web.image.tag | toString) -}}
 {{- end }}
 
 {{/*

--- a/charts/aerospike-ce-kubernetes-operator/templates/deployment.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/deployment.yaml
@@ -29,6 +29,12 @@ spec:
       {{- end }}
       securityContext:
         runAsNonRoot: true
+        # Pin runAsUser/runAsGroup to the distroless static:nonroot UID/GID
+        # (65532) so the kubelet does not have to fall back to the image's
+        # USER directive. Defense-in-depth against a base-image change that
+        # might silently switch to a different non-root UID.
+        runAsUser: 65532
+        runAsGroup: 65532
         seccompProfile:
           type: RuntimeDefault
       containers:

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/clusterrole.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/clusterrole.yaml
@@ -33,12 +33,12 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["get", "list", "watch"]
-  # secrets:list removed; UI must request specific secret names via get.
-  # The previous cluster-wide list permission would have exposed every
-  # secret in the cluster (including unrelated workload credentials) to a
-  # compromised UI pod. If a UI feature genuinely needs to enumerate
-  # secrets in an Aerospike namespace, follow up with a namespace-scoped
-  # Role per Aerospike namespace instead of restoring this ClusterRole entry.
+  # secrets:list intentionally NOT granted at cluster scope — the previous
+  # cluster-wide list permission would have exposed every Secret in the
+  # cluster (including unrelated workload credentials) to a compromised UI
+  # pod. The UI's ACL picker (/api/k8s/secrets) needs secrets:[get,list] in
+  # .Release.Namespace only; that is granted via the namespace-scoped Role
+  # in templates/ui/role.yaml + rolebinding.yaml.
   - apiGroups: [""]
     resources: ["namespaces"]
     verbs: ["create", "list"]

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/clusterrole.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/clusterrole.yaml
@@ -33,9 +33,12 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["get", "list", "watch"]
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["list"]
+  # secrets:list removed; UI must request specific secret names via get.
+  # The previous cluster-wide list permission would have exposed every
+  # secret in the cluster (including unrelated workload credentials) to a
+  # compromised UI pod. If a UI feature genuinely needs to enumerate
+  # secrets in an Aerospike namespace, follow up with a namespace-scoped
+  # Role per Aerospike namespace instead of restoring this ClusterRole entry.
   - apiGroups: [""]
     resources: ["namespaces"]
     verbs: ["create", "list"]

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/role.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/role.yaml
@@ -1,0 +1,22 @@
+{{- if and (eq (include "aerospike-ce-kubernetes-operator.ui.api.enabled" .) "true") .Values.ui.rbac.create .Values.ui.k8s.enabled }}
+# Namespace-scoped Role granting the UI ServiceAccount permission to list and
+# read secrets in .Release.Namespace. This replaces the previously-removed
+# cluster-wide secrets:list permission on the UI ClusterRole.
+#
+# Why namespace-scoped: cluster-wide secrets:list would expose every Secret in
+# the cluster (including unrelated workload credentials) to a compromised UI
+# pod. Restricting to .Release.Namespace limits blast radius to where the UI
+# already runs, while still satisfying the cluster-manager API's
+# /api/k8s/secrets endpoint used by the ACL picker.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "aerospike-ce-kubernetes-operator.ui.fullname" . }}-secrets
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "aerospike-ce-kubernetes-operator.ui.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+{{- end }}

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/rolebinding.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/rolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if and (eq (include "aerospike-ce-kubernetes-operator.ui.api.enabled" .) "true") .Values.ui.rbac.create .Values.ui.k8s.enabled }}
+# Binds the UI ServiceAccount to the namespace-scoped secrets Role.
+# Companion to templates/ui/role.yaml.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "aerospike-ce-kubernetes-operator.ui.fullname" . }}-secrets
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "aerospike-ce-kubernetes-operator.ui.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "aerospike-ce-kubernetes-operator.ui.fullname" . }}-secrets
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "aerospike-ce-kubernetes-operator.ui.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/aerospike-ce-kubernetes-operator/values.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/values.yaml
@@ -85,8 +85,12 @@ replicaCount: 1
 image:
   # -- Container image repository
   repository: ghcr.io/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator
-  # -- Container image tag
-  tag: "latest"
+  # -- Container image tag. Leave empty to fall through to .Chart.AppVersion
+  # so installs are pinned to the chart's matching operator release. Avoid
+  # using "latest" — it makes deployments unreproducible and silently
+  # interacts with imagePullPolicy: IfNotPresent (cached :latest never gets
+  # refreshed).
+  tag: ""
   # -- Image pull policy: Always, IfNotPresent, or Never
   pullPolicy: IfNotPresent
 
@@ -112,14 +116,17 @@ serviceAccount:
 # =============================================================================
 # Resource Limits
 # =============================================================================
-# -- CPU and memory resource requests/limits for the operator pod
+# -- CPU and memory resource requests/limits for the operator pod.
+# Memory is aligned with config/manager/manager.yaml (kustomize manifest);
+# the previous 256Mi limit / 128Mi request risked OOMKill once
+# MaxConcurrentReconciles=2 fans out across many AerospikeClusters.
 resources:
   limits:
     cpu: 500m
-    memory: 256Mi
+    memory: 512Mi
   requests:
     cpu: 100m
-    memory: 128Mi
+    memory: 256Mi
 
 # =============================================================================
 # Webhook Configuration
@@ -239,8 +246,12 @@ cilium:
 # Pod Disruption Budget
 # =============================================================================
 podDisruptionBudget:
-  # -- Create a PodDisruptionBudget for the operator deployment
-  enabled: false
+  # -- Create a PodDisruptionBudget for the operator deployment.
+  # Enabled by default so that voluntary node drains (kubectl drain, cluster
+  # autoscaler scale-in) cannot evict the only operator pod and leave Aerospike
+  # clusters unmanaged. Even with replicaCount=1 the PDB blocks voluntary
+  # eviction until the replacement pod is Ready on another node.
+  enabled: true
   # -- Minimum available pods (mutually exclusive with maxUnavailable)
   minAvailable: 1
   # -- Maximum unavailable pods (mutually exclusive with minAvailable).
@@ -348,7 +359,9 @@ ui:
     enabled: true
     image:
       repository: ghcr.io/aerospike-ce-ecosystem/aerospike-cluster-manager-api
-      tag: "latest"
+      # -- Container image tag. Leave empty to fall through to
+      # .Chart.AppVersion (see ui.api.image helper in _helpers.tpl).
+      tag: ""
       pullPolicy: IfNotPresent
     service:
       type: ClusterIP
@@ -533,7 +546,9 @@ ui:
     enabled: true
     image:
       repository: ghcr.io/aerospike-ce-ecosystem/aerospike-cluster-manager-web
-      tag: "latest"
+      # -- Container image tag. Leave empty to fall through to
+      # .Chart.AppVersion (see ui.web.image helper in _helpers.tpl).
+      tag: ""
       pullPolicy: IfNotPresent
     service:
       type: ClusterIP

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -43,7 +43,7 @@ spec:
         args:
           - --leader-elect
           - --health-probe-bind-address=:8081
-        image: ghcr.io/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator:latest
+        image: ghcr.io/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator:1.3.1
         imagePullPolicy: IfNotPresent
         name: manager
         ports: []

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -43,7 +43,7 @@ spec:
         args:
           - --leader-elect
           - --health-probe-bind-address=:8081
-        image: controller:latest
+        image: ghcr.io/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator:latest
         imagePullPolicy: IfNotPresent
         name: manager
         ports: []


### PR DESCRIPTION
## Summary
Hardens the operator chart with safer defaults: concrete image tags, scoped RBAC, sensible memory limits, HA defaults, and explicit non-root user.

## Issues Addressed
1. **CRITICAL** `image.tag: "latest"` defaults -> unreproducible deployments + IfNotPresent staleness
2. **CRITICAL** UI ClusterRole `secrets:list` cluster-wide -> all secrets exposed if UI compromised
3. **HIGH** Operator memory 256Mi limit (kustomize was 512Mi) -> OOMKill risk under concurrent reconcile
4. **HIGH** No PDB by default + replicaCount=1 -> operator offline during voluntary drain
5. **HIGH** `controller:latest` placeholder in raw kustomize manifest
6. **HIGH** Pod spec missing explicit runAsUser -> defense-in-depth gap

## Follow-ups
- If UI features depended on `secrets:list`, add namespace-scoped Role per Aerospike namespace (not cluster-wide)
- Consider committing a kustomize `images:` patch in `config/default/kustomization.yaml`

## Test Plan
- [x] `helm lint` passes
- [x] `helm template` renders all images as ghcr.io/.../<repo>:1.3.1 (chart AppVersion), no `:latest`
- [x] `runAsUser: 65532` present in operator pod spec
- [x] PDB rendered by default
- [ ] Install in kind, verify operator runs as 65532
- [ ] Drain operator node with new PDB, confirm graceful eviction