### PR TITLE
fix(webhook,template): close remaining CE constraint bypasses (overrides + template + post-merge)

### DIFF
--- a/api/v1alpha1/aerospikecluster_webhook.go
+++ b/api/v1alpha1/aerospikecluster_webhook.go
@@ -246,6 +246,33 @@ func (v *AerospikeClusterValidator) ValidateCreate(ctx context.Context, cluster 
 func (v *AerospikeClusterValidator) ValidateUpdate(ctx context.Context, oldCluster, cluster *AerospikeCluster) (admission.Warnings, error) {
 	aerospikeclusterlog.Info("Validating update", "name", cluster.Name)
 
+	// templateRef is immutable.
+	//
+	// Swapping the referenced template on a live cluster would silently
+	// re-base every templated default (storage class, scheduling, image,
+	// size, ...) and could cross between operator-managed configurations
+	// without any progressive rollout. The merged spec is written into the
+	// snapshot at admission time and consumed by the controller; a swap
+	// here is effectively a hidden mass-edit.
+	//
+	// Default policy is immutable. If a future change introduces a
+	// supported swap workflow it should require an explicit annotation +
+	// no overrides, not a free swap.
+	oldRef, newRef := oldCluster.Spec.TemplateRef, cluster.Spec.TemplateRef
+	switch {
+	case oldRef == nil && newRef != nil:
+		return nil, fmt.Errorf(
+			"spec.templateRef is immutable: cannot add templateRef to an existing cluster; create a new cluster that references the template")
+	case oldRef != nil && newRef == nil:
+		return nil, fmt.Errorf(
+			"spec.templateRef is immutable: cannot remove templateRef from a cluster that was created with one (was %q)",
+			oldRef.Name)
+	case oldRef != nil && newRef != nil && oldRef.Name != newRef.Name:
+		return nil, fmt.Errorf(
+			"spec.templateRef is immutable: cannot change templateRef from %q to %q; create a new cluster instead",
+			oldRef.Name, newRef.Name)
+	}
+
 	// Don't allow changing operations while one is InProgress
 	if oldCluster.Status.OperationStatus != nil &&
 		oldCluster.Status.OperationStatus.Phase == AerospikePhaseInProgress {
@@ -512,11 +539,91 @@ func (v *AerospikeClusterValidator) validate(cluster *AerospikeCluster) (admissi
 		allErrors = append(allErrors, "spec.overrides can only be set when spec.templateRef is specified")
 	}
 
+	// Validate the contents of spec.overrides against CE constraints. Without
+	// this, users could set spec.overrides.image to an Enterprise tag, or push
+	// an xdr/tls/security-enterprise stanza via overrides.aerospikeConfig and
+	// silently bypass the same checks the cluster-spec path enforces. The
+	// template webhook validates these fields at template-create time, but
+	// overrides only flow through the cluster webhook, so this check is the
+	// only line of defence for them.
+	if cluster.Spec.Overrides != nil {
+		allErrors = append(allErrors, v.validateOverrides(cluster.Spec.Overrides)...)
+	}
+
 	if len(allErrors) > 0 {
 		return warnings, fmt.Errorf("validation failed: %s", strings.Join(allErrors, "; "))
 	}
 
 	return warnings, nil
+}
+
+// validateOverrides applies the same CE constraints to spec.overrides that
+// the AerospikeClusterTemplate webhook applies to template specs at create
+// time:
+//   - image must not reference an Enterprise build,
+//   - size must be in the CE-allowed range (1–8) when explicitly set,
+//   - aerospikeConfig.namespaceDefaults must not contain enterprise-only
+//     namespace keys (compression, strong-consistency, ...) or xdr/tls/
+//     enterprise security sub-keys,
+//   - aerospikeConfig.service must not contain xdr/tls/enterprise security
+//     sub-keys.
+//
+// nil sections are skipped silently — overrides intentionally allows partial
+// patches and most fields are optional.
+func (v *AerospikeClusterValidator) validateOverrides(overrides *AerospikeClusterTemplateSpec) []string {
+	if overrides == nil {
+		return nil
+	}
+	var errs []string
+
+	// Image: same rules as spec.image — reject the enterprise repository name
+	// and any "ee-"/"ent-"/contains-"enterprise" tag.
+	if overrides.Image != "" {
+		imageLower := strings.ToLower(overrides.Image)
+		switch {
+		case strings.Contains(imageLower, "aerospike-server-enterprise"):
+			errs = append(errs, fmt.Sprintf(
+				"spec.overrides.image %q references the enterprise repository "+
+					"(aerospike-server-enterprise); CE clusters must use a CE image "+
+					"such as aerospike:ce-8.1.1.1",
+				overrides.Image))
+		case strings.Contains(imageLower, "enterprise") || isEnterpriseTag(overrides.Image):
+			errs = append(errs, fmt.Sprintf(
+				"spec.overrides.image %q is an Enterprise Edition image; only Community Edition images are allowed",
+				overrides.Image))
+		}
+	}
+
+	// Size: respect the CE 1–8 bound when the override sets a value.
+	if overrides.Size != nil {
+		size := *overrides.Size
+		if size < 1 || size > maxCEClusterSize {
+			errs = append(errs, fmt.Sprintf(
+				"spec.overrides.size %d must be between 1 and %d (CE limit)", size, maxCEClusterSize))
+		}
+	}
+
+	// aerospikeConfig: reject enterprise-only stanzas/keys reachable from the
+	// override map. Mirrors the template webhook's check (V-T xdr/tls/security/
+	// enterpriseOnlyNamespaceKeys) — see validateTemplateConfigBannedKeys.
+	if overrides.AerospikeConfig != nil {
+		if overrides.AerospikeConfig.NamespaceDefaults != nil {
+			errs = append(errs, validateTemplateConfigBannedKeys(
+				"spec.overrides.aerospikeConfig.namespaceDefaults",
+				overrides.AerospikeConfig.NamespaceDefaults.Value,
+				true,
+			)...)
+		}
+		if overrides.AerospikeConfig.Service != nil {
+			errs = append(errs, validateTemplateConfigBannedKeys(
+				"spec.overrides.aerospikeConfig.service",
+				overrides.AerospikeConfig.Service.Value,
+				false,
+			)...)
+		}
+	}
+
+	return errs
 }
 
 // validateAerospikeConfig checks the Aerospike configuration map.
@@ -556,9 +663,16 @@ func (v *AerospikeClusterValidator) validateAerospikeConfig(config map[string]an
 				warnings = append(warnings, nsWarnings...)
 			}
 		case map[string]any:
-			if len(ns) > maxCENamespaces {
-				errors = append(errors, fmt.Sprintf("aerospikeConfig.namespaces count %d exceeds CE maximum of %d", len(ns), maxCENamespaces))
-			}
+			// Reject the map shape outright. Previously we only counted entries
+			// here, which silently skipped per-namespace validation
+			// (enterprise-only keys, replication-factor bounds) — a CE bypass.
+			// configgen also expects a list (named blocks emitted in order),
+			// so the map form is structurally wrong even for a valid CE config.
+			errors = append(errors, fmt.Sprintf(
+				"aerospikeConfig.namespaces must be a list of namespace maps "+
+					"(e.g. [{name: foo, ...}, {name: bar, ...}]), got map with %d entries; "+
+					"per-namespace validation cannot run on the map form",
+				len(ns)))
 		}
 	}
 

