### PR TITLE
docs(samples): set nsup-period: 60 so TTL writes work out of the box

### DIFF
--- a/config/samples/acko_v1alpha1_aerospikecluster.yaml
+++ b/config/samples/acko_v1alpha1_aerospikecluster.yaml
@@ -33,6 +33,8 @@ spec:
     namespaces:
       - name: test
         replication-factor: 1  # Single node, so replication-factor must be 1
+        nsup-period: 60  # Enable nsup so records with non-zero TTL can be written
+                         # (Aerospike 8.x rejects TTL writes when nsup-period=0)
         storage-engine:
           type: memory  # Pure in-memory storage (data lost on pod restart)
           data-size: 1073741824  # 1 GiB of memory allocated for this namespace

--- a/config/samples/acko_v1alpha1_template_dev.yaml
+++ b/config/samples/acko_v1alpha1_template_dev.yaml
@@ -39,4 +39,6 @@ spec:
       proto-fd-max: 1024
     namespaceDefaults:
       replication-factor: 1
+      nsup-period: 60   # Enable nsup so records with non-zero TTL can be written
+                        # (Aerospike 8.x rejects TTL writes when nsup-period=0)
       # data-size: optional; CE 8.x auto-sizes in-memory namespaces when omitted

--- a/config/samples/acko_v1alpha1_template_prod.yaml
+++ b/config/samples/acko_v1alpha1_template_prod.yaml
@@ -64,6 +64,8 @@ spec:
     namespaceDefaults:
       data-size: 2147483648   # 2GiB default per namespace
       replication-factor: 2
+      nsup-period: 60         # Enable nsup so records with non-zero TTL can be written
+                              # (Aerospike 8.x rejects TTL writes when nsup-period=0)
     network:
       heartbeat:
         mode: mesh

--- a/config/samples/acko_v1alpha1_template_stage.yaml
+++ b/config/samples/acko_v1alpha1_template_stage.yaml
@@ -38,6 +38,8 @@ spec:
       proto-fd-max: 4096
     namespaceDefaults:
       replication-factor: 2
+      nsup-period: 60   # Enable nsup so records with non-zero TTL can be written
+                        # (Aerospike 8.x rejects TTL writes when nsup-period=0)
       # data-size: optional; CE 8.x auto-sizes in-memory namespaces when omitted
     network:
       heartbeat:

--- a/config/samples/aerospike-cluster-3node.yaml
+++ b/config/samples/aerospike-cluster-3node.yaml
@@ -62,6 +62,8 @@ spec:
     namespaces:
       - name: testns
         replication-factor: 2  # Each record stored on 2 of the 3 nodes (high availability)
+        nsup-period: 60  # Enable nsup so records with non-zero TTL can be written
+                         # (Aerospike 8.x rejects TTL writes when nsup-period=0)
         storage-engine:
           type: device  # File-backed (device) storage engine
           file: /opt/aerospike/data/testns.dat  # Data file on the persistent volume

--- a/config/samples/aerospike-cluster-acl.yaml
+++ b/config/samples/aerospike-cluster-acl.yaml
@@ -73,6 +73,8 @@ spec:
     namespaces:
       - name: testns
         replication-factor: 2  # Each record on 2 of the 3 nodes
+        nsup-period: 60  # Enable nsup so records with non-zero TTL can be written
+                         # (Aerospike 8.x rejects TTL writes when nsup-period=0)
         storage-engine:
           type: device
           file: /opt/aerospike/data/testns.dat

--- a/config/samples/aerospike-cluster-external-access.yaml
+++ b/config/samples/aerospike-cluster-external-access.yaml
@@ -31,6 +31,8 @@ spec:
     namespaces:
       - name: test
         replication-factor: 2
+        nsup-period: 60  # Enable nsup so records with non-zero TTL can be written
+                         # (Aerospike 8.x rejects TTL writes when nsup-period=0)
         storage-engine:
           type: memory
           data-size: 1073741824

