### PR TITLE
fix(webhook): close 3 validation bypass paths in aerospikeConfig

### DIFF
--- a/api/v1alpha1/aerospikecluster_webhook.go
+++ b/api/v1alpha1/aerospikecluster_webhook.go
@@ -1423,8 +1423,8 @@ func (v *AerospikeClusterValidator) validateMonitoring(m *AerospikeMonitoringSpe
 }
 
 // validateNetworkPortUniqueness checks that service, heartbeat, and fabric
-// ports are distinct and do not collide with another Aerospike subsection's
-// reserved port (e.g. service.port=3003 vs the info port).
+// ports are valid TCP integers, distinct, and do not collide with another
+// Aerospike subsection's reserved port (e.g. service.port=3003 vs info).
 func (v *AerospikeClusterValidator) validateNetworkPortUniqueness(cluster *AerospikeCluster) []string {
 	netCfg, ok := cluster.Spec.AerospikeConfig.Value["network"].(map[string]any)
 	if !ok {
@@ -1436,20 +1436,27 @@ func (v *AerospikeClusterValidator) validateNetworkPortUniqueness(cluster *Aeros
 		port int
 	}
 
-	extractPort := func(section map[string]any) (int, bool) {
-		raw, exists := section["port"]
-		if !exists {
+	var errors []string
+
+	extractPort := func(sub string, raw any) (int, bool) {
+		switch x := raw.(type) {
+		case int:
+			return x, true
+		case float64:
+			return int(x), true
+		case int64:
+			return int(x), true
+		case string:
+			// String-typed ports were previously silently dropped; surface
+			// them so YAML shape mistakes (port: "3000") fail at admission.
+			errors = append(errors, fmt.Sprintf(
+				"aerospikeConfig.network.%s.port must be an integer, got string %q", sub, x))
+			return 0, false
+		default:
+			errors = append(errors, fmt.Sprintf(
+				"aerospikeConfig.network.%s.port must be an integer, got %T", sub, raw))
 			return 0, false
 		}
-		switch v := raw.(type) {
-		case int:
-			return v, true
-		case float64:
-			return int(v), true
-		case int64:
-			return int(v), true
-		}
-		return 0, false
 	}
 
 	var ports []portEntry
@@ -1458,12 +1465,24 @@ func (v *AerospikeClusterValidator) validateNetworkPortUniqueness(cluster *Aeros
 		if !ok {
 			continue
 		}
-		if port, ok := extractPort(subCfg); ok {
-			ports = append(ports, portEntry{name: sub, port: port})
+		raw, exists := subCfg["port"]
+		if !exists {
+			continue
 		}
+		port, ok := extractPort(sub, raw)
+		if !ok {
+			continue
+		}
+		// TCP port range check; out-of-range values are rejected and skipped
+		// so they do not poison the uniqueness / reserved-port checks below.
+		if port < 1 || port > 65535 {
+			errors = append(errors, fmt.Sprintf(
+				"aerospikeConfig.network.%s.port=%d must be in range 1-65535", sub, port))
+			continue
+		}
+		ports = append(ports, portEntry{name: sub, port: port})
 	}
 
-	var errors []string
 	// Cross-check user-configured ports against the reserved Aerospike port
 	// table; reject when a subsection's port collides with the reserved port
 	// of a *different* subsection (e.g. service.port=3003 → info port).

--- a/api/v1alpha1/aerospikecluster_webhook.go
+++ b/api/v1alpha1/aerospikecluster_webhook.go
@@ -1422,7 +1422,9 @@ func (v *AerospikeClusterValidator) validateMonitoring(m *AerospikeMonitoringSpe
 	return errors, warnings
 }
 
-// validateNetworkPortUniqueness checks that service, heartbeat, and fabric ports are distinct.
+// validateNetworkPortUniqueness checks that service, heartbeat, and fabric
+// ports are distinct and do not collide with another Aerospike subsection's
+// reserved port (e.g. service.port=3003 vs the info port).
 func (v *AerospikeClusterValidator) validateNetworkPortUniqueness(cluster *AerospikeCluster) []string {
 	netCfg, ok := cluster.Spec.AerospikeConfig.Value["network"].(map[string]any)
 	if !ok {
@@ -1462,6 +1464,18 @@ func (v *AerospikeClusterValidator) validateNetworkPortUniqueness(cluster *Aeros
 	}
 
 	var errors []string
+	// Cross-check user-configured ports against the reserved Aerospike port
+	// table; reject when a subsection's port collides with the reserved port
+	// of a *different* subsection (e.g. service.port=3003 → info port).
+	for _, p := range ports {
+		for reservedPort, reservedFor := range aerospikeReservedPorts {
+			if int(reservedPort) == p.port && reservedFor != p.name {
+				errors = append(errors, fmt.Sprintf(
+					"aerospikeConfig.network.%s.port=%d conflicts with reserved port %d (used for %s)",
+					p.name, p.port, reservedPort, reservedFor))
+			}
+		}
+	}
 	for i := 0; i < len(ports); i++ {
 		for j := i + 1; j < len(ports); j++ {
 			if ports[i].port == ports[j].port {

--- a/api/v1alpha1/aerospikecluster_webhook.go
+++ b/api/v1alpha1/aerospikecluster_webhook.go
@@ -682,7 +682,10 @@ func (v *AerospikeClusterValidator) validateAerospikeConfig(config map[string]an
 	// aerospikeAccessControl is configured; the security section is intentionally
 	// skipped during config generation (configgen).
 	if secSection, exists := config["security"]; exists {
-		if secMap, ok := secSection.(map[string]any); ok {
+		secMap, ok := secSection.(map[string]any)
+		if !ok {
+			errors = append(errors, fmt.Sprintf("aerospikeConfig.security must be a map, got %T", secSection))
+		} else {
 			for enterpriseKey, reason := range enterpriseOnlySecurityKeys {
 				if _, found := secMap[enterpriseKey]; found {
 					errors = append(errors, fmt.Sprintf(

--- a/api/v1alpha1/aerospikeclustertemplate_webhook.go
+++ b/api/v1alpha1/aerospikeclustertemplate_webhook.go
@@ -231,7 +231,11 @@ func validateTemplateConfigBannedKeys(fieldPath string, cfg map[string]any, isNa
 			"%s must not contain 'tls' section (TLS is Enterprise-only)", fieldPath))
 	}
 	if secSection, exists := cfg["security"]; exists {
-		if secMap, ok := secSection.(map[string]any); ok {
+		secMap, ok := secSection.(map[string]any)
+		if !ok {
+			errs = append(errs, fmt.Sprintf(
+				"%s.security must be a map, got %T", fieldPath, secSection))
+		} else {
 			for enterpriseKey, reason := range enterpriseOnlySecurityKeys {
 				if _, found := secMap[enterpriseKey]; found {
 					errs = append(errs, fmt.Sprintf(

--- a/api/v1alpha1/webhook_test.go
+++ b/api/v1alpha1/webhook_test.go
@@ -4297,6 +4297,35 @@ func TestValidate_NetworkPortUniqueness_DistinctPorts(t *testing.T) {
 	}
 }
 
+func TestValidate_NetworkPortConflict_ServiceUsesInfoPort(t *testing.T) {
+	// service.port=3003 collides with the reserved Aerospike info port,
+	// even though no two of {service, heartbeat, fabric} share the same value.
+	v := &AerospikeClusterValidator{}
+	cluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:  3,
+			Image: "aerospike:ce-8.1.1.1",
+			AerospikeConfig: &AerospikeConfigSpec{
+				Value: map[string]any{
+					"network": map[string]any{
+						"service":   map[string]any{"port": 3003},
+						"heartbeat": map[string]any{"port": 3002, "mode": "mesh"},
+						"fabric":    map[string]any{"port": 3001},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := v.validate(cluster)
+	if err == nil {
+		t.Fatal("expected error for service.port=3003 vs reserved info port, got nil")
+	}
+	if !strings.Contains(err.Error(), "conflicts with reserved port 3003") {
+		t.Errorf("expected reserved-port error mentioning 3003, got: %v", err)
+	}
+}
+
 func TestValidate_NetworkPortUniqueness_NoNetworkSection(t *testing.T) {
 	v := &AerospikeClusterValidator{}
 	cluster := &AerospikeCluster{

--- a/api/v1alpha1/webhook_test.go
+++ b/api/v1alpha1/webhook_test.go
@@ -4326,6 +4326,63 @@ func TestValidate_NetworkPortConflict_ServiceUsesInfoPort(t *testing.T) {
 	}
 }
 
+func TestValidate_NetworkPort_OutOfRange(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+	cluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:  3,
+			Image: "aerospike:ce-8.1.1.1",
+			AerospikeConfig: &AerospikeConfigSpec{
+				Value: map[string]any{
+					"network": map[string]any{
+						"service":   map[string]any{"port": 0},
+						"heartbeat": map[string]any{"port": 99999, "mode": "mesh"},
+						"fabric":    map[string]any{"port": 3001},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := v.validate(cluster)
+	if err == nil {
+		t.Fatal("expected error for out-of-range ports, got nil")
+	}
+	if !strings.Contains(err.Error(), "service.port=0 must be in range") {
+		t.Errorf("expected range error for service.port=0, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "heartbeat.port=99999 must be in range") {
+		t.Errorf("expected range error for heartbeat.port=99999, got: %v", err)
+	}
+}
+
+func TestValidate_NetworkPort_StringTypeRejected(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+	cluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:  3,
+			Image: "aerospike:ce-8.1.1.1",
+			AerospikeConfig: &AerospikeConfigSpec{
+				Value: map[string]any{
+					"network": map[string]any{
+						"service":   map[string]any{"port": "3000"},
+						"heartbeat": map[string]any{"port": 3002, "mode": "mesh"},
+						"fabric":    map[string]any{"port": 3001},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := v.validate(cluster)
+	if err == nil {
+		t.Fatal("expected error for string-typed port, got nil")
+	}
+	if !strings.Contains(err.Error(), `service.port must be an integer, got string "3000"`) {
+		t.Errorf("expected explicit string-type error, got: %v", err)
+	}
+}
+
 func TestValidate_NetworkPortUniqueness_NoNetworkSection(t *testing.T) {
 	v := &AerospikeClusterValidator{}
 	cluster := &AerospikeCluster{


### PR DESCRIPTION
## Summary
Three P1 webhook validation gaps in `api/v1alpha1` that allowed malformed or
unsafe `aerospikeConfig` to pass admission silently.

- **security non-map silent skip**: When `aerospikeConfig.security` was supplied as a list/scalar (YAML shape error), the type assertion to `map[string]any` silently skipped the Enterprise-key check, letting `tls`/`ldap`/`log`/`syslog` slip past if the section was structurally malformed. Now mirrors the explicit type-error pattern already used for `service`/`network`/`logging`. Same fix applied to `validateTemplateConfigBannedKeys`.
- **reserved-port cross-check missing**: `validateNetworkPortUniqueness` only compared `service`/`heartbeat`/`fabric` against each other. A user could set `service.port=3003` (the info port) without the webhook flagging it. Now every user-configured port is cross-checked against `aerospikeReservedPorts` and rejected when it matches the reserved port of a *different* subsection (`service.port=3000` is still fine).
- **port range + string-typed port silent drop**: `port=0` and `port=99999` were accepted; `port: "3000"` (YAML quoting mistake) was silently dropped by the type-switch default. Both now surface explicit admission errors.

## Test plan
- [x] `make build` (controller-gen + go fmt + go vet + manager binary)
- [x] `go test ./api/v1alpha1/... -count=1`
- [x] New unit tests:
  - `TestValidate_NetworkPortConflict_ServiceUsesInfoPort` (3003 reserved cross-check)
  - `TestValidate_NetworkPort_OutOfRange` (port=0 / port=99999)
  - `TestValidate_NetworkPort_StringTypeRejected` (port: "3000")
- [ ] e2e smoke once merged: deploy a cluster with valid ports to confirm no regression on the happy path