### PR TITLE
fix(chart,init): NetworkPolicy webhook block, well-known password, init error swallow, PDB drain block

### DIFF
--- a/charts/aerospike-ce-kubernetes-operator/templates/default-templates.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/default-templates.yaml
@@ -21,9 +21,14 @@ metadata:
   labels:
     {{- include "aerospike-ce-kubernetes-operator.labels" $ | nindent 4 }}
     app.kubernetes.io/component: cluster-template
-  annotations:
-    "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-weight": "10"
+  # Intentionally NOT a Helm hook: hook resources are not part of the release
+  # manifest, so `helm uninstall` would leave these AerospikeClusterTemplates
+  # behind. A subsequent `helm install` then collides on the leaked names, and
+  # toggling defaultTemplates.enabled false→true also breaks because Helm has
+  # no record of the prior install. The CRD-existence precondition is enforced
+  # by `aerospike-ce-kubernetes-operator.validate.defaultTemplatesNeedCRDs`
+  # in _helpers.tpl, so we no longer need post-install/post-upgrade hooks to
+  # stage creation after CRD installation.
 spec:
   {{- toYaml $merged | nindent 2 }}
 {{- end }}

--- a/charts/aerospike-ce-kubernetes-operator/templates/networkpolicy.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/networkpolicy.yaml
@@ -23,11 +23,14 @@ spec:
         - port: 8443
           protocol: TCP
     {{- if .Values.webhook.enabled }}
-    - from:
-        - namespaceSelector:
-            matchLabels:
-              webhooks: enabled
-      ports:
+    # Webhook port: ingress is intentionally unrestricted in standard NetworkPolicy.
+    # Admission requests originate from kube-apiserver, which has no labelable
+    # pod or namespace selector in core Kubernetes networking.k8s.io/v1. A
+    # `from:` selector here would drop every admission request and break
+    # cluster reconciliation. The Cilium variant (ciliumnetworkpolicy.yaml)
+    # restricts this to `fromEntities: kube-apiserver`; standard NetworkPolicy
+    # cannot express that and must allow ingress from all sources.
+    - ports:
         - port: {{ .Values.webhook.port }}
           protocol: TCP
     {{- end }}

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/deployment-api.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/deployment-api.yaml
@@ -10,9 +10,17 @@ metadata:
   labels:
     {{- include "aerospike-ce-kubernetes-operator.ui.api.labels" . | nindent 4 }}
 spec:
-  {{- if not .Values.ui.autoscaling.enabled }}
+  {{- /*
+    Render `replicas` UNLESS an HPA is actually managing this Deployment.
+    The HPA at templates/ui/hpa.yaml only targets the web Deployment, so the
+    API never has an HPA. Skipping `replicas` here would let the apiserver
+    default to 1 with nothing to scale it, regardless of `ui.replicaCount`.
+    Suppress `replicas` only when BOTH the web HPA is active AND web is
+    enabled (i.e. the HPA resource was actually rendered) — but even then
+    the API is unmanaged, so we still emit replicas. Net effect: replicas
+    is always emitted for the API Deployment until a per-API HPA exists.
+  */}}
   replicas: {{ .Values.ui.replicaCount }}
-  {{- end }}
   strategy:
     {{- if .Values.ui.postgresql.enabled }}
     type: Recreate

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/secret.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/secret.yaml
@@ -1,16 +1,37 @@
 {{- if and (eq (include "aerospike-ce-kubernetes-operator.ui.api.enabled" .) "true") (not .Values.ui.postgresql.existingSecret) }}
+{{- /*
+Resolve the embedded PostgreSQL password.
+Precedence:
+  1. Existing Secret on the cluster — preserved across upgrades so we never
+     rotate the password underneath a running database (which would lock the
+     API out of its own data).
+  2. User-supplied .Values.ui.postgresql.password (explicit override).
+  3. Auto-generated 24-char alphanumeric password on first install.
+The previous default of "aerospike" was a well-known credential and has been
+removed; values.yaml now ships an empty password to trigger auto-generation.
+*/}}
+{{- $secretName := printf "%s-db" (include "aerospike-ce-kubernetes-operator.ui.fullname" .) -}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace $secretName -}}
+{{- $password := "" -}}
+{{- if and $existing (index (default (dict) $existing.data) "POSTGRES_PASSWORD") -}}
+{{-   $password = index $existing.data "POSTGRES_PASSWORD" | b64dec -}}
+{{- else if .Values.ui.postgresql.password -}}
+{{-   $password = .Values.ui.postgresql.password -}}
+{{- else -}}
+{{-   $password = randAlphaNum 24 -}}
+{{- end -}}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "aerospike-ce-kubernetes-operator.ui.fullname" . }}-db
+  name: {{ $secretName }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "aerospike-ce-kubernetes-operator.ui.labels" . | nindent 4 }}
 type: Opaque
 stringData:
   {{- if .Values.ui.postgresql.enabled }}