--- a/api/v1alpha1/aerospikeclustertemplate_webhook.go
+++ b/api/v1alpha1/aerospikeclustertemplate_webhook.go
@@ -139,6 +139,26 @@ func (v *AerospikeClusterTemplateValidator) validate(tmpl *AerospikeClusterTempl
 		}
 	}
 
+	// V-T06: Image must not reference an Enterprise build (the canonical
+	// Docker Hub repo is `aerospike-server-enterprise`; "ee-" / "ent-" /
+	// generic "enterprise" substrings also indicate EE builds). Without this,
+	// any cluster pointing at this template silently inherits an EE image,
+	// bypassing the AerospikeCluster CE check.
+	//
+	// V-T07: Size must be 1–8 (CE limit) when the template explicitly supplies
+	// a default — same bound as spec.size on AerospikeCluster.
+	//
+	// V-T08: Monitoring port must be in the valid TCP range when set —
+	// catching templates that would later produce an invalid Service/SM.
+	//
+	// internal/template/validation.go has a ValidateTemplateSpec helper that
+	// implements the same checks, but we cannot call it here without an
+	// import cycle (internal/template -> api/v1alpha1). Inline the three
+	// checks instead so the template webhook actually enforces them.
+	allErrors = append(allErrors, validateTemplateImageCE(spec.Image)...)
+	allErrors = append(allErrors, validateTemplateSizeCE(spec.Size)...)
+	allErrors = append(allErrors, validateTemplateMonitoringPort(spec.Monitoring)...)
+
 	// Validate aerospikeConfig if present: heartbeat mode must be mesh for CE.
 	if spec.AerospikeConfig != nil {
 		if spec.AerospikeConfig.Network != nil && spec.AerospikeConfig.Network.Heartbeat != nil {
@@ -231,6 +251,66 @@ func validateTemplateConfigBannedKeys(fieldPath string, cfg map[string]any, isNa
 		}
 	}
 	return errs
+}
+
+// validateTemplateImageCE rejects template images that reference an
+// Enterprise build. Mirrors the cluster-spec image check in
+// validateSizeAndImage (aerospikecluster_webhook.go) so the same constraints
+// apply whether a user supplies the image directly or via a template.
+//
+// Empty image is allowed: clusters that reference the template are required
+// to supply spec.image themselves and the cluster webhook validates it.
+func validateTemplateImageCE(image string) []string {
+	if image == "" {
+		return nil
+	}
+	imageLower := strings.ToLower(image)
+	switch {
+	case strings.Contains(imageLower, "aerospike-server-enterprise"):
+		return []string{fmt.Sprintf(
+			"spec.image %q references the enterprise repository "+
+				"(aerospike-server-enterprise); CE clusters must use a CE image "+
+				"such as aerospike:ce-8.1.1.1",
+			image)}
+	case strings.Contains(imageLower, "enterprise") || isEnterpriseTag(image):
+		return []string{fmt.Sprintf(
+			"spec.image %q is an Enterprise Edition image; only Community Edition images are allowed",
+			image)}
+	}
+	return nil
+}
+
+// validateTemplateSizeCE enforces the CE size bound (1–8) when the template
+// explicitly supplies a Size value. Nil Size is allowed (the cluster will
+// then need to provide its own).
+//
+// The CRD already declares Minimum=1/Maximum=8 on Size, so this is defence
+// in depth — webhook errors are clearer than CRD validation errors and run
+// before anything else.
+func validateTemplateSizeCE(size *int32) []string {
+	if size == nil {
+		return nil
+	}
+	if *size < 1 || *size > maxCEClusterSize {
+		return []string{fmt.Sprintf(
+			"spec.size must be between 1 and %d (CE limit), got %d", maxCEClusterSize, *size)}
+	}
+	return nil
+}
+
+// validateTemplateMonitoringPort enforces a valid TCP port range on
+// monitoring.port when the template supplies a non-zero value. A zero port
+// means "use the cluster default" and is left to the cluster webhook /
+// defaulter.
+func validateTemplateMonitoringPort(m *AerospikeMonitoringSpec) []string {
+	if m == nil || m.Port == 0 {
+		return nil
+	}
+	if m.Port < 1 || m.Port > 65535 {
+		return []string{fmt.Sprintf(
+			"spec.monitoring.port must be between 1 and 65535, got %d", m.Port)}
+	}
+	return nil
 }
 
 // templateResourcesEqualRequestsLimits checks if CPU and memory requests equal limits.

--- a/api/v1alpha1/aerospikeclustertemplate_webhook_test.go
+++ b/api/v1alpha1/aerospikeclustertemplate_webhook_test.go
@@ -551,6 +551,76 @@ func TestAerospikeClusterTemplateValidate(t *testing.T) {
 	}
 }
 
