### PR TITLE
docs(readme): drop Podman note from Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,6 @@ cd aerospike-ce-kubernetes-operator
 kind create cluster --config kind-config.yaml
 ```
 
-> **macOS + Podman**: this project standardizes on Podman (ADR 2026-02-01). If you use Podman instead of Docker, prefix the command with `KIND_EXPERIMENTAL_PROVIDER=podman` and ensure `podman machine start` has been run first.
-
 ### Step 2: Install cert-manager
 
 cert-manager is required for webhook TLS certificate management.


### PR DESCRIPTION
Most readers are on Docker. The Podman pointer added in #258 added noise for the common path; users on Podman already know to set `KIND_EXPERIMENTAL_PROVIDER=podman`. Reverts that one paragraph only — chart paths, OCI URL, defaultTemplates default, and Kustomize de-emphasis from #258 are unaffected.