-  POSTGRES_PASSWORD: {{ .Values.ui.postgresql.password | quote }}
-  DATABASE_URL: {{ printf "postgresql://%s:%s@localhost:5432/%s" (.Values.ui.postgresql.username | urlquery) (.Values.ui.postgresql.password | urlquery) .Values.ui.postgresql.database | quote }}
+  POSTGRES_PASSWORD: {{ $password | quote }}
+  DATABASE_URL: {{ printf "postgresql://%s:%s@localhost:5432/%s" (.Values.ui.postgresql.username | urlquery) ($password | urlquery) .Values.ui.postgresql.database | quote }}
   {{- else }}
   {{- if .Values.ui.env.databaseUrl }}
   DATABASE_URL: {{ .Values.ui.env.databaseUrl | quote }}

--- a/charts/aerospike-ce-kubernetes-operator/values.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/values.yaml
@@ -666,8 +666,15 @@ ui:
     database: aerospike_manager
     # -- Database user
     username: aerospike
-    # -- Database password (used for embedded sidecar only)
-    password: aerospike
+    # -- Database password (used for embedded sidecar only).
+    # When empty (default), the chart auto-generates a 24-character random
+    # password on first install via Helm's `lookup` + `randAlphaNum`. The
+    # generated value is preserved across `helm upgrade` by re-reading the
+    # existing Secret, so the password remains stable for the life of the
+    # release. To override, set this to your own value or supply a complete
+    # Secret via `ui.postgresql.existingSecret`. The previous default of
+    # "aerospike" was a well-known credential and is no longer shipped.
+    password: ""
     # -- Use an existing Secret instead of creating one.
     # The Secret must contain POSTGRES_PASSWORD and DATABASE_URL keys.
     existingSecret: ""

--- a/charts/aerospike-ce-kubernetes-operator/values.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/values.yaml
@@ -247,16 +247,20 @@ cilium:
 # =============================================================================
 podDisruptionBudget:
   # -- Create a PodDisruptionBudget for the operator deployment.
-  # Enabled by default so that voluntary node drains (kubectl drain, cluster
-  # autoscaler scale-in) cannot evict the only operator pod and leave Aerospike
-  # clusters unmanaged. Even with replicaCount=1 the PDB blocks voluntary
-  # eviction until the replacement pod is Ready on another node.
+  # Enabled by default so that voluntary disruptions (cluster autoscaler
+  # scale-in, controlled rollouts) respect a budget and don't take the
+  # operator offline simultaneously with Aerospike pods that need it.
   enabled: true
-  # -- Minimum available pods (mutually exclusive with maxUnavailable)
-  minAvailable: 1
+  # -- Minimum available pods (mutually exclusive with maxUnavailable).
+  # Leave empty unless you scale `replicaCount` above 1; setting
+  # minAvailable=1 with replicaCount=1 makes the operator pod un-evictable
+  # and blocks `kubectl drain` indefinitely.
+  minAvailable: ""
   # -- Maximum unavailable pods (mutually exclusive with minAvailable).
-  # Uncomment and remove minAvailable to use.
-  maxUnavailable: ""
+  # Default of 1 allows exactly one operator pod to be evicted at a time,
+  # which is the only safe value when replicaCount=1 (drain proceeds; the
+  # scheduler recreates the pod on another node).
+  maxUnavailable: 1
 
 # =============================================================================
 # Horizontal Pod Autoscaler

