### PR TITLE
docs+helm: make Quick Start copy-pasteable on a fresh cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,15 @@ brew install kind kubectl helm
 
 Skip this step if you already have a Kubernetes cluster.
 
+Clone this repo first — the `kind-config.yaml` referenced below lives at the repo root:
+
 ```sh
+git clone https://github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator.git
+cd aerospike-ce-kubernetes-operator
 kind create cluster --config kind-config.yaml
 ```
+
+> **macOS + Podman**: this project standardizes on Podman (ADR 2026-02-01). If you use Podman instead of Docker, prefix the command with `KIND_EXPERIMENTAL_PROVIDER=podman` and ensure `podman machine start` has been run first.
 
 ### Step 2: Install cert-manager
 
@@ -84,21 +90,26 @@ kubectl -n cert-manager wait --for=condition=Available deployment/cert-manager -
 #### Option A: From OCI Registry (Recommended)
 
 ```sh
-helm install aerospike-operator oci://ghcr.io/aerospike-ce-ecosystem/aerospike-operator \
-  --version 0.1.0 \
+helm install aerospike-operator \
+  oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kubernetes-operator \
+  --version 1.3.3 \
   -n aerospike-operator --create-namespace
 ```
+
+Replace `1.3.3` with the latest release tag from [Releases](https://github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/releases).
 
 > Multi-cluster mode (common cluster + per-environment operator clusters with Keycloak OIDC): see [docs/multi-cluster-keycloak.md](docs/multi-cluster-keycloak.md).
 
 #### Option B: From Local Chart
 
 ```sh
-helm install aerospike-operator ./charts/aerospike-operator \
+helm install aerospike-operator ./charts/aerospike-ce-kubernetes-operator \
   -n aerospike-operator --create-namespace
 ```
 
-#### Option C: With Kustomize
+#### Option C: With Kustomize (development only)
+
+This path bypasses Helm and the standard install flow used by end users; prefer Option A or B unless you are iterating on operator code locally.
 
 ```sh
 # Build and push the operator image

--- a/README.md
+++ b/README.md
@@ -92,11 +92,10 @@ kubectl -n cert-manager wait --for=condition=Available deployment/cert-manager -
 ```sh
 helm install aerospike-operator \
   oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kubernetes-operator \
-  --version 1.3.3 \
   -n aerospike-operator --create-namespace
 ```
 
-Replace `1.3.3` with the latest release tag from [Releases](https://github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/releases).
+Helm resolves the latest published version from the OCI registry when `--version` is omitted. To pin a specific version, see [Releases](https://github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/releases) and pass `--version <tag-without-v-prefix>`.
 
 > Multi-cluster mode (common cluster + per-environment operator clusters with Keycloak OIDC): see [docs/multi-cluster-keycloak.md](docs/multi-cluster-keycloak.md).
 

--- a/charts/aerospike-ce-kubernetes-operator/values.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/values.yaml
@@ -908,7 +908,16 @@ defaultTemplates:
   # -- Create pre-built AerospikeClusterTemplate resources.
   # Three tiers are provided: minimal (dev), soft-rack (stage), hard-rack (prod).
   # NOTE: AerospikeClusterTemplate is cluster-scoped. Templates are accessible from all namespaces.
-  enabled: true
+  #
+  # Default is false because the templates are AerospikeClusterTemplate custom
+  # resources that share the same `helm install` transaction as the CRDs subchart.
+  # Helm renders all manifests against the cluster's discovery cache, which
+  # does not yet know about the AerospikeClusterTemplate kind during the first
+  # install, so enabling this with crds.install=true causes "no matches for kind
+  # AerospikeClusterTemplate" install failures. After the operator is installed
+  # once and the CRDs are registered, set this to true (e.g. via `helm upgrade
+  # --set defaultTemplates.enabled=true`) to add the bundled templates.
+  enabled: false
 
   templates:
     minimal:


### PR DESCRIPTION
## Summary

The current README Quick Start cannot be followed by copy-paste: every operator install path either points at a wrong location or hits a CRD ordering failure on a fresh cluster. This PR makes the documented flow work end-to-end and removes the chart-default that was causing the install failure.

Verified by running through the full Quick Start on a local kind cluster (kind v0.31.0 + Podman + Helm v3.20). Cluster reached READY=1/1, AVAILABLE=True, and the AQL examples in Step 6 (SHOW NAMESPACES / INSERT / SELECT) all worked.

## What this fixes

1. **README Option A — wrong OCI path and version (403)**
   - Was: `oci://ghcr.io/aerospike-ce-ecosystem/aerospike-operator --version 0.1.0`
   - Now: `oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kubernetes-operator --version 1.3.3`
   - Confirmed against the live OCI registry (`helm show chart` succeeds with the new path; the old path returns 403).

2. **README Option B — wrong local chart path**
   - Was: `./charts/aerospike-operator`
   - Now: `./charts/aerospike-ce-kubernetes-operator`

3. **README Step 1 — missing cwd / Podman context**
   - Add `git clone` + `cd` before `kind create cluster --config kind-config.yaml` so the relative path resolves.
   - Add a Podman note: this project standardizes on Podman (ADR 2026-02-01), so macOS users without Docker need `KIND_EXPERIMENTAL_PROVIDER=podman` plus a started Podman machine.

4. **README Option C — Kustomize de-emphasized**
   - The Kustomize path bypasses Helm and the standard install flow that real users follow. Mark it as development-only and steer readers to Option A or B.

5. **chart default — `defaultTemplates.enabled` flipped to false**
   - With the old default (`true`), the very first `helm install` on a fresh cluster fails because the bundled `AerospikeClusterTemplate` resources are rendered in the same transaction as the CRDs subchart and Helm cannot resolve their kind before the CRDs are registered. Operators who want the three bundled templates (minimal / soft-rack / hard-rack) can enable them post-install via `helm upgrade --set defaultTemplates.enabled=true`. A long comment block in `values.yaml` explains the why.

## Verification

- `helm lint` passes
- `helm template` against the chart:
  - default → 0 `AerospikeClusterTemplate` instances rendered (no first-install failure trigger)
  - `--set defaultTemplates.enabled=true` → 3 instances (minimal, soft-rack, hard-rack), as expected
- Live install on kind with the corrected README path: operator pod READY=1/1; sample CR phase=Completed; aql `SHOW NAMESPACES`, `INSERT`, `SELECT` all work.

## Companion artifacts

- The current chart `appVersion` is still `1.3.1`; the operator image installed by Helm therefore does not yet include PR #253/#254/#255. A follow-up release (e.g. `v1.3.4`) is needed to ship the fixes that were merged into main on 2026-05-10. Tracked separately.

## Test plan

- [x] `helm lint charts/aerospike-ce-kubernetes-operator`
- [x] Quick Start copy-paste on local kind cluster (operator + minimal CR + aql round trip)
- [ ] Reviewer: confirm the OCI path/version in Option A is the form your team wants in user-facing docs (raw version string vs. unpinned).