### PR TITLE
fix(helm): pin Cluster Manager UI image tag to a published release

### DIFF
--- a/charts/aerospike-ce-kubernetes-operator/templates/_helpers.tpl
+++ b/charts/aerospike-ce-kubernetes-operator/templates/_helpers.tpl
@@ -220,15 +220,26 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 
 {{/*
 UI image helpers (per-component).
-Tag defaults to .Chart.AppVersion when ui.api.image.tag / ui.web.image.tag is
-empty, so users get a concrete pinned tag out of the box rather than ":latest".
+Tag resolution order:
+  1. ui.api.image.tag / ui.web.image.tag (per-component override)
+  2. ui.imageTag (shared cluster-manager release, pinned in values.yaml)
+  3. .Chart.AppVersion (last resort)
+aerospike-cluster-manager is versioned independently from the operator, so
+falling straight through to .Chart.AppVersion can resolve to a tag that
+does not exist in ghcr.io. ui.imageTag is the intended default knob.
 */}}
+{{- define "aerospike-ce-kubernetes-operator.ui.imageTag" -}}
+{{- default .Chart.AppVersion .Values.ui.imageTag | toString -}}
+{{- end }}
+
 {{- define "aerospike-ce-kubernetes-operator.ui.api.image" -}}
-{{- printf "%s:%s" .Values.ui.api.image.repository (default .Chart.AppVersion .Values.ui.api.image.tag | toString) -}}
+{{- $tag := default (include "aerospike-ce-kubernetes-operator.ui.imageTag" .) .Values.ui.api.image.tag -}}
+{{- printf "%s:%s" .Values.ui.api.image.repository ($tag | toString) -}}
 {{- end }}
 
 {{- define "aerospike-ce-kubernetes-operator.ui.web.image" -}}
-{{- printf "%s:%s" .Values.ui.web.image.repository (default .Chart.AppVersion .Values.ui.web.image.tag | toString) -}}
+{{- $tag := default (include "aerospike-ce-kubernetes-operator.ui.imageTag" .) .Values.ui.web.image.tag -}}
+{{- printf "%s:%s" .Values.ui.web.image.repository ($tag | toString) -}}
 {{- end }}
 
 {{/*

--- a/charts/aerospike-ce-kubernetes-operator/values.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/values.yaml
@@ -353,6 +353,15 @@ ui:
   # -- Image pull secrets for private registries (applied to all UI Deployments)
   imagePullSecrets: []
 
+  # -- Default tag for both UI components (api + web).
+  # aerospike-cluster-manager is versioned independently from the operator,
+  # so the chart pins a known-good cluster-manager release here rather than
+  # letting the UI image tag fall through to .Chart.AppVersion (which is
+  # the operator's version and may not exist as a cluster-manager tag).
+  # Override per-component via ui.api.image.tag / ui.web.image.tag, or
+  # set this to "" to fall through to .Chart.AppVersion.
+  imageTag: "0.24.0"
+
   # =============================================================================
   # API (FastAPI) — port 8000 internally, Service port 80
   # =============================================================================
@@ -364,7 +373,8 @@ ui:
     image:
       repository: ghcr.io/aerospike-ce-ecosystem/aerospike-cluster-manager-api
       # -- Container image tag. Leave empty to fall through to
-      # .Chart.AppVersion (see ui.api.image helper in _helpers.tpl).
+      # ui.imageTag (preferred) or .Chart.AppVersion. See the
+      # ui.api.image helper in _helpers.tpl.
       tag: ""
       pullPolicy: IfNotPresent
     service:
@@ -551,7 +561,8 @@ ui:
     image:
       repository: ghcr.io/aerospike-ce-ecosystem/aerospike-cluster-manager-web
       # -- Container image tag. Leave empty to fall through to
-      # .Chart.AppVersion (see ui.web.image helper in _helpers.tpl).
+      # ui.imageTag (preferred) or .Chart.AppVersion. See the
+      # ui.web.image helper in _helpers.tpl.
       tag: ""
       pullPolicy: IfNotPresent
     service:

--- a/docs/content/getting-started/install.md
+++ b/docs/content/getting-started/install.md
@@ -65,6 +65,18 @@ To see all available values:
 helm show values oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kubernetes-operator
 ```
 
+#### Pin a different Cluster Manager UI release
+
+The Cluster Manager UI (`ui-api` and `ui-web` Deployments) is versioned independently from the operator. The chart pins a known-good `aerospike-cluster-manager` release in `ui.imageTag`. To track a different release, override it globally:
+
+```bash
+helm install aerospike-ce-kubernetes-operator oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kubernetes-operator \
+  -n aerospike-operator --create-namespace \
+  --set ui.imageTag=0.24.0
+```
+
+Or override a single component via `ui.api.image.tag` / `ui.web.image.tag`. Available tags are listed at [aerospike-cluster-manager-api](https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager/pkgs/container/aerospike-cluster-manager-api) and [aerospike-cluster-manager-web](https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager/pkgs/container/aerospike-cluster-manager-web).
+
 </TabItem>
 <TabItem value="local-build" label="Local Build">
 


### PR DESCRIPTION
## Summary

- The chart's UI image fallback used `.Chart.AppVersion`, but `aerospike-cluster-manager` is versioned independently from the operator. The appVersion tag does **not** exist on ghcr.io, so the default `helm install oci://.../aerospike-ce-kubernetes-operator` left both `ui-api` and `ui-web` Pods in `ImagePullBackOff`.
- Introduce `ui.imageTag` as the shared default knob for both UI components, pinned to the latest published cluster-manager release (`0.24.0`).
- New resolution order:
  1. `ui.api.image.tag` / `ui.web.image.tag` (per-component override)
  2. `ui.imageTag` (shared cluster-manager release)
  3. `.Chart.AppVersion` (last resort)
- Documentation: `docs/content/getting-started/install.md` adds a "Pin a different Cluster Manager UI release" snippet.

## Repro (before this PR)

```
$ helm install aerospike-ce-kubernetes-operator \
    oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kubernetes-operator \
    -n aerospike-operator --create-namespace --wait
Error: INSTALLATION FAILED: context deadline exceeded
$ kubectl -n aerospike-operator describe pod -l app.kubernetes.io/component=ui-api
... Failed to pull image ".../aerospike-cluster-manager-api:1.3.6": not found
```

`1.3.6` is the chart's `appVersion`; the latest published cluster-manager tag is `0.24.0`.

## Verification

```
helm template test charts/aerospike-ce-kubernetes-operator/
  → cluster-manager-api:0.24.0
  → cluster-manager-web:0.24.0

helm template test ... --set ui.api.image.tag=custom-api --set ui.web.image.tag=custom-web
  → cluster-manager-api:custom-api
  → cluster-manager-web:custom-web

helm template test ... --set ui.imageTag=""
  → cluster-manager-api:1.3.1   (fallback to .Chart.AppVersion)

helm lint  → 1 chart(s) linted, 0 chart(s) failed
```

End-to-end re-install on `kind` reaches `Running 2/2` for `ui-api` and `Running 1/1` for `ui-web` out of the box; ackoctl QA against the cluster-manager API (`/api/v1/*`) passes without any value overrides.

## Test plan

- [x] `helm lint charts/aerospike-ce-kubernetes-operator/`
- [x] `helm template` for default, per-component override, and empty-fallback cases
- [x] Fresh `kind` install with no `--set` flags → both UI Pods `Running`
- [x] `ackoctl connection health <conn>` against the cluster-manager API returns `connected: true`