### PR TITLE
docs: drop legacy LOG_HANDLERS / dictConfig refs + sanitize vendor-internal mentions

### DIFF
--- a/charts/aerospike-ce-kubernetes-operator/README.md
+++ b/charts/aerospike-ce-kubernetes-operator/README.md
@@ -175,8 +175,8 @@ When `ui.api.otel.enabled=false` (default), the deployment sets
 
 ACM emits structured JSON to stdout (with `request_id` /
 `otelTraceID` / `otelSpanID` correlation fields) and delegates all
-external routing — PII redaction, sampling, vendor exporters (NELO,
-Datadog, Loki, Sentry, ...) — to an **external OpenTelemetry Collector**
+external routing — PII redaction, sampling, vendor exporters (Datadog,
+Loki, Elasticsearch, Sentry, ...) — to an **external OpenTelemetry Collector**
 that the operator runs elsewhere in the cluster. This chart does NOT
 deploy a Collector; it only opt-in deploys a per-pod OTLP-forwarder
 sidecar.
@@ -229,9 +229,8 @@ Validation guards:
 
 See [docs/observability.md](https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager/blob/main/docs/observability.md)
 and [docs/logging.md](https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager/blob/main/docs/logging.md)
-in the cluster-manager repo for the full reference, including the
-migration table from the pre-0.X.0 `LOG_HANDLERS` / `LOGGING_CONFIG_FILE`
-in-process extension hooks.
+in the cluster-manager repo for the full reference and example fluent-bit
+sidecar configuration.
 
 #### Customizing the UI deployment
 

--- a/charts/aerospike-ce-kubernetes-operator/values.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/values.yaml
@@ -432,23 +432,25 @@ ui:
     extraVolumeMounts: []
 
     # -- Extra environment variables passed to the api container.
-    # Useful for plugin handler configuration (NELO_HOST, NELO_PROJECT_TOKEN, etc.)
+    # Use this for any custom configuration the api container needs (e.g.
+    # third-party SDK endpoints, timezone overrides). Standard Kubernetes
+    # env-var schema applies.
     # Example:
     #   extraEnv:
-    #     - name: NELO_HOST
-    #       value: "nelo-collector.svc.cluster.local"
+    #     - name: TZ
+    #       value: "Asia/Seoul"
     extraEnv: []
 
     # -- envFrom entries (configMapRef / secretRef) for bulk env injection.
     # Example:
     #   extraEnvFrom:
     #     - secretRef:
-    #         name: nelo-token
+    #         name: my-api-secrets
     extraEnvFrom: []
 
     # -- Additional Python packages installed by an init container into a
-    # PYTHONPATH-mounted volume so plugin log handlers (pynelo, ddtrace, ...)
-    # can be loaded without rebuilding the upstream image.
+    # PYTHONPATH-mounted volume so extra dependencies can be loaded without
+    # rebuilding the upstream image.
     #
     # Limitations: requires PyPI egress from the cluster, adds pod-startup
     # latency, may break with C extensions whose ABI mismatches the runtime

--- a/docs/content/getting-started/cluster-manager-ui.md
+++ b/docs/content/getting-started/cluster-manager-ui.md
@@ -622,7 +622,7 @@ helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kuber
 
 #### Log routing via OpenTelemetry Collector
 
-ACM emits structured JSON to stdout (with `request_id` / `otelTraceID` / `otelSpanID` correlation fields). External log routing — PII redaction, sampling, vendor-specific exporters (NELO, Datadog, Loki, Sentry, Elasticsearch, ...) — is delegated to an **external OpenTelemetry Collector** that you operate elsewhere in the cluster. The chart does NOT deploy a Collector; it only opt-in deploys a per-pod OTLP-forwarder sidecar that tails the api's rotating-file mirror.
+ACM emits structured JSON to stdout (with `request_id` / `otelTraceID` / `otelSpanID` correlation fields). External log routing — PII redaction, sampling, vendor-specific exporters (Datadog, Loki, Elasticsearch, Sentry, ...) — is delegated to an **external OpenTelemetry Collector** that you operate elsewhere in the cluster. The chart does NOT deploy a Collector; it only opt-in deploys a per-pod OTLP-forwarder sidecar that tails the api's rotating-file mirror.
 
 Two deployment patterns are supported.
 
