### PR TITLE
fix(controller): harden dynamic-config value validation and reconcile pod RBAC drift

### DIFF
--- a/internal/controller/reconciler_dynamic_config.go
+++ b/internal/controller/reconciler_dynamic_config.go
@@ -3,8 +3,10 @@ package controller
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
+	"unicode"
 
 	aero "github.com/aerospike/aerospike-client-go/v8"
 	"github.com/go-logr/logr"
@@ -347,19 +349,52 @@ func buildRollbackCommand(log logr.Logger, change configdiff.Change) string {
 	return cmd
 }
 
+// tomlBareKeyRe matches a safe asinfo bare key: alphanumerics, underscores,
+// hyphens and dots (dots are used for nested keys like heartbeat.interval).
+// Mirrors the webhook's tomlBareKeyRe validation, extended to allow the dotted
+// key paths that dynamic config changes carry.
+var tomlBareKeyRe = regexp.MustCompile(`^[A-Za-z0-9_.-]+$`)
+
+// hasUnsafeValueChars reports whether s contains characters that could break or
+// inject into the asinfo set-config wire format. The asinfo protocol is
+// sensitive to ';' and ':' (directive/field separators), '=' (key/value
+// separator), ASCII control characters such as '\n', '\r', '\t' (which can
+// terminate or splice a directive) and leading/trailing whitespace.
+func hasUnsafeValueChars(s string) (bool, string) {
+	if strings.ContainsAny(s, ";:=") {
+		return true, "must not contain ';', ':' or '='"
+	}
+	for _, r := range s {
+		if r < 0x20 || r == 0x7f || unicode.IsControl(r) {
+			return true, "must not contain control characters (e.g. newline, carriage return, tab)"
+		}
+	}
+	if strings.TrimSpace(s) != s {
+		return true, "must not contain leading or trailing whitespace"
+	}
+	return false, ""
+}
+
 // buildSetConfigCommand builds the asinfo set-config command for a change.
