### PR TITLE
feat(chart)!: drop in-process logging extension; OTLP-forwarder sidecar

### DIFF
--- a/charts/aerospike-ce-kubernetes-operator/README.md
+++ b/charts/aerospike-ce-kubernetes-operator/README.md
@@ -171,103 +171,67 @@ ui:
 When `ui.api.otel.enabled=false` (default), the deployment sets
 `OTEL_SDK_DISABLED=true` and the API uses NoOp providers — zero overhead.
 
-#### Pluggable log handlers (chart 0.3.0+)
+#### Log routing via external OTel Collector
 
-Forward API logs to NELO, Datadog, Loki, Sentry, or any
-`logging.Handler` without rebuilding the upstream image. Either the
-`extraPipPackages` init-container path or a custom image works:
+ACM emits structured JSON to stdout (with `request_id` /
+`otelTraceID` / `otelSpanID` correlation fields) and delegates all
+external routing — PII redaction, sampling, vendor exporters (NELO,
+Datadog, Loki, Sentry, ...) — to an **external OpenTelemetry Collector**
+that the operator runs elsewhere in the cluster. This chart does NOT
+deploy a Collector; it only opt-in deploys a per-pod OTLP-forwarder
+sidecar.
 
-```yaml
-ui:
-  api:
-    extraPipPackages:
-      - "pynelo>=1.0.0"
-    logging:
-      handlers: "pynelo:AsyncNeloHandler"
-    extraEnv:
-      - name: NELO_HOST
-        value: "nelo-collector.svc.cluster.local"
-    extraEnvFrom:
-      - secretRef:
-          name: nelo-token
-```
+Two patterns:
 
-For more elaborate routing (multiple handlers, formatters, filters), the
-`ui.api.logging.dictConfig` value is written to a ConfigMap, mounted at
-`/etc/asm/logging.yaml`, and applied via `logging.config.dictConfig`:
+1. **Node-level DaemonSet OTel Collector** scraping container logs.
+   Default — leave `ui.api.logging.fileMirror.enabled=false` and
+   `ui.api.logging.sidecar.enabled=false`. ACM stdout is the only sink;
+   your existing Collector DaemonSet picks it up from
+   `/var/log/containers/*.log`.
 
-```yaml
-ui:
-  api:
-    logging:
-      dictConfig:
-        version: 1
-        disable_existing_loggers: false
-        formatters:
-          json:
-            "()": pythonjsonlogger.json.JsonFormatter
-            fmt: "%(asctime)s %(levelname)s %(name)s %(message)s %(otelTraceID)s"
-        handlers:
-          console:
-            class: logging.StreamHandler
-            formatter: json
-        loggers:
-          aerospike_cluster_manager_api:
-            level: INFO
-            handlers: [console]
-            propagate: false
-```
-
-See [docs/observability.md](https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager/blob/main/docs/observability.md)
-and [docs/logging.md](https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager/blob/main/docs/logging.md)
-in the cluster-manager repo for the full reference, including airgap and
-constraint notes.
-
-#### Sidecar log shipper (fileMirror + sidecar)
-
-For operators who want to forward logs through a generic agent
-(fluent-bit, vector, promtail, ...) instead of an in-process SDK, enable
-the file mirror and add a sidecar container. The api writes records to a
-rotating file on a shared `emptyDir`, and the sidecar tails that file:
+2. **Pod-internal OTLP-forwarder sidecar** (when DaemonSet scraping is
+   not an option — e.g. multi-tenant clusters where each tenant brings
+   its own Collector, or no permission for a hostPath DaemonSet). Enable
+   `fileMirror` + `sidecar`. The chart wires a shared `emptyDir`, the
+   api writes a rotating file, and a fluent-bit sidecar forwards via
+   OTLP/gRPC to the Collector you specify:
 
 ```yaml
 ui:
+  env:
+    logFormat: "json"     # recommended so the Collector can parse fields
   api:
     logging:
       fileMirror:
-        enabled: true
-        # mountPath / path / maxBytes / backupCount have sensible defaults;
-        # see values.yaml for the full schema.
+        enabled: true     # /var/log/acm/api.log on a shared emptyDir
       sidecar:
         enabled: true
-        # Defaults to fluent-bit. Override image / command / args / env to
-        # pick vector, promtail, or a vendor-specific shipper.
-        config:
-          content: |
-            [SERVICE]
-                Flush 1
-            [INPUT]
-                Name tail
-                Path /var/log/acm/*.log
-                Refresh_Interval 5
-            [OUTPUT]
-                Name forward
-                Match *
-                Host fluentd.observability.svc.cluster.local
-                Port 24224
+        otlp:
+          endpoint: "otel-collector.observability.svc.cluster.local:4317"
+          # tls: true
+          # headers: "x-tenant=acm,authorization=Bearer ..."
 ```
 
-The chart fails template rendering if `sidecar.enabled=true` is set
-without `fileMirror.enabled=true` (sidecar would have nothing to tail),
-or if `fileMirror.enabled=true` is combined with `logging.configFile` /
-`logging.dictConfig` (those modes own the entire pipeline). This catches
-the misconfiguration at `helm install` time rather than as a silent
-no-op at runtime.
+The chart renders a default fluent-bit config that tails the file,
+parses JSON, and forwards via the `opentelemetry` output plugin. To
+plug a different shipper (vector, promtail, vendor agent), override
+`sidecar.image` and `sidecar.config.content`.
 
-`fileMirror.enabled=true` (without a sidecar) is also valid — it lets a
-node-level DaemonSet attach to the api pod's `emptyDir` indirectly via
-log-driver paths, or simply serves as a per-pod retention buffer when
-`kubectl logs` rotation is too aggressive for your environment.
+Validation guards:
+
+- `sidecar.enabled=true` without `fileMirror.enabled=true` → install
+  fails (sidecar would have nothing to tail).
+- `sidecar.enabled=true` without `sidecar.otlp.endpoint` AND without
+  `sidecar.config.content` → install fails (default template needs an
+  endpoint; bring your own config if you want different routing).
+- `sidecar.config.content` containing a `---` line or starting with `%`
+  → install fails (would corrupt the rendered ConfigMap YAML).
+
+See [docs/observability.md](https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager/blob/main/docs/observability.md)
+and [docs/logging.md](https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager/blob/main/docs/logging.md)
+in the cluster-manager repo for the full reference, including the
+migration table from the pre-0.X.0 `LOG_HANDLERS` / `LOGGING_CONFIG_FILE`
+in-process extension hooks.
 
 #### Customizing the UI deployment
 