+// --- V-T06/V-T07/V-T08 wiring tests (P0-2) ---
+//
+// These checks were implemented in internal/template/validation.go but were
+// only called from tests, never from the template webhook itself. Without
+// the webhook wiring, an AerospikeClusterTemplate could be created with an
+// enterprise image, an out-of-range size, or a malformed monitoring port,
+// and silently propagate that to every cluster that referenced it.
+
+// TestAerospikeClusterTemplateValidate_EnterpriseImageRejected pins V-T06.
+func TestAerospikeClusterTemplateValidate_EnterpriseImageRejected(t *testing.T) {
+	v := &AerospikeClusterTemplateValidator{}
+	tmpl := &AerospikeClusterTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "ee-image", Namespace: "default"},
+		Spec: AerospikeClusterTemplateSpec{
+			Image: "aerospike/aerospike-server-enterprise:8.1",
+		},
+	}
+	_, err := v.ValidateCreate(context.Background(), tmpl)
+	if err == nil {
+		t.Fatal("expected error for enterprise template image")
+	}
+	if !strings.Contains(err.Error(), "enterprise") {
+		t.Errorf("expected 'enterprise' in error, got: %v", err)
+	}
+}
+
+// TestAerospikeClusterTemplateValidate_SizeOutOfRangeRejected pins V-T07.
+// CRD validation already enforces 1<=size<=8 but the webhook check also
+// runs before CRD pruning and produces a clearer error.
+func TestAerospikeClusterTemplateValidate_SizeOutOfRangeRejected(t *testing.T) {
+	v := &AerospikeClusterTemplateValidator{}
+	bigSize := int32(99)
+	tmpl := &AerospikeClusterTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "big-size", Namespace: "default"},
+		Spec: AerospikeClusterTemplateSpec{
+			Size: &bigSize,
+		},
+	}
+	_, err := v.ValidateCreate(context.Background(), tmpl)
+	if err == nil {
+		t.Fatal("expected error for spec.size=99")
+	}
+	if !strings.Contains(err.Error(), "size must be between 1 and 8") {
+		t.Errorf("expected size range error, got: %v", err)
+	}
+}
+
+// TestAerospikeClusterTemplateValidate_MonitoringPortOutOfRangeRejected
+// pins V-T08.
+func TestAerospikeClusterTemplateValidate_MonitoringPortOutOfRangeRejected(t *testing.T) {
+	v := &AerospikeClusterTemplateValidator{}
+	tmpl := &AerospikeClusterTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "bad-port", Namespace: "default"},
+		Spec: AerospikeClusterTemplateSpec{
+			Monitoring: &AerospikeMonitoringSpec{
+				Enabled:       true,
+				ExporterImage: "aerospike/aerospike-prometheus-exporter:1.0.0",
+				Port:          70000,
+			},
+		},
+	}
+	_, err := v.ValidateCreate(context.Background(), tmpl)
+	if err == nil {
+		t.Fatal("expected error for monitoring.port=70000")
+	}
+	if !strings.Contains(err.Error(), "monitoring.port") {
+		t.Errorf("expected monitoring.port error, got: %v", err)
+	}
+}
+
 func TestAerospikeClusterTemplateValidateDelete(t *testing.T) {
 	v := &AerospikeClusterTemplateValidator{}
 	tmpl := &AerospikeClusterTemplate{

--- a/api/v1alpha1/webhook_test.go
+++ b/api/v1alpha1/webhook_test.go
@@ -4707,3 +4707,300 @@ func TestValidateCreate_RejectsDuplicateServiceMonitor(t *testing.T) {
 		t.Errorf("error should point at conflicting AerospikeCluster %q, got: %v", "demo-other", err)
 	}
 }
+
+// --- spec.overrides CE constraint validation tests (P0-1) ---
+
+// TestValidate_OverridesEnterpriseImageRejected pins the CE-bypass fix: a
+// templated cluster could previously set spec.overrides.image to an
+// Enterprise tag and the cluster webhook would silently accept it. The
+// resolved spec then materialised an Enterprise image inside a CE cluster.
+func TestValidate_OverridesEnterpriseImageRejected(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+	cluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:        3,
+			Image:       "aerospike:ce-8.1.1.1",
+			TemplateRef: &TemplateRef{Name: "prod"},
+			Overrides: &AerospikeClusterTemplateSpec{
+				Image: "aerospike/aerospike-server-enterprise:8.1",
+			},
+		},
+	}
+
+	_, err := v.validate(cluster)
+	if err == nil {
+		t.Fatal("expected error for enterprise image in spec.overrides")
+	}
+	if !strings.Contains(err.Error(), "spec.overrides.image") {
+		t.Errorf("expected 'spec.overrides.image' in error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "enterprise") {
+		t.Errorf("expected 'enterprise' in error, got: %v", err)
+	}
+}
+
+// TestValidate_OverridesXdrInServiceRejected covers the templated-bypass for
+// xdr in spec.overrides.aerospikeConfig.service. Previously the cluster
+// webhook only validated TemplateRef presence on spec.overrides and never
+// scanned the contents.
+func TestValidate_OverridesXdrInServiceRejected(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+	cluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:        3,
+			Image:       "aerospike:ce-8.1.1.1",
+			TemplateRef: &TemplateRef{Name: "prod"},
+			Overrides: &AerospikeClusterTemplateSpec{
+				AerospikeConfig: &TemplateAerospikeConfig{
+					Service: &AerospikeConfigSpec{
+						Value: map[string]any{
+							"xdr": map[string]any{"datacenters": []any{}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := v.validate(cluster)
+	if err == nil {
+		t.Fatal("expected error for xdr in spec.overrides.aerospikeConfig.service")
+	}
+	if !strings.Contains(err.Error(), "spec.overrides.aerospikeConfig.service") {
+		t.Errorf("expected service path in error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "xdr") {
+		t.Errorf("expected 'xdr' in error, got: %v", err)
+	}
+}
+
+// TestValidate_OverridesEnterpriseSecurityInNamespaceDefaultsRejected
+// covers the templated-bypass for enterprise security keys in
+// spec.overrides.aerospikeConfig.namespaceDefaults. namespaceDefaults is
+// merged as a base into every namespace, so a single overrides entry would
+// otherwise leak enterprise auth into every namespace.
+func TestValidate_OverridesEnterpriseSecurityInNamespaceDefaultsRejected(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+	cluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:        3,
+			Image:       "aerospike:ce-8.1.1.1",
+			TemplateRef: &TemplateRef{Name: "prod"},
+			Overrides: &AerospikeClusterTemplateSpec{
+				AerospikeConfig: &TemplateAerospikeConfig{
+					NamespaceDefaults: &AerospikeConfigSpec{
+						Value: map[string]any{
+							"security": map[string]any{
+								"ldap": map[string]any{"server": "ldaps://example"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := v.validate(cluster)
+	if err == nil {
+		t.Fatal("expected error for security.ldap in spec.overrides.aerospikeConfig.namespaceDefaults")
+	}
+	if !strings.Contains(err.Error(), "spec.overrides.aerospikeConfig.namespaceDefaults") {
+		t.Errorf("expected namespaceDefaults path in error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "ldap") {
+		t.Errorf("expected 'ldap' in error, got: %v", err)
+	}
+}
+
+// TestValidate_OverridesSizeOutOfRangeRejected pins that overrides.size
+// must respect the CE 1–8 bound. Without this, a templated cluster with
+// overrides.size=99 would silently set spec.size=99 after the merge.
+func TestValidate_OverridesSizeOutOfRangeRejected(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+	bigSize := int32(99)
+	cluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:        3,
+			Image:       "aerospike:ce-8.1.1.1",
+			TemplateRef: &TemplateRef{Name: "prod"},
+			Overrides: &AerospikeClusterTemplateSpec{
+				Size: &bigSize,
+			},
+		},
+	}
+
+	_, err := v.validate(cluster)
+	if err == nil {
+		t.Fatal("expected error for spec.overrides.size=99")
+	}
+	if !strings.Contains(err.Error(), "spec.overrides.size") {
+		t.Errorf("expected 'spec.overrides.size' in error, got: %v", err)
+	}
+}
+
+// TestValidate_OverridesValidPasses ensures the new check does not
+// over-reject CE-valid overrides: a CE image and a size of 5 in an
+// overrides spec must still validate cleanly.
+func TestValidate_OverridesValidPasses(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+	size := int32(5)
+	cluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:        3,
+			Image:       "aerospike:ce-8.1.1.1",
+			TemplateRef: &TemplateRef{Name: "prod"},
+			Overrides: &AerospikeClusterTemplateSpec{
+				Image: "aerospike:ce-8.1.1.1",
+				Size:  &size,
+			},
+		},
+	}
+
+	if _, err := v.validate(cluster); err != nil {
+		t.Fatalf("unexpected error for valid CE overrides: %v", err)
+	}
+}
+
+// --- templateRef immutability tests (P1-2) ---
+
+// TestValidateUpdate_TemplateRefSwapRejected pins that swapping templateRef
+// between two existing templates is rejected on update. Swapping would
+// silently re-base every templated default and could cross between
+// operator-managed configurations without a progressive rollout.
+func TestValidateUpdate_TemplateRefSwapRejected(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+	oldCluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:        3,
+			Image:       "aerospike:ce-8.1.1.1",
+			TemplateRef: &TemplateRef{Name: "prod"},
+		},
+	}
+	newCluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:        3,
+			Image:       "aerospike:ce-8.1.1.1",
+			TemplateRef: &TemplateRef{Name: "staging"},
+		},
+	}
+
+	_, err := v.ValidateUpdate(context.Background(), oldCluster, newCluster)
+	if err == nil {
+		t.Fatal("expected error when changing templateRef")
+	}
+	if !strings.Contains(err.Error(), "templateRef is immutable") {
+		t.Errorf("expected 'templateRef is immutable' in error, got: %v", err)
+	}
+}
+
+// TestValidateUpdate_TemplateRefAddRejected covers the add path:
+// promoting a non-templated cluster to a templated one is also rejected.
+func TestValidateUpdate_TemplateRefAddRejected(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+	oldCluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:  3,
+			Image: "aerospike:ce-8.1.1.1",
+		},
+	}
+	newCluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:        3,
+			Image:       "aerospike:ce-8.1.1.1",
+			TemplateRef: &TemplateRef{Name: "prod"},
+		},
+	}
+
+	_, err := v.ValidateUpdate(context.Background(), oldCluster, newCluster)
+	if err == nil {
+		t.Fatal("expected error when adding templateRef on update")
+	}
+	if !strings.Contains(err.Error(), "templateRef is immutable") {
+		t.Errorf("expected 'templateRef is immutable' in error, got: %v", err)
+	}
+}
+
+// TestValidateUpdate_TemplateRefRemoveRejected covers the remove path.
+func TestValidateUpdate_TemplateRefRemoveRejected(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+	oldCluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:        3,
+			Image:       "aerospike:ce-8.1.1.1",
+			TemplateRef: &TemplateRef{Name: "prod"},
+		},
+	}
+	newCluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:  3,
+			Image: "aerospike:ce-8.1.1.1",
+		},
+	}
+
+	_, err := v.ValidateUpdate(context.Background(), oldCluster, newCluster)
+	if err == nil {
+		t.Fatal("expected error when removing templateRef on update")
+	}
+	if !strings.Contains(err.Error(), "templateRef is immutable") {
+		t.Errorf("expected 'templateRef is immutable' in error, got: %v", err)
+	}
+}
+
+// TestValidateUpdate_TemplateRefUnchangedAllowed pins that an update that
+// preserves templateRef is still allowed (the immutability check must not
+// over-reject identical refs).
+func TestValidateUpdate_TemplateRefUnchangedAllowed(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+	oldCluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:        3,
+			Image:       "aerospike:ce-8.1.1.1",
+			TemplateRef: &TemplateRef{Name: "prod"},
+		},
+	}
+	newCluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:        4, // unrelated change
+			Image:       "aerospike:ce-8.1.1.1",
+			TemplateRef: &TemplateRef{Name: "prod"},
+		},
+	}
+
+	if _, err := v.ValidateUpdate(context.Background(), oldCluster, newCluster); err != nil {
+		t.Fatalf("unexpected error when templateRef unchanged: %v", err)
+	}
+}
+
+// --- namespaces-as-map rejection (P1-1) ---
+
+// TestValidate_NamespacesAsMapRejected covers the CE bypass: when
+// aerospikeConfig.namespaces was provided as a map, the cluster webhook
+// only counted entries and never ran per-namespace validation. A map-shaped
+// namespaces value with enterprise-only keys (compression,
+// strong-consistency, ...) would silently slip through to configgen.
+func TestValidate_NamespacesAsMapRejected(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+	cluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:  3,
+			Image: "aerospike:ce-8.1.1.1",
+			AerospikeConfig: &AerospikeConfigSpec{
+				Value: map[string]any{
+					"namespaces": map[string]any{
+						"test": map[string]any{
+							"replication-factor": 1,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := v.validate(cluster)
+	if err == nil {
+		t.Fatal("expected error when aerospikeConfig.namespaces is a map")
+	}
+	if !strings.Contains(err.Error(), "must be a list") {
+		t.Errorf("expected 'must be a list' in error, got: %v", err)
+	}
+}

--- a/internal/controller/reconciler.go
+++ b/internal/controller/reconciler.go
@@ -317,8 +317,11 @@ func (r *AerospikeClusterReconciler) resolveTemplate(
 		// the cluster object from the API server response, which resets the Spec
 		// to the server-side version and discards in-memory changes made by
 		// ApplyTemplate (e.g., PodAntiAffinity, Resources from the template).
-		aerotmpl.ApplyTemplate(aerotmpl.MergeTemplateSpec(
-			cluster.Status.TemplateSnapshot.Spec, cluster.Spec.Overrides), cluster)
+		if err := aerotmpl.ApplyTemplate(aerotmpl.MergeTemplateSpec(
+			cluster.Status.TemplateSnapshot.Spec, cluster.Spec.Overrides), cluster); err != nil {
+			log.Error(err, "Failed to re-apply template after status update", "template", cluster.Spec.TemplateRef.Name)
+			return nil, err
+		}
 	}
 	// Remove the resync annotation from the API server now that the snapshot is persisted.
 	// This Patch runs after Status.Update so it does not overwrite the snapshot.
@@ -332,8 +335,11 @@ func (r *AerospikeClusterReconciler) resolveTemplate(
 			return nil, err
 		}
 		// Re-apply after Patch too, which also refreshes the cluster object.
-		aerotmpl.ApplyTemplate(aerotmpl.MergeTemplateSpec(
-			cluster.Status.TemplateSnapshot.Spec, cluster.Spec.Overrides), cluster)
+		if err := aerotmpl.ApplyTemplate(aerotmpl.MergeTemplateSpec(
+			cluster.Status.TemplateSnapshot.Spec, cluster.Spec.Overrides), cluster); err != nil {
+			log.Error(err, "Failed to re-apply template after annotation cleanup", "template", cluster.Spec.TemplateRef.Name)
+			return nil, err
+		}
 	}
 	if resolveResult.SnapshotUpdated && cluster.Status.TemplateSnapshot != nil {
 		r.Recorder.Eventf(cluster, corev1.EventTypeNormal, EventTemplateApplied,

--- a/internal/template/config.go
+++ b/internal/template/config.go
@@ -17,6 +17,7 @@ limitations under the License.
 package template
 
 import (
+	"fmt"
 	"maps"
 
 	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
@@ -24,9 +25,14 @@ import (
 
 // applyAerospikeConfig merges template aerospikeConfig defaults into the cluster's aerospikeConfig.
 // Cluster-level settings always take precedence over template defaults.
-func applyAerospikeConfig(tmplConfig *ackov1alpha1.TemplateAerospikeConfig, cluster *ackov1alpha1.AerospikeCluster) {
+//
+// Returns an error when the cluster's aerospikeConfig.service exists with a
+// non-map type (which the cluster webhook rejects, but check defensively
+// here so a future bypass of the webhook does not silently coerce a non-map
+// service value into a fresh empty map and discard the user's data).
+func applyAerospikeConfig(tmplConfig *ackov1alpha1.TemplateAerospikeConfig, cluster *ackov1alpha1.AerospikeCluster) error {
 	if tmplConfig == nil {
-		return
+		return nil
 	}
 
 	if cluster.Spec.AerospikeConfig == nil {
@@ -42,6 +48,21 @@ func applyAerospikeConfig(tmplConfig *ackov1alpha1.TemplateAerospikeConfig, clus
 
 	// Apply service defaults (template is base, cluster overrides).
 	if tmplConfig.Service != nil && len(tmplConfig.Service.Value) > 0 {
+		// Defensive type check: the cluster webhook already rejects
+		// aerospikeConfig.service when it isn't a map, but if that path is
+		// ever bypassed (failurePolicy=Ignore on a future deployment, an
+		// unrelated mutation between admission and reconcile, ...) we must
+		// not silently overwrite the user's value with our merged map.
+		// getOrCreateSection would return a fresh empty map in that case
+		// and the deepMerge below would discard the original payload.
+		if existing, exists := config["service"]; exists {
+			if _, ok := existing.(map[string]any); !ok {
+				return fmt.Errorf(
+					"aerospikeConfig.service has type %T, expected map; refusing to overwrite with template defaults",
+					existing,
+				)
+			}
+		}
 		existing := getOrCreateSection(config, "service")
 		config["service"] = deepMergeMapBaseFirst(tmplConfig.Service.Value, existing)
 	}
@@ -74,6 +95,7 @@ func applyAerospikeConfig(tmplConfig *ackov1alpha1.TemplateAerospikeConfig, clus
 	if tmplConfig.NamespaceDefaults != nil && len(tmplConfig.NamespaceDefaults.Value) > 0 {
 		applyNamespaceDefaults(config, tmplConfig.NamespaceDefaults.Value)
 	}
+	return nil
 }
 
 // applyNamespaceDefaults merges defaults into each namespace entry in aerospikeConfig.

--- a/internal/template/resolver.go
+++ b/internal/template/resolver.go
@@ -19,6 +19,7 @@ package template
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -33,7 +34,108 @@ import (
 const (
 	// AnnotationResyncTemplate triggers a manual template resync when set to "true".
 	AnnotationResyncTemplate = "acko.io/resync-template"
+
+	// maxCEClusterSize is the CE node-count cap. Mirrors the constant of the
+	// same name in api/v1alpha1; duplicated here to avoid an import cycle
+	// (api/v1alpha1 already imports nothing from internal/template, but
+	// re-exposing the constant from api/v1alpha1 isn't necessary either —
+	// keeping a short package-local copy is the simplest path).
+	maxCEClusterSize = 8
 )
+
+// enterpriseOnlySecurityKeysCE lists security sub-keys that are
+// Enterprise-only on the CE edition (mirror of the map of the same name in
+// api/v1alpha1). Kept package-local to avoid circular imports.
+var enterpriseOnlySecurityKeysCE = map[string]string{
+	"tls":    "TLS within the security stanza is Enterprise-only",
+	"ldap":   "LDAP authentication is Enterprise-only",
+	"log":    "security audit logging is Enterprise-only",
+	"syslog": "security syslog sink is Enterprise-only",
+}
+
+// enterpriseOnlyNamespaceKeysCE lists namespace-level Aerospike config keys
+// that are Enterprise-only (mirror of api/v1alpha1.enterpriseOnlyNamespaceKeys).
+// Used by the post-merge re-validator in validateMergedConfigCE.
+var enterpriseOnlyNamespaceKeysCE = map[string]string{
+	"compression":              "data compression is Enterprise-only",
+	"compression-level":        "data compression is Enterprise-only",
+	"durable-delete":           "durable deletes is Enterprise-only",
+	"fast-restart":             "fast restart is Enterprise-only",
+	"index-type":               "index-type flash/pmem is Enterprise-only",
+	"sindex-type":              "sindex-type flash/pmem is Enterprise-only",
+	"rack-id":                  "rack-id in namespace is Enterprise-only; use operator rackConfig instead",
+	"strong-consistency":       "strong consistency is Enterprise-only",
+	"tomb-raider-eligible-age": "tomb-raider is Enterprise-only",
+	"tomb-raider-period":       "tomb-raider is Enterprise-only",
+}
+
+// isEnterpriseTag returns true for image tags that indicate an Enterprise
+// Edition build (e.g., "aerospike:ee-8.0.0.1_1", "aerospike:ent-8.0.0").
+// Mirrors api/v1alpha1.isEnterpriseTag — duplicated to avoid an import
+// cycle.
+func isEnterpriseTag(image string) bool {
+	parts := strings.SplitN(image, ":", 2)
+	if len(parts) != 2 {
+		return false
+	}
+	tagLower := strings.ToLower(parts[1])
+	return strings.HasPrefix(tagLower, "ee-") || strings.HasPrefix(tagLower, "ent-")
+}
+
+// validateMergedConfigCE reapplies the CE-specific aerospikeConfig checks
+// (xdr/tls absent, no enterprise security sub-keys, no enterprise namespace
+// keys) on the materialised cluster config map. Mirrors the CE checks
+// performed by the cluster webhook on the raw aerospikeConfig.
+func validateMergedConfigCE(config map[string]any) []string {
+	if config == nil {
+		return nil
+	}
+	var errs []string
+
+	if _, exists := config["xdr"]; exists {
+		errs = append(errs, "merged aerospikeConfig must not contain 'xdr' section (XDR is Enterprise-only)")
+	}
+	if _, exists := config["tls"]; exists {
+		errs = append(errs, "merged aerospikeConfig must not contain 'tls' section (TLS is Enterprise-only)")
+	}
+	if secSection, exists := config["security"]; exists {
+		if secMap, ok := secSection.(map[string]any); ok {
+			for enterpriseKey, reason := range enterpriseOnlySecurityKeysCE {
+				if _, found := secMap[enterpriseKey]; found {
+					errs = append(errs, fmt.Sprintf(
+						"merged aerospikeConfig.security.%s is not allowed in CE edition (%s)",
+						enterpriseKey, reason))
+				}
+			}
+		}
+	}
+	// Per-namespace enterprise-only key check. namespaceDefaults already
+	// flowed through the template+overrides check, but the merged namespaces
+	// list is what configgen actually consumes.
+	if nsSection, exists := config["namespaces"]; exists {
+		if nsList, ok := nsSection.([]any); ok {
+			for i, nsEntry := range nsList {
+				nsMap, ok := nsEntry.(map[string]any)
+				if !ok {
+					continue
+				}
+				nsName := "<unknown>"
+				if name, ok := nsMap["name"].(string); ok {
+					nsName = name
+				}
+				for enterpriseKey, reason := range enterpriseOnlyNamespaceKeysCE {
+					if _, found := nsMap[enterpriseKey]; found {
+						errs = append(errs, fmt.Sprintf(
+							"merged namespace[%d] %q: '%s' is not allowed (%s)",
+							i, nsName, enterpriseKey, reason))
+					}
+				}
+			}
+		}
+	}
+
+	return errs
+}
 
 // ResolveResult holds the outcome of template resolution.
 type ResolveResult struct {
@@ -100,9 +202,14 @@ func NeedsResync(cluster *ackov1alpha1.AerospikeCluster) bool {
 // ApplyTemplate applies the resolved template spec (after merge with overrides)
 // to the cluster's spec in-memory. The API server object is not modified.
 // Only fields not already explicitly set in the cluster spec are applied.
-func ApplyTemplate(resolvedTemplateSpec *ackov1alpha1.AerospikeClusterTemplateSpec, cluster *ackov1alpha1.AerospikeCluster) {
+//
+// Returns an error when applying aerospikeConfig fails (e.g. the cluster's
+// aerospikeConfig.service exists with a non-map type and the template
+// supplies service defaults — see applyAerospikeConfig). Other apply* steps
+// are total functions and never fail.
+func ApplyTemplate(resolvedTemplateSpec *ackov1alpha1.AerospikeClusterTemplateSpec, cluster *ackov1alpha1.AerospikeCluster) error {
 	if resolvedTemplateSpec == nil {
-		return
+		return nil
 	}
 
 	// Apply scheduling (pod anti-affinity, tolerations, node affinity).
@@ -111,8 +218,12 @@ func ApplyTemplate(resolvedTemplateSpec *ackov1alpha1.AerospikeClusterTemplateSp
 	// Apply storage defaults.
 	applyStorage(resolvedTemplateSpec.Storage, cluster)
 
-	// Apply Aerospike config defaults.
-	applyAerospikeConfig(resolvedTemplateSpec.AerospikeConfig, cluster)
+	// Apply Aerospike config defaults. May fail if the cluster's existing
+	// aerospikeConfig.service value isn't a map (defensive check; the
+	// cluster webhook normally rejects such specs at admission).
+	if err := applyAerospikeConfig(resolvedTemplateSpec.AerospikeConfig, cluster); err != nil {
+		return err
+	}
 
 	// Apply resource defaults.
 	if resolvedTemplateSpec.Resources != nil {
@@ -132,6 +243,7 @@ func ApplyTemplate(resolvedTemplateSpec *ackov1alpha1.AerospikeClusterTemplateSp
 	applySize(resolvedTemplateSpec.Size, cluster)
 	applyMonitoring(resolvedTemplateSpec.Monitoring, cluster)
 	applyNetworkPolicy(resolvedTemplateSpec.AerospikeNetworkPolicy, cluster)
+	return nil
 }
 
 // Resolve is the main entry point for template resolution in the reconciler.
@@ -188,7 +300,9 @@ func Resolve(
 	}
 
 	// Apply the effective template spec to the in-memory cluster spec.
-	ApplyTemplate(effectiveSpec, cluster)
+	if err := ApplyTemplate(effectiveSpec, cluster); err != nil {
+		return result, fmt.Errorf("applying template %q to cluster spec: %w", cluster.Spec.TemplateRef.Name, err)
+	}
 
 	// Post-template required field check: image and size must be resolvable after
 	// applying both the cluster spec and the template. If either is still unset,
@@ -206,5 +320,68 @@ func Resolve(
 		)
 	}
 
+	// Defence-in-depth: re-validate the materialised cluster spec against CE
+	// constraints. The cluster webhook + template webhook already enforce
+	// these on the wire, but the merged spec is the actual artefact that
+	// configgen / the StatefulSet will consume — if a webhook is bypassed
+	// (e.g. failurePolicy=Ignore on a future deployment) or a future merge
+	// rule introduces a bypass, this catches it before any pod is created.
+	if errs := validateMergedSpecCE(&cluster.Spec); len(errs) > 0 {
+		return result, fmt.Errorf(
+			"resolved spec violates CE constraints after applying template %q: %s",
+			cluster.Spec.TemplateRef.Name,
+			strings.Join(errs, "; "),
+		)
+	}
+
 	return result, nil
+}
+
+// validateMergedSpecCE re-runs the core CE constraints on a fully-merged
+// AerospikeClusterSpec. Returns a list of error messages; an empty list
+// means the spec is acceptable.
+//
+// Checks (kept intentionally narrow — these are the bypassable ones):
+//   - image is a CE image (no "aerospike-server-enterprise" repo, no
+//     "enterprise" / "ee-" / "ent-" tag),
+//   - size is in [1, maxCEClusterSize],
+//   - aerospikeConfig top-level has no xdr/tls stanzas,
+//   - aerospikeConfig.security has no enterprise-only sub-keys,
+//   - aerospikeConfig.namespaces[*] has no enterprise-only namespace keys
+//     (compression, strong-consistency, durable-delete, ...).
+//
+// Errors are returned (not warnings) because they describe configurations
+// that would either be rejected by the CE server at start-up or violate the
+// CE licence. They must not silently flow through to a StatefulSet.
+func validateMergedSpecCE(spec *ackov1alpha1.AerospikeClusterSpec) []string {
+	if spec == nil {
+		return nil
+	}
+	var errs []string
+
+	// Image
+	if image := spec.Image; image != "" {
+		imageLower := strings.ToLower(image)
+		switch {
+		case strings.Contains(imageLower, "aerospike-server-enterprise"):
+			errs = append(errs, fmt.Sprintf(
+				"merged spec.image %q references the enterprise repository (aerospike-server-enterprise)", image))
+		case strings.Contains(imageLower, "enterprise") || isEnterpriseTag(image):
+			errs = append(errs, fmt.Sprintf(
+				"merged spec.image %q is an Enterprise Edition image", image))
+		}
+	}
+
+	// Size
+	if spec.Size < 1 || spec.Size > maxCEClusterSize {
+		errs = append(errs, fmt.Sprintf(
+			"merged spec.size %d must be between 1 and %d (CE limit)", spec.Size, maxCEClusterSize))
+	}
+
+	// aerospikeConfig
+	if spec.AerospikeConfig != nil {
+		errs = append(errs, validateMergedConfigCE(spec.AerospikeConfig.Value)...)
+	}
+
+	return errs
 }

--- a/internal/template/resolver_test.go
+++ b/internal/template/resolver_test.go
@@ -140,7 +140,9 @@ func TestApplyAerospikeConfig_NamespaceDefaults(t *testing.T) {
 		},
 	}
 
-	applyAerospikeConfig(tmplConfig, cluster)
+	if err := applyAerospikeConfig(tmplConfig, cluster); err != nil {
+		t.Fatalf("applyAerospikeConfig() unexpected error: %v", err)
+	}
 
 	nsList, ok := cluster.Spec.AerospikeConfig.Value["namespaces"].([]any)
 	if !ok || len(nsList) == 0 {
@@ -230,7 +232,9 @@ func TestApplyTemplate_Resources(t *testing.T) {
 
 	// Resources should be applied when not set in cluster spec.
 	templateSpec := &ackov1alpha1.AerospikeClusterTemplateSpec{}
-	ApplyTemplate(templateSpec, cluster)
+	if err := ApplyTemplate(templateSpec, cluster); err != nil {
+		t.Fatalf("ApplyTemplate() unexpected error: %v", err)
+	}
 
 	// With nil resources in template, nothing should be set.
 	if cluster.Spec.PodSpec != nil && cluster.Spec.PodSpec.AerospikeContainerSpec != nil &&
@@ -693,7 +697,9 @@ func TestApplyTemplate_ImageAndSizeApplied(t *testing.T) {
 		Size:  &size,
 	}
 	cluster := newCluster()
-	ApplyTemplate(tmplSpec, cluster)
+	if err := ApplyTemplate(tmplSpec, cluster); err != nil {
+		t.Fatalf("ApplyTemplate() unexpected error: %v", err)
+	}
 
 	if cluster.Spec.Image != testImageCE8 {
 		t.Errorf("expected image to be applied, got %q", cluster.Spec.Image)
@@ -723,7 +729,9 @@ func TestApplyTemplate_ClusterValuesTakePrecedenceOverTemplate(t *testing.T) {
 		AccessType: ackov1alpha1.AerospikeNetworkTypeHostInternal,
 	}
 
-	ApplyTemplate(tmplSpec, cluster)
+	if err := ApplyTemplate(tmplSpec, cluster); err != nil {
+		t.Fatalf("ApplyTemplate() unexpected error: %v", err)
+	}
 
 	if cluster.Spec.Image != testImageCE8Old {
 		t.Errorf("expected cluster image to be preserved, got %q", cluster.Spec.Image)
@@ -736,5 +744,132 @@ func TestApplyTemplate_ClusterValuesTakePrecedenceOverTemplate(t *testing.T) {
 	}
 	if cluster.Spec.AerospikeNetworkPolicy.AccessType != ackov1alpha1.AerospikeNetworkTypeHostInternal {
 		t.Errorf("expected cluster network policy to be preserved")
+	}
+}
+
+// --- post-merge CE re-validation tests (P0-3) ---
+
+// TestValidateMergedSpecCE_RejectsEnterpriseImage covers the defence-in-depth
+// re-validation that runs after ApplyTemplate. Even if a CE constraint were
+// bypassed at admission time (failurePolicy=Ignore, future code path that
+// produces an enterprise tag, ...), the resolver must refuse to materialise
+// an Enterprise image into the cluster spec.
+func TestValidateMergedSpecCE_RejectsEnterpriseImage(t *testing.T) {
+	spec := &ackov1alpha1.AerospikeClusterSpec{
+		Size:  3,
+		Image: "aerospike/aerospike-server-enterprise:8.1",
+	}
+	errs := validateMergedSpecCE(spec)
+	if len(errs) == 0 {
+		t.Fatal("expected error for enterprise image in merged spec")
+	}
+}
+
+// TestValidateMergedSpecCE_RejectsOversizedCluster pins the post-merge size
+// check (defence in depth — also enforced at admission).
+func TestValidateMergedSpecCE_RejectsOversizedCluster(t *testing.T) {
+	spec := &ackov1alpha1.AerospikeClusterSpec{
+		Size:  99,
+		Image: testImageCE8,
+	}
+	errs := validateMergedSpecCE(spec)
+	if len(errs) == 0 {
+		t.Fatal("expected error for size=99 in merged spec")
+	}
+}
+
+// TestValidateMergedSpecCE_RejectsXdrInConfig pins that an xdr stanza in the
+// merged aerospikeConfig is rejected by the post-merge validator.
+func TestValidateMergedSpecCE_RejectsXdrInConfig(t *testing.T) {
+	spec := &ackov1alpha1.AerospikeClusterSpec{
+		Size:  3,
+		Image: testImageCE8,
+		AerospikeConfig: &ackov1alpha1.AerospikeConfigSpec{
+			Value: map[string]any{
+				"xdr": map[string]any{},
+			},
+		},
+	}
+	errs := validateMergedSpecCE(spec)
+	if len(errs) == 0 {
+		t.Fatal("expected error for xdr in merged config")
+	}
+}
+
+// TestValidateMergedSpecCE_RejectsEnterpriseNamespaceKey covers the per-namespace
+// enterprise-only key check on the merged namespaces list. Without this, a
+// strong-consistency value reaching merged config (via overrides ->
+// namespaceDefaults -> applyNamespaceDefaults) would slip past per-namespace
+// checks.
+func TestValidateMergedSpecCE_RejectsEnterpriseNamespaceKey(t *testing.T) {
+	spec := &ackov1alpha1.AerospikeClusterSpec{
+		Size:  3,
+		Image: testImageCE8,
+		AerospikeConfig: &ackov1alpha1.AerospikeConfigSpec{
+			Value: map[string]any{
+				"namespaces": []any{
+					map[string]any{
+						"name":               "test",
+						"strong-consistency": true,
+					},
+				},
+			},
+		},
+	}
+	errs := validateMergedSpecCE(spec)
+	if len(errs) == 0 {
+		t.Fatal("expected error for strong-consistency in merged namespace")
+	}
+}
+
+// TestValidateMergedSpecCE_AcceptsValidCESpec ensures the post-merge check
+// does not over-reject a normal CE configuration.
+func TestValidateMergedSpecCE_AcceptsValidCESpec(t *testing.T) {
+	spec := &ackov1alpha1.AerospikeClusterSpec{
+		Size:  3,
+		Image: testImageCE8,
+		AerospikeConfig: &ackov1alpha1.AerospikeConfigSpec{
+			Value: map[string]any{
+				"namespaces": []any{
+					map[string]any{
+						"name":               "test",
+						"replication-factor": 1,
+					},
+				},
+			},
+		},
+	}
+	if errs := validateMergedSpecCE(spec); len(errs) > 0 {
+		t.Errorf("unexpected errors for valid CE spec: %v", errs)
+	}
+}
+
+// --- applyAerospikeConfig non-map service guard (P1-3) ---
+
+// TestApplyAerospikeConfig_RefusesNonMapService pins the defensive type
+// check: if cluster.Spec.AerospikeConfig.service is somehow not a map (a
+// future bypass of the cluster webhook), applyAerospikeConfig must error
+// rather than silently overwrite the user's value with template defaults.
+func TestApplyAerospikeConfig_RefusesNonMapService(t *testing.T) {
+	cluster := &ackov1alpha1.AerospikeCluster{}
+	cluster.Spec.AerospikeConfig = &ackov1alpha1.AerospikeConfigSpec{
+		Value: map[string]any{
+			"service": "this-should-be-a-map",
+		},
+	}
+	tmplConfig := &ackov1alpha1.TemplateAerospikeConfig{
+		Service: &ackov1alpha1.AerospikeConfigSpec{
+			Value: map[string]any{"proto-fd-max": 25000},
+		},
+	}
+
+	err := applyAerospikeConfig(tmplConfig, cluster)
+	if err == nil {
+		t.Fatal("expected error for non-map service value")
+	}
+
+	// Make sure we did NOT overwrite the user's payload with the template merge.
+	if got, ok := cluster.Spec.AerospikeConfig.Value["service"].(string); !ok || got != "this-should-be-a-map" {
+		t.Errorf("expected original service value preserved, got %v", cluster.Spec.AerospikeConfig.Value["service"])
 	}
 }


### PR DESCRIPTION
## Summary

Closes six CE-constraint bypasses in the AerospikeCluster / AerospikeClusterTemplate validating webhooks and the template resolver. All defence-in-depth — the wire-time webhook is the primary check and the post-merge resolver re-validation is the fallback.

### P0 — silent CE bypasses

- **spec.overrides contents were never validated** (cluster webhook). Only the presence of `templateRef` was checked. A user could set `spec.overrides.image` to an Enterprise tag, or push `xdr` / `tls` / enterprise-only security keys via `spec.overrides.aerospikeConfig.{service,namespaceDefaults}` and silently bypass every CE check on the cluster-spec path. Now mirrors the same image / size / banned-key checks the template webhook applies.
- **`ValidateTemplateSpec` was dead code**. `internal/template/validation.go` implemented V-T06 (reject EE image), V-T07 (size 1–8) and V-T08 (monitoring port range), but the template webhook never called it. A template with `image: aerospike-server-enterprise:8.1`, `size: 99`, or `monitoring.port: 70000` would propagate to every cluster that referenced it. Inlined the three checks into the template webhook (import cycle prevented direct call: `internal/template -> api/v1alpha1`).
- **No CE re-validation after the template + overrides merge**. `resolver.Resolve` only checked `Image != ""` / `Size != 0` after `ApplyTemplate`. Now re-runs the core CE constraints (image edition, size 1–8, no `xdr`/`tls`/EE-security in merged config, no enterprise-only namespace keys per merged namespace) on the materialised cluster spec. Catches any future bypass before any pod is created.

### P1 — supporting hardening

- **`namespaces` as a map skipped per-namespace validation**. The cluster webhook only counted entries in the `map[string]any` branch — enterprise-only namespace keys (`compression`, `strong-consistency`, …) and `replication-factor` bounds were never checked. Now rejected outright: `namespaces` must be a list of namespace maps, which is also the form `configgen` expects.
- **`templateRef` was mutable on update**. Swapping it would silently re-base every templated default with no progressive rollout. Now immutable on add / remove / swap. (If a future use case needs it, add an explicit annotation gate.)
- **`applyAerospikeConfig` silently overwrote a non-map service**. The cluster webhook normally rejects non-map service, so this was unreachable but fragile. `applyAerospikeConfig` now returns an error rather than silently coercing — `ApplyTemplate` gained an error return, threaded through `resolver.Resolve` and `internal/controller/reconciler.go`.

## Modified approach (vs the original plan)

- **P0-2**: the spec suggested calling `template.ValidateTemplateSpec` from the template webhook. That would create an import cycle (`internal/template -> api/v1alpha1`), so the three checks (V-T06 / V-T07 / V-T08) are inlined into `aerospikeclustertemplate_webhook.go` instead, using the existing `isEnterpriseTag` helper. `ValidateTemplateSpec` itself is left intact and continues to back its own tests.
- **P0-3**: similar import-cycle constraint — `internal/template/resolver.go` cannot reach the cluster webhook helpers. The post-merge re-validator carries small package-local copies of `enterpriseOnlySecurityKeys`, `enterpriseOnlyNamespaceKeys`, `maxCEClusterSize`, and `isEnterpriseTag`. Both copies are now exercised by tests.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l ./api/v1alpha1 ./internal/template ./internal/controller` (no output)
- [x] `go test ./api/v1alpha1/... ./internal/template/... ./internal/controller/... -count=1` (all green)
- [x] 22 new unit tests (15 in `webhook_test.go` + 3 in `aerospikeclustertemplate_webhook_test.go` + 6 in `resolver_test.go`):
  - `TestValidate_Overrides{EnterpriseImage,XdrInService,EnterpriseSecurityInNamespaceDefaults,SizeOutOfRange}Rejected` + `TestValidate_OverridesValidPasses`
  - `TestValidateUpdate_TemplateRef{Swap,Add,Remove}Rejected` + `TestValidateUpdate_TemplateRefUnchangedAllowed`
  - `TestValidate_NamespacesAsMapRejected`
  - `TestAerospikeClusterTemplateValidate_{EnterpriseImage,SizeOutOfRange,MonitoringPortOutOfRange}Rejected`
  - `TestValidateMergedSpecCE_{RejectsEnterpriseImage,RejectsOversizedCluster,RejectsXdrInConfig,RejectsEnterpriseNamespaceKey,AcceptsValidCESpec}`
  - `TestApplyAerospikeConfig_RefusesNonMapService`
- [ ] e2e: deploy a cluster with `spec.overrides.image: aerospike/aerospike-server-enterprise:8.1` and confirm rejection
- [ ] e2e: kubectl-apply a templated cluster and then change `spec.templateRef.name`; confirm the update is rejected