-// Returns an error if any field contains characters that could break the
-// asinfo protocol (semicolons or colons used as delimiters).
+// Returns an error if any field contains characters that could break or inject
+// into the asinfo protocol. Keys must be safe bare keys (tomlBareKeyRe); the
+// context, namespace id and value must be free of asinfo delimiters (';', ':',
+// '='), ASCII control characters and surrounding whitespace.
 func buildSetConfigCommand(change configdiff.Change) (string, error) {
 	valueStr := fmt.Sprintf("%v", change.NewValue)
+
+	// Key must be a safe bare key (no delimiters, control chars or whitespace).
+	if !tomlBareKeyRe.MatchString(change.Key) {
+		return "", fmt.Errorf("invalid character in key %q: must match %s", change.Key, tomlBareKeyRe.String())
+	}
+
 	for _, field := range []struct{ name, val string }{
-		{"key", change.Key},
 		{"context", change.Context},
 		{"namespace", change.Namespace},
 		{"value", valueStr},
 	} {
-		if strings.ContainsAny(field.val, ";:") {
-			return "", fmt.Errorf("invalid character in %s %q: must not contain ';' or ':'", field.name, field.val)
+		if unsafe, reason := hasUnsafeValueChars(field.val); unsafe {
+			return "", fmt.Errorf("invalid character in %s %q: %s", field.name, field.val, reason)
 		}
 	}
 

--- a/internal/controller/reconciler_dynamic_config_test.go
+++ b/internal/controller/reconciler_dynamic_config_test.go
@@ -240,6 +240,120 @@ func TestBuildSetConfigCommand_RejectsSemicolonInContext(t *testing.T) {
 	}
 }
 
+// TestBuildSetConfigCommand_RejectsUnsafeChars covers the hardened value
+// validation: asinfo's wire format is also sensitive to '=', control
+// characters (newline, carriage return, tab) and surrounding whitespace, any
+// of which could inject a second directive.
+func TestBuildSetConfigCommand_RejectsUnsafeChars(t *testing.T) {
+	tests := []struct {
+		name      string
+		change    configdiff.Change
+		wantInErr string
+	}{
+		{
+			name: "equals in value",
+			change: configdiff.Change{
+				Context: "service", Key: "ticker-interval", NewValue: "10;migrate-threads=99",
+			},
+			wantInErr: "10;migrate-threads=99",
+		},
+		{
+			name: "newline in value",
+			change: configdiff.Change{
+				Context: "service", Key: "ticker-interval", NewValue: "10\nset-config",
+			},
+			wantInErr: "control characters",
+		},
+		{
+			name: "carriage return in value",
+			change: configdiff.Change{
+				Context: "service", Key: "ticker-interval", NewValue: "10\rinject",
+			},
+			wantInErr: "control characters",
+		},
+		{
+			name: "tab in value",
+			change: configdiff.Change{
+				Context: "service", Key: "ticker-interval", NewValue: "10\tinject",
+			},
+			wantInErr: "control characters",
+		},
+		{
+			name: "leading whitespace in value",
+			change: configdiff.Change{
+				Context: "service", Key: "ticker-interval", NewValue: " 10",
+			},
+			wantInErr: "whitespace",
+		},
+		{
+			name: "trailing whitespace in value",
+			change: configdiff.Change{
+				Context: "service", Key: "ticker-interval", NewValue: "10 ",
+			},
+			wantInErr: "whitespace",
+		},
+		{
+			name: "newline in namespace id",
+			change: configdiff.Change{
+				Context: "namespace", Key: "default-ttl", NewValue: 3600, Namespace: "myns\ninject",
+			},
+			wantInErr: "control characters",
+		},
+		{
+			name: "equals in namespace id",
+			change: configdiff.Change{
+				Context: "namespace", Key: "default-ttl", NewValue: 3600, Namespace: "myns;id=other",
+			},
+			wantInErr: "myns;id=other",
+		},
+		{
+			name: "control char in key",
+			change: configdiff.Change{
+				Context: "service", Key: "proto-fd-max\ninject", NewValue: 20000,
+			},
+			wantInErr: "proto-fd-max",
+		},
+		{
+			name: "equals in key",
+			change: configdiff.Change{
+				Context: "service", Key: "proto-fd-max=evil", NewValue: 20000,
+			},
+			wantInErr: "proto-fd-max=evil",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := buildSetConfigCommand(tt.change)
+			if err == nil {
+				t.Fatalf("expected error for %s, got nil", tt.name)
+			}
+			if !strings.Contains(err.Error(), tt.wantInErr) {
+				t.Errorf("error %q should mention %q", err.Error(), tt.wantInErr)
+			}
+		})
+	}
+}
+
+// TestBuildSetConfigCommand_AllowsDottedKey ensures the hardened key validation
+// still accepts legitimate dotted asinfo keys like heartbeat.interval.
+func TestBuildSetConfigCommand_AllowsDottedKey(t *testing.T) {
+	change := configdiff.Change{
+		Path:     "network.heartbeat.interval",
+		Context:  "network",
+		Key:      "heartbeat.interval",
+		NewValue: 250,
+	}
+	cmd, err := buildSetConfigCommand(change)
+	if err != nil {
+		t.Fatalf("unexpected error for dotted key: %v", err)
+	}
+	expected := "set-config:context=network;heartbeat.interval=250"
+	if cmd != expected {
+		t.Errorf("buildSetConfigCommand = %q, want %q", cmd, expected)
+	}
+}
+
 // --- RollbackResult tests ---
 
 func TestRollbackResult_HasFailures(t *testing.T) {

--- a/internal/controller/reconciler_pod_rbac.go
+++ b/internal/controller/reconciler_pod_rbac.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"reflect"
 
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -37,6 +38,14 @@ func (r *AerospikeClusterReconciler) reconcilePodServiceRBAC(
 	log := logf.FromContext(ctx)
 	saName := "default"
 
+	desiredRules := []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{""},
+			Resources: []string{"services"},
+			Verbs:     []string{"get"},
+		},
+	}
+
 	// Reconcile Role
 	existingRole := &rbacv1.Role{}
 	err := r.Get(ctx, types.NamespacedName{Name: roleName, Namespace: cluster.Namespace}, existingRole)
@@ -46,13 +55,7 @@ func (r *AerospikeClusterReconciler) reconcilePodServiceRBAC(
 				Name:      roleName,
 				Namespace: cluster.Namespace,
 			},
-			Rules: []rbacv1.PolicyRule{
-				{
-					APIGroups: []string{""},
-					Resources: []string{"services"},
-					Verbs:     []string{"get"},
-				},
-			},
+			Rules: desiredRules,
 		}
 		if err := r.setOwnerRef(cluster, role); err != nil {
 			return err
@@ -63,10 +66,33 @@ func (r *AerospikeClusterReconciler) reconcilePodServiceRBAC(
 		}
 	} else if err != nil {
 		return fmt.Errorf("getting pod service reader role %s: %w", roleName, err)
+	} else if !reflect.DeepEqual(existingRole.Rules, desiredRules) {
+		// Role exists but has drifted from the desired spec; correct it.
+		existingRole.Rules = desiredRules
+		if err := r.setOwnerRef(cluster, existingRole); err != nil {
+			return err
+		}
+		log.Info("Updating drifted pod service reader Role", "name", roleName)
+		if err := r.Update(ctx, existingRole); err != nil {
+			return fmt.Errorf("updating pod service reader role %s: %w", roleName, err)
+		}
 	}
 
 	// Reconcile RoleBinding
 	bindingName := roleName