--- a/config/samples/aerospike-cluster-monitoring.yaml
+++ b/config/samples/aerospike-cluster-monitoring.yaml
@@ -80,6 +80,8 @@ spec:
     namespaces:
       - name: testns
         replication-factor: 2
+        nsup-period: 60  # Enable nsup so records with non-zero TTL can be written
+                         # (Aerospike 8.x rejects TTL writes when nsup-period=0)
         storage-engine:
           type: memory
           data-size: 2147483648  # 2 GiB

--- a/config/samples/aerospike-cluster-multirack.yaml
+++ b/config/samples/aerospike-cluster-multirack.yaml
@@ -69,6 +69,8 @@ spec:
     namespaces:
       - name: testns
         replication-factor: 2  # Each record on 2 nodes, ideally in different racks/zones
+        nsup-period: 60  # Enable nsup so records with non-zero TTL can be written
+                         # (Aerospike 8.x rejects TTL writes when nsup-period=0)
         storage-engine:
           type: device
           file: /opt/aerospike/data/testns.dat

--- a/config/samples/aerospike-cluster-storage-advanced.yaml
+++ b/config/samples/aerospike-cluster-storage-advanced.yaml
@@ -117,6 +117,8 @@ spec:
       - name: test
         indexes-memory-budget: 1073741824
         replication-factor: 2
+        nsup-period: 60  # Enable nsup so records with non-zero TTL can be written
+                         # (Aerospike 8.x rejects TTL writes when nsup-period=0)
         storage-engine:
           type: device
           devices:


### PR DESCRIPTION
## Summary

- Add `nsup-period: 60` to every sample namespace block and template `namespaceDefaults` (10 files).
- Without it, Aerospike 8.x rejects any write with a non-zero TTL on these samples, surfacing as HTTP 403 from cluster-manager.

## Why

`config/samples/*.yaml` are the first thing a new user applies. Today every one of them leaves `nsup-period` at the default `0`. Combined with `allow-ttl-without-nsup=false` (also default), that means:

```
$ ackoctl record put $CONN --namespace=test --set=users --pk=alice \
    --bins='{"name":"Alice"}' --ttl=3600
Error: cluster-manager 403: Operation forbidden by server.
       If setting TTL, ensure the namespace has 'nsup-period' configured.
```

This is the Aerospike server's silent-leak safeguard — TTLs without nsup mean expired records would never get cleaned up — but it makes the samples feel broken for any TTL-bearing workload. We hit this during ackoctl end-to-end testing on a kind cluster.

`nsup-period: 60` is the recommended dev/prod default (60 s sweep) and matches the Aerospike documentation.

## Scope

Direct samples patched (7):
- `acko_v1alpha1_aerospikecluster.yaml` (minimal CR)
- `aerospike-cluster-3node.yaml`
- `aerospike-cluster-acl.yaml`
- `aerospike-cluster-external-access.yaml`
- `aerospike-cluster-monitoring.yaml`
- `aerospike-cluster-multirack.yaml`
- `aerospike-cluster-storage-advanced.yaml`

Templates patched (3) — adding to `namespaceDefaults` so every cluster built from these inherits the fix:
- `acko_v1alpha1_template_prod.yaml`
- `acko_v1alpha1_template_stage.yaml`
- `acko_v1alpha1_template_dev.yaml`

`aerospike-cluster-with-template.yaml` is unchanged — all of its clusters inherit from one of the three templates above.

## Verification

- `kubectl apply --dry-run=client -f <each file>` → all 10 files OK.
- `kubectl apply --dry-run=server -f acko_v1alpha1_aerospikecluster.yaml` → webhook accepts `nsup-period` parameter.
- Live retry: after `asinfo set-config:context=namespace;id=test;nsup-period=60` on the running aerospike-basic pod, `ackoctl record put --ttl=3600` succeeded with `meta.ttl=3599`, confirming this is the only change needed.

## Test plan

- [ ] CI lint / fmt
- [ ] `make test` (envtest)
- [ ] Reviewer applies any sample to a fresh kind cluster and confirms `record put --ttl=N` works
