### PR TITLE
docs(ackoctl-cli): drop apt/yum install tabs

### DIFF
--- a/docs/content/getting-started/ackoctl-cli.md
+++ b/docs/content/getting-started/ackoctl-cli.md
@@ -24,27 +24,6 @@ brew install aerospike-ce-ecosystem/tap/ackoctl
 ```
 
 </TabItem>
-<TabItem value="apt" label="Debian / Ubuntu">
-
-```bash
-sudo install -d /etc/apt/keyrings
-curl -fsSL https://aerospike-ce-ecosystem.github.io/ackoctl/key.gpg \
-  | sudo gpg --dearmor -o /etc/apt/keyrings/ackoctl.gpg
-echo "deb [signed-by=/etc/apt/keyrings/ackoctl.gpg] https://aerospike-ce-ecosystem.github.io/ackoctl/apt stable main" \
-  | sudo tee /etc/apt/sources.list.d/ackoctl.list
-sudo apt update && sudo apt install ackoctl
-```
-
-</TabItem>
-<TabItem value="yum" label="RHEL / Fedora / Rocky / AlmaLinux">
-
-```bash
-sudo curl -fsSL https://aerospike-ce-ecosystem.github.io/ackoctl/yum/ackoctl.repo \
-  -o /etc/yum.repos.d/ackoctl.repo
-sudo dnf install ackoctl
-```
-
-</TabItem>
 <TabItem value="posix" label="Any POSIX shell">
 
 ```bash

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/getting-started/ackoctl-cli.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/getting-started/ackoctl-cli.md
@@ -24,27 +24,6 @@ brew install aerospike-ce-ecosystem/tap/ackoctl
 ```
 
 </TabItem>
-<TabItem value="apt" label="Debian / Ubuntu">
-
-```bash
-sudo install -d /etc/apt/keyrings
-curl -fsSL https://aerospike-ce-ecosystem.github.io/ackoctl/key.gpg \
-  | sudo gpg --dearmor -o /etc/apt/keyrings/ackoctl.gpg
-echo "deb [signed-by=/etc/apt/keyrings/ackoctl.gpg] https://aerospike-ce-ecosystem.github.io/ackoctl/apt stable main" \
-  | sudo tee /etc/apt/sources.list.d/ackoctl.list
-sudo apt update && sudo apt install ackoctl
-```
-
-</TabItem>
-<TabItem value="yum" label="RHEL / Fedora / Rocky / AlmaLinux">
-
-```bash
-sudo curl -fsSL https://aerospike-ce-ecosystem.github.io/ackoctl/yum/ackoctl.repo \
-  -o /etc/yum.repos.d/ackoctl.repo
-sudo dnf install ackoctl
-```
-
-</TabItem>
 <TabItem value="posix" label="POSIX 셸 일반 (패키지 매니저 없이)">
 
 ```bash


### PR DESCRIPTION
## Summary

- ackoctl upstream removed APT/YUM repo channels (aerospike-ce-ecosystem/ackoctl#27, #29); its README and `docs/install.md` now ship only **Homebrew** + **`curl … install.sh | sh`**.
- The `apt` and `yum` `<TabItem>` blocks here still pointed at infrastructure that no longer exists (GPG keyring URL, repo metadata on `gh-pages`) — users following them would have hit a 404.
- Drop the two stale tabs from both the English source and the Korean translation; keep Homebrew (default) + Any POSIX shell tabs.

## Test plan

- [x] `npm run build` — both `en` and `ko` Docusaurus builds compile cleanly, no broken-link warnings
- [x] `grep -l "apt install ackoctl\|dnf install ackoctl"` against the built HTML returns nothing
- [ ] Reviewer: confirm tab order / default tab still makes sense for the simplified channel list