@@ -687,19 +687,7 @@ The chart fails template rendering on misconfigurations rather than producing a 
 | `sidecar.enabled=true` without `sidecar.otlp.endpoint` AND without `sidecar.config.content` | install fails — default template needs an endpoint |
 | `sidecar.config.content` containing a `---` line or starting with `%` | install fails — would corrupt rendered ConfigMap YAML |
 
-#### Migrating from pre-0.X.0 `LOG_HANDLERS` / `dictConfig`
-
-Earlier releases of this chart exposed `ui.api.logging.handlers`, `ui.api.logging.configFile`, and `ui.api.logging.dictConfig` that wired in-process Python logging hooks on the ACM api. Those hooks were removed in [aerospike-cluster-manager#368](https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager/pull/368) and the matching chart values are gone in [aerospike-ce-kubernetes-operator#269](https://github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/pull/269). Every prior use case maps to an OTel Collector primitive:
-
-| Old chart values | OTel Collector equivalent |
-|---|---|
-| `ui.api.logging.handlers: "pynelo:AsyncNeloHandler"` | Run an OTLP→NELO exporter/bridge on the Collector; point `sidecar.otlp.endpoint` at it. |
-| Per-record PII redaction inside the handler | `attributes` / `redaction` / `transform` processor in the Collector pipeline. |
-| Sampling (error 100% / info 1%) inside the handler | `probabilistic_sampler` / `tail_sampling` processor. |
-| Fixed extra fields (`service`, `env`, `tenant`) | `resource` / `attributes` processor; or OTel SDK resource attributes via `ui.api.otel.resourceAttributes`. |
-| `ui.api.logging.dictConfig` for full pipeline ownership | Collector `service.pipelines.logs` configuration. |
-
-See the [ACM logging reference](https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager/blob/main/docs/logging.md) and the [observability guide](https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager/blob/main/docs/observability.md) for the full migration matrix.
+See the [ACM logging reference](https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager/blob/main/docs/logging.md) and the [observability guide](https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager/blob/main/docs/observability.md) for the full reference and example fluent-bit sidecar configuration.
 
 ---
 

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/getting-started/cluster-manager-ui.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/getting-started/cluster-manager-ui.md
@@ -130,7 +130,7 @@ helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kuber
 
 ### OpenTelemetry Collector를 통한 로그 라우팅
 
-ACM은 stdout으로 구조화된 JSON 로그를 출력합니다(`request_id` / `otelTraceID` / `otelSpanID` 상관관계 필드 포함). 외부 로그 라우팅 — PII 마스킹, 샘플링, 벤더별 exporter(NELO, Datadog, Loki, Sentry, Elasticsearch, ...) — 는 클러스터 어딘가에서 운영자가 직접 운영하는 **외부 OpenTelemetry Collector**에 위임됩니다. 차트는 Collector 자체를 배포하지 않으며, ACM api의 회전 파일 미러를 tail해서 OTLP로 forward하는 per-pod 사이드카만 옵션으로 배포합니다.
+ACM은 stdout으로 구조화된 JSON 로그를 출력합니다(`request_id` / `otelTraceID` / `otelSpanID` 상관관계 필드 포함). 외부 로그 라우팅 — PII 마스킹, 샘플링, 벤더별 exporter(Datadog, Loki, Elasticsearch, Sentry, ...) — 는 클러스터 어딘가에서 운영자가 직접 운영하는 **외부 OpenTelemetry Collector**에 위임됩니다. 차트는 Collector 자체를 배포하지 않으며, ACM api의 회전 파일 미러를 tail해서 OTLP로 forward하는 per-pod 사이드카만 옵션으로 배포합니다.
 
 지원되는 deployment 패턴은 두 가지입니다.
 
@@ -195,19 +195,7 @@ ui:
 | `sidecar.enabled=true`인데 `sidecar.otlp.endpoint`도 `sidecar.config.content`도 비어 있는 경우 | 기본 템플릿이 endpoint를 필요로 함 — install 실패 |
 | `sidecar.config.content`에 `---` 줄이 있거나 `%`로 시작하는 경우 | 렌더된 ConfigMap YAML이 깨질 위험 — install 실패 |
 
-### 구버전 `LOG_HANDLERS` / `dictConfig`에서 마이그레이션
-
-이전 릴리스의 차트는 `ui.api.logging.handlers`, `ui.api.logging.configFile`, `ui.api.logging.dictConfig`를 통해 ACM api에 in-process Python 로깅 훅을 wiring했습니다. 해당 훅은 [aerospike-cluster-manager#368](https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager/pull/368)에서 제거되었고, 차트 쪽 매핑 값은 [aerospike-ce-kubernetes-operator#269](https://github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/pull/269)에서 제거되었습니다. 기존 use case는 모두 OTel Collector 프리미티브로 매핑됩니다:
-
-| 구버전 차트 값 | OTel Collector 대체 |
-|---|---|
-| `ui.api.logging.handlers: "pynelo:AsyncNeloHandler"` | Collector에 OTLP→NELO exporter/bridge를 운영하고, `sidecar.otlp.endpoint`를 그쪽으로 향하게 함. |
-| 핸들러 내부에서 수행하던 per-record PII 마스킹 | Collector 파이프라인의 `attributes` / `redaction` / `transform` 프로세서. |
-| 핸들러 내부 샘플링 (error 100% / info 1%) | `probabilistic_sampler` / `tail_sampling` 프로세서. |
-| 고정 필드 (`service`, `env`, `tenant`) | `resource` / `attributes` 프로세서; 또는 `ui.api.otel.resourceAttributes`로 OTel SDK 리소스 속성 주입. |
-| `ui.api.logging.dictConfig`로 전체 파이프라인 소유 | Collector `service.pipelines.logs` 설정으로 이전. |
-
-전체 마이그레이션 매트릭스는 [ACM 로깅 레퍼런스](https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager/blob/main/docs/logging.md)와 [observability 가이드](https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager/blob/main/docs/observability.md)를 참고하세요.
+전체 레퍼런스와 fluent-bit 사이드카 예시 설정은 [ACM 로깅 레퍼런스](https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager/blob/main/docs/logging.md)와 [observability 가이드](https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager/blob/main/docs/observability.md)를 참고하세요.
 
 ---
 


### PR DESCRIPTION
## Summary

Follow-up to PRs #269 / #270 / #271. Two related cleanups.

### 1. Legacy logging-hook references

The previously removed `ui.api.logging.handlers` / `configFile` / `dictConfig` values no longer have backwards-compat or migration guidance — the project doesn't carry that maintenance.

- `charts/aerospike-ce-kubernetes-operator/README.md` — drop the "migration table from the pre-0.X.0 `LOG_HANDLERS` / `LOGGING_CONFIG_FILE` in-process extension hooks" reference line.
- `docs/content/getting-started/cluster-manager-ui.md` (en) — drop the "Migrating from pre-0.X.0 `LOG_HANDLERS` / `dictConfig`" subsection and its migration matrix.
- `docs/i18n/ko/.../cluster-manager-ui.md` — same removal, Korean.

### 2. vendor-internal mentions

It refers to a vendor-internal observability platform; it doesn't belong in user-facing docs or inline comments.

- `charts/.../README.md`, `docs` (en + ko) — replace the "Datadog, Loki, …" enumeration with vendor-neutral examples (Datadog / Loki / Elasticsearch / Sentry).
- `charts/.../values.yaml` — rewrite the vendor-internal-flavored `extraEnv` / `extraEnvFrom` / `extraPipPackages` examples to vendor-neutral ones (TZ env, generic secret name, no internal SDK).

## Test plan

- [x] `helm lint .` — clean.
- [x] `npm run build` in `docs/` — both `en` and `ko` locales build cleanly with no broken-link warnings.
- [x] `grep -rni "internal-platform\|vendor-internal SDK\|LOG_HANDLERS\|LOGGING_CONFIG_FILE\|dictConfig\|Migrating from pre\|in-process Python"` in the worktree returns no matches.