--- a/charts/aerospike-ce-kubernetes-operator/README.md
+++ b/charts/aerospike-ce-kubernetes-operator/README.md
@@ -223,6 +223,52 @@ and [docs/logging.md](https://github.com/aerospike-ce-ecosystem/aerospike-cluste
 in the cluster-manager repo for the full reference, including airgap and
 constraint notes.
 
+#### Sidecar log shipper (fileMirror + sidecar)
+
+For operators who want to forward logs through a generic agent
+(fluent-bit, vector, promtail, ...) instead of an in-process SDK, enable
+the file mirror and add a sidecar container. The api writes records to a
+rotating file on a shared `emptyDir`, and the sidecar tails that file:
+
+```yaml
+ui:
+  api:
+    logging:
+      fileMirror:
+        enabled: true
+        # mountPath / path / maxBytes / backupCount have sensible defaults;
+        # see values.yaml for the full schema.
+      sidecar:
+        enabled: true
+        # Defaults to fluent-bit. Override image / command / args / env to
+        # pick vector, promtail, or a vendor-specific shipper.
+        config:
+          content: |
+            [SERVICE]
+                Flush 1
+            [INPUT]
+                Name tail
+                Path /var/log/acm/*.log
+                Refresh_Interval 5
+            [OUTPUT]
+                Name forward
+                Match *
+                Host fluentd.observability.svc.cluster.local
+                Port 24224
+```
+
+The chart fails template rendering if `sidecar.enabled=true` is set
+without `fileMirror.enabled=true` (sidecar would have nothing to tail),
+or if `fileMirror.enabled=true` is combined with `logging.configFile` /
+`logging.dictConfig` (those modes own the entire pipeline). This catches
+the misconfiguration at `helm install` time rather than as a silent
+no-op at runtime.
+
+`fileMirror.enabled=true` (without a sidecar) is also valid — it lets a
+node-level DaemonSet attach to the api pod's `emptyDir` indirectly via
+log-driver paths, or simply serves as a per-pod retention buffer when
+`kubectl logs` rotation is too aggressive for your environment.
+
 #### Customizing the UI deployment
 
 You can customize the UI with service annotations, resource defaults, and extra environment variables:

--- a/charts/aerospike-ce-kubernetes-operator/templates/NOTES.txt
+++ b/charts/aerospike-ce-kubernetes-operator/templates/NOTES.txt
@@ -274,12 +274,21 @@ consider enabling it (ui.networkPolicy.enabled=true).
   ACM API log file mirror is ENABLED
 ------------------------------------------------------------------------
 
-The api container is configured to write log records to a rotating file
-at {{ .Values.ui.api.logging.fileMirror.path }} (shared emptyDir mounted
-at {{ .Values.ui.api.logging.fileMirror.mountPath }}).
+The api container writes log records to a rotating file at
+{{ .Values.ui.api.logging.fileMirror.path }} on a shared emptyDir mounted
+at {{ .Values.ui.api.logging.fileMirror.mountPath }}.
 {{- if .Values.ui.api.logging.sidecar.enabled }}
-A `{{ .Values.ui.api.logging.sidecar.image.repository }}:{{ .Values.ui.api.logging.sidecar.image.tag }}` sidecar is mounted at the same path with
-read-only access.
+
+An OTLP-forwarder sidecar
+`{{ .Values.ui.api.logging.sidecar.image.repository }}:{{ .Values.ui.api.logging.sidecar.image.tag }}`
+tails the same path read-only and forwards records via OTLP to
+  {{ .Values.ui.api.logging.sidecar.otlp.endpoint | default "(unset — sidecar.config.content overrides it)" }}
+
+NOTE: this chart does NOT deploy an OTel Collector. The endpoint above
+must point at one you operate elsewhere (DaemonSet / Deployment /
+namespace-scoped). All redaction / sampling / vendor-specific exporter
+configuration lives in that Collector's pipeline, not in ACM or this
+chart.
 {{- end }}
 
 IMPORTANT: This feature requires the ACM api process to honor

--- a/charts/aerospike-ce-kubernetes-operator/templates/NOTES.txt
+++ b/charts/aerospike-ce-kubernetes-operator/templates/NOTES.txt
@@ -268,6 +268,33 @@ SECURITY NOTE: NetworkPolicy is disabled for the UI. For production deployments,
 consider enabling it (ui.networkPolicy.enabled=true).
 {{- end }}
 
+{{- if .Values.ui.api.logging.fileMirror.enabled }}
+
+------------------------------------------------------------------------
+  ACM API log file mirror is ENABLED
+------------------------------------------------------------------------
+
+The api container is configured to write log records to a rotating file
+at {{ .Values.ui.api.logging.fileMirror.path }} (shared emptyDir mounted
+at {{ .Values.ui.api.logging.fileMirror.mountPath }}).
+{{- if .Values.ui.api.logging.sidecar.enabled }}
+A `{{ .Values.ui.api.logging.sidecar.image.repository }}:{{ .Values.ui.api.logging.sidecar.image.tag }}` sidecar is mounted at the same path with
+read-only access.
+{{- end }}
+
+IMPORTANT: This feature requires the ACM api process to honor
+`LOG_FILE_PATH`, which was added in aerospike-cluster-manager PR #368.
+Make sure `ui.imageTag` (or `ui.api.image.tag`) points to a release that
+includes that change. If you pin an older tag the sidecar will tail an
+empty file with no warning at runtime — the operator's only signal is
+"logs don't appear in the shipper".
+
+Verify quickly:
+
+  kubectl exec -n {{ .Release.Namespace }} deploy/{{ include "aerospike-ce-kubernetes-operator.ui.api.fullname" . }} -c api -- \
+    ls -l {{ .Values.ui.api.logging.fileMirror.path }}
+{{- end }}
+
 Check UI pod status:
   kubectl get pods -l app.kubernetes.io/name=aerospike-cluster-manager,app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
 

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/configmap-log-shipper.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/configmap-log-shipper.yaml
@@ -1,5 +1,5 @@
 {{- if eq (include "aerospike-ce-kubernetes-operator.ui.api.enabled" .) "true" }}
-{{- if and .Values.ui.api.logging.sidecar.enabled .Values.ui.api.logging.sidecar.config.content }}
+{{- if .Values.ui.api.logging.sidecar.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -9,6 +9,61 @@ metadata:
     {{- include "aerospike-ce-kubernetes-operator.ui.api.labels" . | nindent 4 }}
 data:
   {{ .Values.ui.api.logging.sidecar.config.subPath }}: |-
+    {{- if .Values.ui.api.logging.sidecar.config.content }}
+    {{- /*
+      Operator-supplied raw content. The chart treats it as opaque text and
+      mounts it as-is — the format is whatever the chosen shipper (fluent-bit,
+      vector, promtail, ...) expects. YAML safety guards on the input string
+      (no `---`, no leading `%`) live in deployment-api.yaml.
+    */}}
     {{- .Values.ui.api.logging.sidecar.config.content | nindent 4 }}
+    {{- else }}
+    {{- /*
+      Default fluent-bit OTLP-forwarder template. Tails the ACM rotating
+      file at fileMirror.path, parses it as JSON, and forwards via fluent-
+      bit's `opentelemetry` output to the external OTel Collector at
+      sidecar.otlp.endpoint. The OTel Collector is NOT deployed by this
+      chart — operators run it elsewhere (DaemonSet / Deployment) and
+      configure routing / redaction / sampling / vendor exporters there.
+    */}}
+    [SERVICE]
+        Flush         1
+        Daemon        Off
+        Log_Level     info
+        Parsers_File  /fluent-bit/parsers/parsers.conf
+
+    [INPUT]
+        Name              tail
+        Path              {{ .Values.ui.api.logging.fileMirror.mountPath }}/*.log
+        Parser            json
+        Refresh_Interval  5
+        Read_from_Head    true
+        DB                /tmp/fluent-bit-acm.db
+        Tag               acm.api
+
+    [OUTPUT]
+        Name              opentelemetry
+        Match             *
+        {{- /*
+          fluent-bit's opentelemetry output accepts `host` + `port` or a
+          full URI. We split host/port because the value is more readable
+          and parses identically regardless of TLS toggling.
+        */}}
+        Host              {{ regexReplaceAll ":[0-9]+$" (required "ui.api.logging.sidecar.otlp.endpoint is required when sidecar.enabled=true and sidecar.config.content is empty" .Values.ui.api.logging.sidecar.otlp.endpoint) "" }}
+        Port              {{ regexFind "[0-9]+$" (required "ui.api.logging.sidecar.otlp.endpoint must include a port (host:port)" .Values.ui.api.logging.sidecar.otlp.endpoint) | default "4317" }}
+        Logs_uri          /v1/logs
+        Metrics_uri       /v1/metrics
+        Traces_uri        /v1/traces
+        Log_response_payload true
+        {{- if .Values.ui.api.logging.sidecar.otlp.tls }}
+        tls               On
+        tls.verify        {{ if .Values.ui.api.logging.sidecar.otlp.insecureSkipVerify }}Off{{ else }}On{{ end }}
+        {{- else }}
+        tls               Off
+        {{- end }}
+        {{- with .Values.ui.api.logging.sidecar.otlp.headers }}
+        Header            {{ . }}
+        {{- end }}
+    {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/configmap-log-shipper.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/configmap-log-shipper.yaml
@@ -1,0 +1,14 @@
+{{- if eq (include "aerospike-ce-kubernetes-operator.ui.api.enabled" .) "true" }}
+{{- if and .Values.ui.api.logging.sidecar.enabled .Values.ui.api.logging.sidecar.config.content }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "aerospike-ce-kubernetes-operator.ui.api.fullname" . }}-log-shipper
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "aerospike-ce-kubernetes-operator.ui.api.labels" . | nindent 4 }}
+data:
+  {{ .Values.ui.api.logging.sidecar.config.subPath }}: |-
+    {{- .Values.ui.api.logging.sidecar.config.content | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/configmap.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/configmap.yaml
@@ -30,19 +30,6 @@ data:
   DEFAULT_AEROSPIKE_IMAGE: {{ .Values.aerospikeImages.aerospike | quote }}
   DEFAULT_EXPORTER_IMAGE: {{ .Values.aerospikeImages.exporter | quote }}
 {{- end }}
-{{- if and (eq (include "aerospike-ce-kubernetes-operator.ui.api.enabled" .) "true") .Values.ui.api.logging.dictConfig }}
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: {{ include "aerospike-ce-kubernetes-operator.ui.api.fullname" . }}-logging
-  namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "aerospike-ce-kubernetes-operator.ui.api.labels" . | nindent 4 }}
-data:
-  logging.yaml: |
-{{ toYaml .Values.ui.api.logging.dictConfig | indent 4 }}
-{{- end }}
 {{- if eq (include "aerospike-ce-kubernetes-operator.multiCluster.enabled" .) "true" }}
 ---
 # Multi-cluster registry consumed by the web SPA at /cluster-registry.json.

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/deployment-api.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/deployment-api.yaml
@@ -2,6 +2,12 @@
 {{- if and .Values.ui.autoscaling.enabled .Values.ui.postgresql.enabled }}
 {{- fail "ui.autoscaling.enabled and ui.postgresql.enabled cannot both be true. The embedded PostgreSQL sidecar is single-instance only. Disable ui.postgresql.enabled and provide ui.env.databaseUrl for an external database when using HPA." }}
 {{- end }}