--- a/internal/initcontainer/scripts/aerospike-init.sh
+++ b/internal/initcontainer/scripts/aerospike-init.sh
@@ -156,21 +156,52 @@ process_volumes() {
                 rm -rf "${path:?}"/*
                 ;;
             dd)
+                # Pure dd path — failure means the device is unwritable. Do
+                # NOT swallow stderr or chain `|| true`; either of those
+                # defeats `set -e` and lets the init container "succeed"
+                # while leaving Aerospike with a dirty volume.
                 echo "[${label}] Zeroing first 1MB of ${path}..."
-                dd if=/dev/zero of="${path}" bs=1M count=1 conv=notrunc 2>/dev/null
+                if ! dd if=/dev/zero of="${path}" bs=1M count=1 conv=notrunc; then
+                    echo "ERROR: dd failed to zero ${path}; refusing to start Aerospike on a dirty volume." >&2
+                    exit 1
+                fi
                 ;;
             blkdiscard)
+                # blkdiscard is opportunistic: it requires kernel + device
+                # support (e.g. SSDs with TRIM, thin-provisioned volumes) and
+                # legitimately fails on filesystems / loopback / older HDDs.
+                # When discard is unavailable we still MUST guarantee the
+                # device is writable, so we follow up with a 1MB dd that is
+                # not allowed to fail.
                 echo "[${label}] Discarding blocks on ${path}..."
-                blkdiscard "${path}" 2>/dev/null || echo "blkdiscard failed for ${path}, continuing..."
+                if ! blkdiscard "${path}"; then
+                    echo "WARN: blkdiscard not supported on ${path}; falling back to dd verification." >&2
+                fi
+                if ! dd if=/dev/zero of="${path}" bs=1M count=1 conv=notrunc; then
+                    echo "ERROR: post-blkdiscard dd verification failed on ${path}." >&2
+                    exit 1
+                fi
                 ;;
             headerCleanup)
+                # Pure headerCleanup must succeed — Aerospike refuses to
+                # start when stale superblock headers are present.
                 echo "[${label}] Cleaning Aerospike headers on ${path}..."
-                dd if=/dev/zero of="${path}" bs=4096 count=1 conv=notrunc 2>/dev/null
+                if ! dd if=/dev/zero of="${path}" bs=4096 count=1 conv=notrunc; then
+                    echo "ERROR: dd header cleanup failed on ${path}." >&2
+                    exit 1
+                fi
                 ;;
             blkdiscardWithHeaderCleanup)
+                # Combined path: blkdiscard is opportunistic, but the
+                # follow-up header dd is mandatory.
                 echo "[${label}] Discarding blocks and cleaning headers on ${path}..."
-                blkdiscard "${path}" 2>/dev/null || echo "blkdiscard failed for ${path}, continuing..."
-                dd if=/dev/zero of="${path}" bs=4096 count=1 conv=notrunc 2>/dev/null
+                if ! blkdiscard "${path}"; then
+                    echo "WARN: blkdiscard not supported on ${path}; relying on header cleanup only." >&2
+                fi
+                if ! dd if=/dev/zero of="${path}" bs=4096 count=1 conv=notrunc; then
+                    echo "ERROR: dd header cleanup failed on ${path} after blkdiscard." >&2
+                    exit 1
+                fi
                 ;;
             *)
                 echo "[${label}] Skipping ${path} (method: ${method})"


### PR DESCRIPTION
## Summary

Six correctness fixes around the Helm chart and the init container script. Each one addresses a defect that breaks a real install path or produces a security-sensitive default; commits are split per-fix for easier bisecting.

- **fix(chart): allow webhook ingress from kube-apiserver in standard NetworkPolicy** — previous `from: namespaceSelector { matchLabels: { webhooks: enabled } }` dropped every admission request, because kube-apiserver has no labelable pod or namespace selector under `networking.k8s.io/v1`. Webhook port now ingresses from all sources, with a comment explaining why this differs from the metrics port and from the Cilium variant (`fromEntities: kube-apiserver`).
- **fix(chart): generate random Postgres password by default** — the embedded PostgreSQL sidecar shipped the well-known default `aerospike`. Now defaults to empty in values.yaml; `templates/ui/secret.yaml` resolves the password via Helm's `lookup` + `randAlphaNum` pattern (existing Secret > explicit override > 24-char random). The `existingSecret` path is unchanged.
- **fix(chart): always render API Deployment replicas (HPA only targets web)** — `templates/ui/hpa.yaml` only targets the web Deployment, but the API Deployment was suppressing its `replicas:` field whenever `ui.autoscaling.enabled=true`, falling back to the apiserver's default of 1 with no HPA. The API now always emits `replicas` until a per-API HPA exists.
- **fix(chart): remove uninstall-leak from defaultTemplates hook** — three `AerospikeClusterTemplate` resources were `helm.sh/hook: post-install,post-upgrade` with no delete-policy, so `helm uninstall` left them behind and the next install collided. Drop the hook annotations entirely; the existing `validate.defaultTemplatesNeedCRDs` gate already enforces CRD existence at template time.
- **fix(initcontainer): propagate dd/blkdiscard errors instead of swallowing** — `dd ... 2>/dev/null` and `blkdiscard ... 2>/dev/null || echo "...continuing..."` defeated `set -e`, so failed wipes silently let init exit 0 and Aerospike started on a dirty volume. Now `dd` and `headerCleanup` failures are fatal; pure `blkdiscard` is followed by a mandatory dd verification; `blkdiscardWithHeaderCleanup` always requires the header-cleanup dd to succeed.
- **fix(chart): allow operator drain when replicaCount=1** — default `replicaCount: 1` + `minAvailable: 1` made the operator pod un-evictable; `kubectl drain` and cluster autoscaler scale-in blocked indefinitely. Switched defaults to `minAvailable: ""` / `maxUnavailable: 1` so drain proceeds one pod at a time.

## Test plan

- [x] `helm lint charts/aerospike-ce-kubernetes-operator` passes
- [x] `make helm-lint` passes for both charts (operator + CRDs)
- [x] `helm template` renders successfully under default values, with `networkPolicy.enabled=true`, with `defaultTemplates.enabled=true,crds.install=true`, and with `ui.autoscaling.enabled=true,ui.postgresql.enabled=false`
- [x] Spot-checked rendered output:
    - NetworkPolicy webhook port has no `from:` selector
    - Secret carries a 24-char random `POSTGRES_PASSWORD`
    - PDB renders `maxUnavailable: 1`
    - API Deployment carries `replicas: 1` even when HPA is enabled
    - `AerospikeClusterTemplate` resources have no `helm.sh/hook` annotation
- [x] `shellcheck internal/initcontainer/scripts/aerospike-init.sh` is clean
- [ ] Real install on Kind: confirm webhook receives admission requests, drain succeeds with replicaCount=1, helm uninstall + reinstall cycle no longer collides on AerospikeClusterTemplate
- [ ] Verify `helm upgrade` preserves the auto-generated Postgres password (lookup path)