+	desiredRoleRef := rbacv1.RoleRef{
+		APIGroup: "rbac.authorization.k8s.io",
+		Kind:     "Role",
+		Name:     roleName,
+	}
+	desiredSubjects := []rbacv1.Subject{
+		{
+			Kind:      "ServiceAccount",
+			Name:      saName,
+			Namespace: cluster.Namespace,
+		},
+	}
+
 	existingBinding := &rbacv1.RoleBinding{}
 	err = r.Get(ctx, types.NamespacedName{Name: bindingName, Namespace: cluster.Namespace}, existingBinding)
 	if errors.IsNotFound(err) {
@@ -75,18 +101,8 @@ func (r *AerospikeClusterReconciler) reconcilePodServiceRBAC(
 				Name:      bindingName,
 				Namespace: cluster.Namespace,
 			},
-			RoleRef: rbacv1.RoleRef{
-				APIGroup: "rbac.authorization.k8s.io",
-				Kind:     "Role",
-				Name:     roleName,
-			},
-			Subjects: []rbacv1.Subject{
-				{
-					Kind:      "ServiceAccount",
-					Name:      saName,
-					Namespace: cluster.Namespace,
-				},
-			},
+			RoleRef:  desiredRoleRef,
+			Subjects: desiredSubjects,
 		}
 		if err := r.setOwnerRef(cluster, binding); err != nil {
 			return err
@@ -97,6 +113,40 @@ func (r *AerospikeClusterReconciler) reconcilePodServiceRBAC(
 		}
 	} else if err != nil {
 		return fmt.Errorf("getting pod service reader rolebinding %s: %w", bindingName, err)
+	} else if !reflect.DeepEqual(existingBinding.RoleRef, desiredRoleRef) ||
+		!reflect.DeepEqual(existingBinding.Subjects, desiredSubjects) {
+		// RoleBinding exists but has drifted from the desired spec.
+		// RoleRef is immutable, so a divergence there requires recreation;
+		// Subjects can be updated in place.
+		if !reflect.DeepEqual(existingBinding.RoleRef, desiredRoleRef) {
+			log.Info("Recreating pod service reader RoleBinding due to immutable RoleRef drift", "name", bindingName)
+			if err := r.Delete(ctx, existingBinding); err != nil && !errors.IsNotFound(err) {
+				return fmt.Errorf("deleting drifted pod service reader rolebinding %s: %w", bindingName, err)
+			}
+			binding := &rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      bindingName,
+					Namespace: cluster.Namespace,
+				},
+				RoleRef:  desiredRoleRef,
+				Subjects: desiredSubjects,
+			}
+			if err := r.setOwnerRef(cluster, binding); err != nil {
+				return err
+			}
+			if err := r.Create(ctx, binding); err != nil {
+				return fmt.Errorf("recreating pod service reader rolebinding %s: %w", bindingName, err)
+			}
+		} else {
+			existingBinding.Subjects = desiredSubjects
+			if err := r.setOwnerRef(cluster, existingBinding); err != nil {
+				return err
+			}
+			log.Info("Updating drifted pod service reader RoleBinding", "name", bindingName)
+			if err := r.Update(ctx, existingBinding); err != nil {
+				return fmt.Errorf("updating pod service reader rolebinding %s: %w", bindingName, err)
+			}
+		}
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

Two review-driven fixes in `internal/controller`: a **security hardening** and a **drift-correction** fix.

### 1. Harden asinfo `set-config` value validation (`reconciler_dynamic_config.go`)

`buildSetConfigCommand` builds an asinfo `set-config` command from user-supplied CRD config. It previously only rejected `;` and `:` in field values. But the asinfo wire format is also sensitive to `=` (key/value separator) and ASCII control characters (`\n`, `\r`, `\t`), so a crafted value could inject a second directive.

- **Keys** are now validated against a bare-key regex (`^[A-Za-z0-9_.-]+$`) — mirrors the webhook's `tomlBareKeyRe`, extended to allow legitimate dotted keys like `heartbeat.interval`.
- **Context, namespace id, value** are rejected if they contain `;`, `:`, `=`, any ASCII control character, or leading/trailing whitespace.
- Errors clearly name the rejected key/value and the reason.

### 2. Reconcile pod-service-reader RBAC drift (`reconciler_pod_rbac.go`)

The pod-service-reader `Role` and `RoleBinding` were reconciled create-only (create if `IsNotFound`, else no-op), so drift was never corrected. On the already-exists branch:

- **Role**: compares `Rules` against the desired spec, issues `Update` on divergence.
- **RoleBinding**: compares `RoleRef` and `Subjects`. `Subjects` drift is updated in place; `RoleRef` is immutable so a `RoleRef` drift triggers delete+recreate.
- Owner references are preserved in all paths.

### Tests

Extended `reconciler_dynamic_config_test.go` with table-driven cases for the new `=`, control-character and whitespace rejections (in value, namespace id, and key), plus a regression test that legitimate dotted keys are still accepted.

## Test plan

- [x] `go build ./...` succeeds
- [x] `go vet ./...` clean
- [x] `go test ./...` passes (all packages)
- [x] `gofmt -l` on touched files is empty