+{{- if and .Values.ui.api.logging.sidecar.enabled (not .Values.ui.api.logging.fileMirror.enabled) }}
+{{- fail "ui.api.logging.sidecar.enabled=true requires ui.api.logging.fileMirror.enabled=true. Without the file mirror the sidecar has nothing to tail. Enable fileMirror, or disable the sidecar and forward logs in-process via ui.api.logging.handlers." }}
+{{- end }}
+{{- if and .Values.ui.api.logging.fileMirror.enabled (or .Values.ui.api.logging.configFile .Values.ui.api.logging.dictConfig) }}
+{{- fail "ui.api.logging.fileMirror.enabled has no effect when ui.api.logging.configFile or ui.api.logging.dictConfig is set — dictConfig takes full ownership of the logging pipeline. Either disable fileMirror or move the file handler into your dictConfig." }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -43,6 +49,9 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/ui/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/ui/secret.yaml") . | sha256sum }}
+        {{- if and .Values.ui.api.logging.sidecar.enabled .Values.ui.api.logging.sidecar.config.content }}
+        checksum/log-shipper-config: {{ include (print $.Template.BasePath "/ui/configmap-log-shipper.yaml") . | sha256sum }}
+        {{- end }}
       {{- with .Values.ui.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -154,6 +163,14 @@ spec:
             - name: LOGGING_CONFIG_FILE
               value: {{ .Values.ui.api.logging.configFile | quote }}
             {{- end }}
+            {{- if .Values.ui.api.logging.fileMirror.enabled }}
+            - name: LOG_FILE_PATH
+              value: {{ .Values.ui.api.logging.fileMirror.path | quote }}
+            - name: LOG_FILE_MAX_BYTES
+              value: {{ .Values.ui.api.logging.fileMirror.maxBytes | quote }}
+            - name: LOG_FILE_BACKUP_COUNT
+              value: {{ .Values.ui.api.logging.fileMirror.backupCount | quote }}
+            {{- end }}
             {{- with .Values.ui.api.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -184,7 +201,7 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if or .Values.ui.api.extraVolumeMounts .Values.ui.api.extraPipPackages .Values.ui.api.logging.dictConfig }}
+          {{- if or .Values.ui.api.extraVolumeMounts .Values.ui.api.extraPipPackages .Values.ui.api.logging.dictConfig .Values.ui.api.logging.fileMirror.enabled .Values.ui.api.logging.sidecar.enabled }}
           volumeMounts:
             {{- with .Values.ui.api.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
@@ -199,7 +216,49 @@ spec:
               mountPath: /etc/asm
               readOnly: true
             {{- end }}
+            {{- if or .Values.ui.api.logging.fileMirror.enabled .Values.ui.api.logging.sidecar.enabled }}
+            - name: acm-logs
+              mountPath: {{ .Values.ui.api.logging.fileMirror.mountPath | quote }}
+            {{- end }}
           {{- end }}
+        {{- if .Values.ui.api.logging.sidecar.enabled }}
+        - name: log-shipper
+          image: "{{ .Values.ui.api.logging.sidecar.image.repository }}:{{ .Values.ui.api.logging.sidecar.image.tag }}"
+          imagePullPolicy: {{ .Values.ui.api.logging.sidecar.image.pullPolicy }}
+          {{- with .Values.ui.api.logging.sidecar.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.ui.api.logging.sidecar.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.ui.api.logging.sidecar.env }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.ui.api.logging.sidecar.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.ui.api.logging.sidecar.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: acm-logs
+              mountPath: {{ .Values.ui.api.logging.fileMirror.mountPath | quote }}
+              readOnly: true
+            {{- if .Values.ui.api.logging.sidecar.config.content }}
+            - name: log-shipper-config
+              mountPath: {{ .Values.ui.api.logging.sidecar.config.mountPath | quote }}
+              subPath: {{ .Values.ui.api.logging.sidecar.config.subPath | quote }}
+              readOnly: true
+            {{- end }}
+            {{- with .Values.ui.api.logging.sidecar.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+        {{- end }}
         {{- if .Values.ui.postgresql.enabled }}
         - name: postgres
           image: "{{ .Values.ui.postgresql.image.repository }}:{{ .Values.ui.postgresql.image.tag }}"
@@ -273,7 +332,7 @@ spec:
             - name: data
               mountPath: /var/lib/postgresql/data
         {{- end }}
-      {{- if or .Values.ui.postgresql.enabled .Values.ui.api.extraVolumes .Values.ui.api.extraPipPackages .Values.ui.api.logging.dictConfig }}
+      {{- if or .Values.ui.postgresql.enabled .Values.ui.api.extraVolumes .Values.ui.api.extraPipPackages .Values.ui.api.logging.dictConfig .Values.ui.api.logging.fileMirror.enabled .Values.ui.api.logging.sidecar.enabled }}
       volumes:
         {{- if .Values.ui.postgresql.enabled }}
         - name: data
@@ -295,6 +354,15 @@ spec:
         - name: logging-config
           configMap:
             name: {{ include "aerospike-ce-kubernetes-operator.ui.api.fullname" . }}-logging
+        {{- end }}
+        {{- if or .Values.ui.api.logging.fileMirror.enabled .Values.ui.api.logging.sidecar.enabled }}
+        - name: acm-logs
+          emptyDir: {}
+        {{- end }}
+        {{- if and .Values.ui.api.logging.sidecar.enabled .Values.ui.api.logging.sidecar.config.content }}
+        - name: log-shipper-config
+          configMap:
+            name: {{ include "aerospike-ce-kubernetes-operator.ui.api.fullname" . }}-log-shipper
         {{- end }}
       {{- end }}
       {{- with .Values.ui.nodeSelector }}

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/deployment-api.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/deployment-api.yaml
@@ -3,12 +3,12 @@
 {{- fail "ui.autoscaling.enabled and ui.postgresql.enabled cannot both be true. The embedded PostgreSQL sidecar is single-instance only. Disable ui.postgresql.enabled and provide ui.env.databaseUrl for an external database when using HPA." }}
 {{- end }}
 {{- if and .Values.ui.api.logging.sidecar.enabled (not .Values.ui.api.logging.fileMirror.enabled) }}
-{{- fail "ui.api.logging.sidecar.enabled=true requires ui.api.logging.fileMirror.enabled=true. Without the file mirror the sidecar has nothing to tail. Enable fileMirror, or disable the sidecar and forward logs in-process via ui.api.logging.handlers." }}
+{{- fail "ui.api.logging.sidecar.enabled=true requires ui.api.logging.fileMirror.enabled=true. Without the file mirror the sidecar has nothing to tail. Either enable fileMirror, or rely on a node-level OTel Collector DaemonSet scraping container logs instead." }}
 {{- end }}
-{{- if and .Values.ui.api.logging.fileMirror.enabled (or .Values.ui.api.logging.configFile .Values.ui.api.logging.dictConfig) }}
-{{- fail "ui.api.logging.fileMirror.enabled has no effect when ui.api.logging.configFile or ui.api.logging.dictConfig is set — dictConfig takes full ownership of the logging pipeline. Either disable fileMirror or move the file handler into your dictConfig." }}
+{{- if and .Values.ui.api.logging.sidecar.enabled (not .Values.ui.api.logging.sidecar.config.content) (not .Values.ui.api.logging.sidecar.otlp.endpoint) }}
+{{- fail "ui.api.logging.sidecar.enabled=true requires either ui.api.logging.sidecar.otlp.endpoint (to use the default fluent-bit OTLP forwarder config) or ui.api.logging.sidecar.config.content (to bring your own shipper config)." }}
 {{- end }}
-{{- if and .Values.ui.api.logging.sidecar.enabled .Values.ui.api.logging.sidecar.config.content }}
+{{- if .Values.ui.api.logging.sidecar.config.content }}
 {{- /*
   Block YAML-toxic content from ui.api.logging.sidecar.config.content:
   - "---" inside the value risks splitting the ConfigMap into multiple
@@ -68,7 +68,7 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/ui/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/ui/secret.yaml") . | sha256sum }}
-        {{- if and .Values.ui.api.logging.sidecar.enabled .Values.ui.api.logging.sidecar.config.content }}
+        {{- if .Values.ui.api.logging.sidecar.enabled }}
         checksum/log-shipper-config: {{ include (print $.Template.BasePath "/ui/configmap-log-shipper.yaml") . | sha256sum }}
         {{- end }}
       {{- with .Values.ui.podAnnotations }}
@@ -171,17 +171,6 @@ spec:
             - name: OIDC_EXCLUDE_PATHS
               value: {{ join "," .Values.ui.api.auth.oidc.excludePaths | quote }}
             {{- end }}
-            {{- with .Values.ui.api.logging.handlers }}
-            - name: LOG_HANDLERS
-              value: {{ . | quote }}
-            {{- end }}
-            {{- if .Values.ui.api.logging.dictConfig }}
-            - name: LOGGING_CONFIG_FILE
-              value: /etc/asm/logging.yaml
-            {{- else if .Values.ui.api.logging.configFile }}
-            - name: LOGGING_CONFIG_FILE
-              value: {{ .Values.ui.api.logging.configFile | quote }}
-            {{- end }}
             {{- if .Values.ui.api.logging.fileMirror.enabled }}
             - name: LOG_FILE_PATH
               value: {{ .Values.ui.api.logging.fileMirror.path | quote }}
@@ -226,7 +215,7 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if or .Values.ui.api.extraVolumeMounts .Values.ui.api.extraPipPackages .Values.ui.api.logging.dictConfig .Values.ui.api.logging.fileMirror.enabled .Values.ui.api.logging.sidecar.enabled }}
+          {{- if or .Values.ui.api.extraVolumeMounts .Values.ui.api.extraPipPackages .Values.ui.api.logging.fileMirror.enabled .Values.ui.api.logging.sidecar.enabled }}
           volumeMounts:
             {{- with .Values.ui.api.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
@@ -234,11 +223,6 @@ spec:
             {{- if .Values.ui.api.extraPipPackages }}
             - name: extra-packages
               mountPath: /extra-packages
-              readOnly: true
-            {{- end }}
-            {{- if .Values.ui.api.logging.dictConfig }}
-            - name: logging-config
-              mountPath: /etc/asm
               readOnly: true
             {{- end }}
             {{- if or .Values.ui.api.logging.fileMirror.enabled .Values.ui.api.logging.sidecar.enabled }}
@@ -274,12 +258,10 @@ spec:
             - name: acm-logs
               mountPath: {{ .Values.ui.api.logging.fileMirror.mountPath | quote }}
               readOnly: true
-            {{- if .Values.ui.api.logging.sidecar.config.content }}
             - name: log-shipper-config
               mountPath: {{ .Values.ui.api.logging.sidecar.config.mountPath | quote }}
               subPath: {{ .Values.ui.api.logging.sidecar.config.subPath | quote }}
               readOnly: true
-            {{- end }}
             {{- with .Values.ui.api.logging.sidecar.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -357,7 +339,7 @@ spec:
             - name: data
               mountPath: /var/lib/postgresql/data
         {{- end }}
-      {{- if or .Values.ui.postgresql.enabled .Values.ui.api.extraVolumes .Values.ui.api.extraPipPackages .Values.ui.api.logging.dictConfig .Values.ui.api.logging.fileMirror.enabled .Values.ui.api.logging.sidecar.enabled }}
+      {{- if or .Values.ui.postgresql.enabled .Values.ui.api.extraVolumes .Values.ui.api.extraPipPackages .Values.ui.api.logging.fileMirror.enabled .Values.ui.api.logging.sidecar.enabled }}
       volumes:
         {{- if .Values.ui.postgresql.enabled }}
         - name: data
@@ -375,16 +357,11 @@ spec:
         - name: extra-packages
           emptyDir: {}
         {{- end }}
-        {{- if .Values.ui.api.logging.dictConfig }}
-        - name: logging-config
-          configMap:
-            name: {{ include "aerospike-ce-kubernetes-operator.ui.api.fullname" . }}-logging
-        {{- end }}
         {{- if or .Values.ui.api.logging.fileMirror.enabled .Values.ui.api.logging.sidecar.enabled }}
         - name: acm-logs
           emptyDir: {}
         {{- end }}
-        {{- if and .Values.ui.api.logging.sidecar.enabled .Values.ui.api.logging.sidecar.config.content }}
+        {{- if .Values.ui.api.logging.sidecar.enabled }}
         - name: log-shipper-config
           configMap:
             name: {{ include "aerospike-ce-kubernetes-operator.ui.api.fullname" . }}-log-shipper

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/deployment-api.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/deployment-api.yaml
@@ -8,6 +8,25 @@
 {{- if and .Values.ui.api.logging.fileMirror.enabled (or .Values.ui.api.logging.configFile .Values.ui.api.logging.dictConfig) }}
 {{- fail "ui.api.logging.fileMirror.enabled has no effect when ui.api.logging.configFile or ui.api.logging.dictConfig is set — dictConfig takes full ownership of the logging pipeline. Either disable fileMirror or move the file handler into your dictConfig." }}
 {{- end }}
+{{- if and .Values.ui.api.logging.sidecar.enabled .Values.ui.api.logging.sidecar.config.content }}
+{{- /*
+  Block YAML-toxic content from ui.api.logging.sidecar.config.content:
+  - "---" inside the value risks splitting the ConfigMap into multiple
+    YAML documents when rendered through `nindent`. Even when block-scalar
+    indentation keeps a single document intact, a downstream `kubectl
+    diff` / GitOps tool that re-parses the rendered manifest can still
+    trip on it.
+  - A leading "%" is a YAML directive marker and is unsafe in any context.
+  Catch both at install time with a clear error rather than ship a
+  broken ConfigMap that fails on apply with an opaque parser message.
+*/}}
+{{- if contains "\n---" (printf "\n%s" .Values.ui.api.logging.sidecar.config.content) }}
+{{- fail "ui.api.logging.sidecar.config.content must not contain a '---' line (YAML document separator). Inline the directives without document separators, or supply the config via `ui.api.logging.sidecar.extraVolumeMounts` referencing your own ConfigMap." }}
+{{- end }}
+{{- if hasPrefix "%" .Values.ui.api.logging.sidecar.config.content }}
+{{- fail "ui.api.logging.sidecar.config.content must not start with '%' (YAML directive marker). Indent the first line or supply the config via `ui.api.logging.sidecar.extraVolumeMounts` referencing your own ConfigMap." }}
+{{- end }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -166,10 +185,16 @@ spec:
             {{- if .Values.ui.api.logging.fileMirror.enabled }}
             - name: LOG_FILE_PATH
               value: {{ .Values.ui.api.logging.fileMirror.path | quote }}
+            {{- /*
+              `| quote` on a JSON number >= 1e7 renders it in scientific
+              notation (e.g. "5.24288e+07"), which Python's int() rejects
+              with ValueError on startup. Force a decimal-int representation
+              via `printf "%d"` so 52428800 stays "52428800".
+            */}}
             - name: LOG_FILE_MAX_BYTES
-              value: {{ .Values.ui.api.logging.fileMirror.maxBytes | quote }}
+              value: {{ printf "%d" (.Values.ui.api.logging.fileMirror.maxBytes | int) | quote }}
             - name: LOG_FILE_BACKUP_COUNT
-              value: {{ .Values.ui.api.logging.fileMirror.backupCount | quote }}
+              value: {{ printf "%d" (.Values.ui.api.logging.fileMirror.backupCount | int) | quote }}
             {{- end }}
             {{- with .Values.ui.api.extraEnv }}
             {{- toYaml . | nindent 12 }}

--- a/charts/aerospike-ce-kubernetes-operator/values.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/values.yaml
@@ -550,6 +550,90 @@ ui:
       #         handlers: [console]
       dictConfig: {}
 
+      # =========================================================================
+      # File mirror — writes log records to a rotating file on a shared
+      # emptyDir so a sidecar shipper (fluent-bit, vector, promtail, ...) can
+      # tail it. The api container reads LOG_FILE_PATH / LOG_FILE_MAX_BYTES /
+      # LOG_FILE_BACKUP_COUNT — see aerospike-cluster-manager docs/logging.md
+      # "Example C". Ignored when `logging.configFile` or `logging.dictConfig`
+      # is set (dictConfig takes full ownership of the logging pipeline).
+      # =========================================================================
+      fileMirror:
+        # -- Enable file mirror. Auto-mounts an emptyDir at `mountPath` on
+        # both the api container and the sidecar (when enabled), so the
+        # rotating file at `path` is visible to both.
+        enabled: false
+        # -- Mount root of the shared emptyDir inside both the api container
+        # and the sidecar.
+        mountPath: /var/log/acm
+        # -- Log file the api process writes to. Must live under `mountPath`
+        # so the sidecar can read it.
+        path: /var/log/acm/api.log
+        # -- Per-file size cap (bytes) before rotation. Default 50 MiB.
+        maxBytes: 52428800
+        # -- Number of rotated backups kept on disk.
+        backupCount: 3
+
+      # =========================================================================
+      # Log-shipper sidecar (fluent-bit, vector, promtail, vendor-specific
+      # collector, ...). The sidecar shares an emptyDir with the api container
+      # at `fileMirror.mountPath` so it can tail the rotating file.
+      #
+      # `sidecar.enabled=true` requires `fileMirror.enabled=true` — without
+      # the mirror, the sidecar would have nothing to tail. The chart fails
+      # template rendering if the two are inconsistent so the misconfiguration
+      # is caught at `helm install` time instead of as a silent no-op at
+      # runtime.
+      # =========================================================================
+      sidecar:
+        # -- Enable the log-shipper sidecar container.
+        enabled: false
+        # -- Sidecar container image.
+        image:
+          repository: cr.fluentbit.io/fluent/fluent-bit
+          tag: "3.2"
+          pullPolicy: IfNotPresent
+        # -- Override the image's entrypoint command. Leave empty to use the
+        # image default.
+        command: []
+        # -- Override the image's CMD (arguments).
+        args: []
+        # -- Additional env vars passed to the sidecar (e.g. log shipper auth
+        # tokens). Standard Kubernetes env-var schema.
+        env: []
+        # -- Resource requests/limits for the sidecar.
+        resources:
+          requests:
+            cpu: 25m
+            memory: 32Mi
+          limits:
+            cpu: 100m
+            memory: 128Mi
+        # -- Container-level securityContext applied to the sidecar.
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: false
+          capabilities:
+            drop:
+              - ALL
+        # -- Additional volume mounts on the sidecar container. Use together
+        # with `ui.api.extraVolumes` to mount secrets, CA bundles, etc.
+        extraVolumeMounts: []
+        # -- Optional sidecar config file rendered into a ConfigMap and
+        # mounted into the sidecar. When `content` is empty no ConfigMap is
+        # created — the sidecar runs with the image's default config and the
+        # operator is expected to bake one in or supply it via
+        # `extraVolumeMounts`. The file format depends on the shipper:
+        # fluent-bit conf, vector toml, promtail yaml, etc.
+        config:
+          # -- Path inside the sidecar where the file is mounted.
+          mountPath: /fluent-bit/etc/fluent-bit.conf
+          # -- ConfigMap key the file is stored under (also the subPath of
+          # the volume mount).
+          subPath: fluent-bit.conf
+          # -- Raw file content. Empty disables the ConfigMap.
+          content: ""
+
   # =============================================================================
   # Web (Next.js 14 + proxy.js sidecar) — port 3100
   # =============================================================================

--- a/charts/aerospike-ce-kubernetes-operator/values.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/values.yaml
@@ -523,40 +523,27 @@ ui:
           - /api/docs
 
     # =============================================================================
-    # Logging — pluggable handlers via LOG_HANDLERS or full dictConfig.
-    # See aerospike-cluster-manager docs/logging.md for examples.
+    # Logging — stdout (always) + optional rotating file mirror + optional
+    # OTLP-forwarder sidecar. ACM no longer ships in-process logging
+    # extension hooks; external log routing (PII redaction, sampling,
+    # vendor exporters) is delegated to an external OpenTelemetry Collector.
+    # See aerospike-cluster-manager docs/logging.md.
+    #
+    # Two deployment shapes are supported:
+    #   (a) node-level OTel Collector DaemonSet scraping container logs.
+    #       Default: leave `fileMirror.enabled=false` and
+    #       `sidecar.enabled=false`. ACM stdout is the only sink.
+    #   (b) pod-internal sidecar that tails the rotating file and forwards
+    #       OTLP to an external OTel Collector. Set fileMirror.enabled=true
+    #       AND sidecar.enabled=true (the chart fails install if you set
+    #       the sidecar without the mirror).
     # =============================================================================
     logging:
-      # -- LOG_HANDLERS env value. Comma-separated list of handler specs:
-      # "module.path:ClassName" or entry-point name registered under
-      # "aerospike_cluster_manager.log_handlers".
-      # Example: "pynelo:AsyncNeloHandler"
-      handlers: ""
-      # -- Path to an externally-mounted dictConfig file (when you mount it
-      # via your own ConfigMap / Volume). Mutually exclusive with
-      # `dictConfig` below.
-      configFile: ""
-      # -- dictConfig payload. When non-empty, the chart writes it to a
-      # ConfigMap, mounts it at /etc/asm/logging.yaml, and sets
-      # LOGGING_CONFIG_FILE accordingly. Example:
-      #   dictConfig:
-      #     version: 1
-      #     handlers:
-      #       console:
-      #         class: logging.StreamHandler
-      #     loggers:
-      #       aerospike_cluster_manager_api:
-      #         level: INFO
-      #         handlers: [console]
-      dictConfig: {}
-
       # =========================================================================
       # File mirror — writes log records to a rotating file on a shared
-      # emptyDir so a sidecar shipper (fluent-bit, vector, promtail, ...) can
-      # tail it. The api container reads LOG_FILE_PATH / LOG_FILE_MAX_BYTES /
-      # LOG_FILE_BACKUP_COUNT — see aerospike-cluster-manager docs/logging.md
-      # "Example C". Ignored when `logging.configFile` or `logging.dictConfig`
-      # is set (dictConfig takes full ownership of the logging pipeline).
+      # emptyDir so the sidecar (when enabled) can tail it. The api
+      # container reads LOG_FILE_PATH / LOG_FILE_MAX_BYTES /
+      # LOG_FILE_BACKUP_COUNT.
       # =========================================================================
       fileMirror:
         # -- Enable file mirror. Auto-mounts an emptyDir at `mountPath` on
@@ -575,23 +562,51 @@ ui:
         backupCount: 3
 
       # =========================================================================
-      # Log-shipper sidecar (fluent-bit, vector, promtail, vendor-specific
-      # collector, ...). The sidecar shares an emptyDir with the api container
-      # at `fileMirror.mountPath` so it can tail the rotating file.
+      # OTLP-forwarder sidecar (fluent-bit by default).
+      #
+      # The sidecar shares an emptyDir with the api container at
+      # `fileMirror.mountPath`, tails the rotating file, and forwards
+      # records via OTLP/gRPC to an external OpenTelemetry Collector — the
+      # Collector is NOT deployed by this chart, the assumption is that
+      # one already exists in the cluster (DaemonSet, Deployment, or
+      # namespace-scoped). The sidecar is purely a per-pod *exporter*.
       #
       # `sidecar.enabled=true` requires `fileMirror.enabled=true` — without
       # the mirror, the sidecar would have nothing to tail. The chart fails
-      # template rendering if the two are inconsistent so the misconfiguration
-      # is caught at `helm install` time instead of as a silent no-op at
-      # runtime.
+      # template rendering if the two are inconsistent so the
+      # misconfiguration is caught at `helm install` time.
       # =========================================================================
       sidecar:
-        # -- Enable the log-shipper sidecar container.
+        # -- Enable the OTLP-forwarder sidecar container.
         enabled: false
-        # -- Sidecar container image. Pinned to a specific patch tag so
-        # `helm upgrade` does not silently pull a new build under the
-        # floating `3.2` alias. Bump deliberately when fluent-bit releases
-        # a fix you want to take.
+
+        # -- OTLP target. This is the external OTel Collector — set the
+        # endpoint to where Collector's OTLP receiver listens.
+        otlp:
+          # -- Host:port of the OTel Collector's OTLP/gRPC receiver. The
+          # default sidecar config (below) wires this into fluent-bit's
+          # `opentelemetry` output plugin. Required when sidecar.enabled=true
+          # and config.content is empty (the default rendered config
+          # references it).
+          # Example: "otel-collector.observability.svc.cluster.local:4317"
+          endpoint: ""
+          # -- Optional OTLP headers (auth tokens, tenant id). Forwarded
+          # as gRPC metadata. Comma-separated `key=value` pairs.
+          # Example: "x-tenant=acm,authorization=Bearer xxxxx"
+          headers: ""
+          # -- Use TLS for the OTLP connection. When false the sidecar uses
+          # plaintext gRPC — fine for in-cluster Collector with no
+          # mTLS, but production should generally enable TLS.
+          tls: false
+          # -- Insecure-skip-verify when tls=true. Useful for self-signed
+          # Collector certs in dev/staging. Avoid in production.
+          insecureSkipVerify: false
+
+        # -- Sidecar container image. Defaults to fluent-bit, which has a
+        # first-party OTLP output plugin (`opentelemetry`) since 1.9. Pinned
+        # to a specific patch tag so `helm upgrade` does not silently pull a
+        # new build under the floating `3.2` alias. Bump deliberately when
+        # fluent-bit releases a fix you want to take.
         image:
           repository: cr.fluentbit.io/fluent/fluent-bit
           tag: "3.2.10"
@@ -630,19 +645,19 @@ ui:
         # -- Additional volume mounts on the sidecar container. Use together
         # with `ui.api.extraVolumes` to mount secrets, CA bundles, etc.
         extraVolumeMounts: []
-        # -- Optional sidecar config file rendered into a ConfigMap and
-        # mounted into the sidecar. When `content` is empty no ConfigMap is
-        # created — the sidecar runs with the image's default config and the
-        # operator is expected to bake one in or supply it via
-        # `extraVolumeMounts`. The file format depends on the shipper:
-        # fluent-bit conf, vector toml, promtail yaml, etc.
+        # -- Sidecar config file. When `content` is empty the chart renders
+        # a fluent-bit config that tails fileMirror.path and forwards via
+        # OTLP to sidecar.otlp.endpoint. Override `content` to plug in a
+        # different shipper (vector, promtail, vendor agent); the chart
+        # will render exactly what you provide.
         config:
           # -- Path inside the sidecar where the file is mounted.
           mountPath: /fluent-bit/etc/fluent-bit.conf
           # -- ConfigMap key the file is stored under (also the subPath of
           # the volume mount).
           subPath: fluent-bit.conf
-          # -- Raw file content. Empty disables the ConfigMap.
+          # -- Override the rendered config with raw file content. Empty =
+          # use the chart's default fluent-bit OTLP-forwarder template.
           content: ""
 
   # =============================================================================

--- a/charts/aerospike-ce-kubernetes-operator/values.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/values.yaml
@@ -588,10 +588,13 @@ ui:
       sidecar:
         # -- Enable the log-shipper sidecar container.
         enabled: false
-        # -- Sidecar container image.
+        # -- Sidecar container image. Pinned to a specific patch tag so
+        # `helm upgrade` does not silently pull a new build under the
+        # floating `3.2` alias. Bump deliberately when fluent-bit releases
+        # a fix you want to take.
         image:
           repository: cr.fluentbit.io/fluent/fluent-bit
-          tag: "3.2"
+          tag: "3.2.10"
           pullPolicy: IfNotPresent
         # -- Override the image's entrypoint command. Leave empty to use the
         # image default.
@@ -610,7 +613,15 @@ ui:
             cpu: 100m
             memory: 128Mi
         # -- Container-level securityContext applied to the sidecar.
+        # runAsUser is pinned to 1001 to match `ui.podSecurityContext.runAsUser`
+        # and `fsGroup` — the api container writes the rotating file as UID
+        # 1001, and the sidecar must read it as the same UID/GID so the
+        # contract holds even when the operator overrides the pod-level
+        # securityContext to a different non-root user. Bump alongside any
+        # change to `ui.podSecurityContext.runAsUser`.
         securityContext:
+          runAsUser: 1001
+          runAsNonRoot: true
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: false
           capabilities:


### PR DESCRIPTION
## Summary

Companion to [aerospike-cluster-manager#368](https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager/pull/368) and [issue #362](https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager/issues/362).

**Direction change (BREAKING)**: the chart drops `ui.api.logging.handlers`, `ui.api.logging.configFile`, and `ui.api.logging.dictConfig` — the in-process Python logging extension hooks they wrapped are removed from the ACM image too. External log routing (PII redaction, sampling, vendor exporters) is delegated to an **external OpenTelemetry Collector** that operators run elsewhere in the cluster. This chart does NOT embed a Collector; it only opt-in deploys a per-pod OTLP-forwarder sidecar.

### What's kept

- `ui.api.logging.fileMirror.{enabled,mountPath,path,maxBytes,backupCount}` — unchanged; still wires `LOG_FILE_PATH` / `LOG_FILE_MAX_BYTES` / `LOG_FILE_BACKUP_COUNT` on the api container.
- `ui.api.logging.sidecar` — kept and reworked around OTLP.

### What's new

- `ui.api.logging.sidecar.otlp.{endpoint,headers,tls,insecureSkipVerify}` — points at the external OTel Collector. When `sidecar.config.content` is empty, the chart renders a default fluent-bit config that tails `fileMirror.path`, parses JSON, and forwards via fluent-bit's `opentelemetry` output plugin to that endpoint.
- `sidecar.image` still defaults to `cr.fluentbit.io/fluent/fluent-bit:3.2.10`; override for vector / promtail / vendor agent.

### Validation guards (`templates/ui/deployment-api.yaml`)

- `sidecar.enabled=true` without `fileMirror.enabled=true` → fail.
- `sidecar.enabled=true` without either `sidecar.otlp.endpoint` or `sidecar.config.content` → fail (default template needs an endpoint).
- `sidecar.config.content` containing `---` line or starting with `%` → fail.

### Migration matrix (chart values)

| Pre-0.X.0 | Post-0.X.0 |
|---|---|
| Direct attach of a vendor SDK handler | Remove. Run the vendor exporter (or an OTLP→vendor bridge) on your Collector; set `sidecar.otlp.endpoint`.|Direct attach of a vendor SDK handler | Remove. Run the vendor exporter (or an OTLP→vendor bridge) on your Collector; set `sidecar.otlp.endpoint`. |
| `ui.api.logging.dictConfig: { ... }` | Remove. Translate to Collector `service.pipelines.logs`. The chart no longer renders a `*-logging` ConfigMap. |
| `ui.api.logging.configFile: "/path/to/mounted.yaml"` | Same as above — Collector owns the pipeline. |

## Example values for the new pattern

```yaml
ui:
  env:
    logFormat: "json"
  api:
    logging:
      fileMirror:
        enabled: true
      sidecar:
        enabled: true
        otlp:
          endpoint: "otel-collector.observability.svc.cluster.local:4317"
          # tls: true
          # headers: "x-tenant=acm,authorization=Bearer …"
```

## Test plan

- [x] `helm lint .` — clean.
- [x] `helm template .` (default values) — no logging extras rendered.
- [x] `helm template . --set ui.api.logging.fileMirror.enabled=true --set ui.api.logging.sidecar.enabled=true --set ui.api.logging.sidecar.otlp.endpoint=otel-collector.obs:4317` — full sidecar + default fluent-bit OTLP forwarder config, correct Host/Port split.
- [x] `--set ui.api.logging.sidecar.otlp.headers='x-tenant=acm'` — Header line appears.
- [x] `--set ui.api.logging.sidecar.enabled=true` (no fileMirror) — clear error.
- [x] `--set ui.api.logging.fileMirror.enabled=true --set ui.api.logging.sidecar.enabled=true` (no endpoint, no content) — clear error.
- [x] `sidecar.config.content` with `---` line — clear error.
- [ ] Kind e2e: install with the example above, run an OTel Collector, confirm ACM records arrive at the Collector with `trace_id` / `span_id` attributes.

## Versioning

`feat!` Conventional Commit triggers a MAJOR bump. Per workspace policy MAJOR is gated on explicit user approval — confirmed in PR discussion. Release tag will be cut manually after the companion ACM PR lands and a paired version is decided across both charts.
