### PR TITLE
fix: close config-correctness gaps and harden CI from project review

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,7 @@
 # More info: https://docs.docker.com/engine/reference/builder/#dockerignore-file
 # Ignore build artifacts and non-essential files
 bin/
-cover.out
+cover*.out
 dist/
 *.md
 !go.mod

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,6 +32,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
+# Least-privilege: linting only reads the checked-out code.
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Run on Ubuntu

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -20,6 +20,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
+# Least-privilege: e2e only reads the checked-out code.
+permissions:
+  contents: read
+
 jobs:
   test-e2e:
     name: Run on Ubuntu

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
+# Least-privilege: tests only read the checked-out code.
+permissions:
+  contents: read
+
 jobs:
   unit-test:
     name: Unit Tests

--- a/docs/content/reference/helm-values.md
+++ b/docs/content/reference/helm-values.md
@@ -212,7 +212,7 @@ When `ui.rbac.create=true`, the generated ClusterRole includes the following per
 | `ui.postgresql.image.pullPolicy` | string | `IfNotPresent` | Image pull policy. |
 | `ui.postgresql.database` | string | `aerospike_manager` | Database name. |
 | `ui.postgresql.username` | string | `aerospike` | Database user. |
-| `ui.postgresql.password` | string | `aerospike` | Database password (embedded sidecar only). |
+| `ui.postgresql.password` | string | `""` | Database password (embedded sidecar only). When empty, the chart auto-generates a random 24-character password on first install and preserves it across upgrades. |
 | `ui.postgresql.existingSecret` | string | `""` | Existing Secret name containing `POSTGRES_PASSWORD` and `DATABASE_URL` keys. |
 | `ui.postgresql.resources.requests.cpu` | string | `50m` | CPU request. |
 | `ui.postgresql.resources.requests.memory` | string | `128Mi` | Memory request. |

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/reference/helm-values.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/reference/helm-values.md
@@ -205,7 +205,7 @@ Aerospike Cluster Manager는 오퍼레이터와 함께 배포되는 풀스택 �
 | `ui.postgresql.image.pullPolicy` | string | `IfNotPresent` | 이미지 풀 정책. |
 | `ui.postgresql.database` | string | `aerospike_manager` | 데이터베이스 이름. |
 | `ui.postgresql.username` | string | `aerospike` | 데이터베이스 사용자. |
-| `ui.postgresql.password` | string | `aerospike` | 데이터베이스 비밀번호 (내장 사이드카 전용). |
+| `ui.postgresql.password` | string | `""` | 데이터베이스 비밀번호 (내장 사이드카 전용). 비어 있으면 첫 설치 시 24자 무작위 비밀번호를 자동 생성하며 업그레이드 시에도 유지됩니다. |
 | `ui.postgresql.existingSecret` | string | `""` | `POSTGRES_PASSWORD`와 `DATABASE_URL` 키를 포함하는 기존 Secret 이름. |
 | `ui.postgresql.resources.requests.cpu` | string | `50m` | CPU 요청. |
 | `ui.postgresql.resources.requests.memory` | string | `128Mi` | 메모리 요청. |

--- a/internal/configdiff/diff.go
+++ b/internal/configdiff/diff.go
@@ -242,6 +242,10 @@ func valuesEqual(a, b any) bool {
 // numericValue converts any Go numeric type to float64 so values can be
 // compared regardless of the concrete type they were decoded as. The second
 // return is false when v is not a number.
+//
+// Widening to float64 is exact for Aerospike config values: every numeric
+// parameter (ports, proto-fd-max, memory/data sizes, periods) is far below
+// 2^53, the largest integer float64 represents exactly.
 func numericValue(v any) (float64, bool) {
 	switch n := v.(type) {
 	case int:

--- a/internal/configdiff/diff.go
+++ b/internal/configdiff/diff.go
@@ -216,23 +216,52 @@ func lastSegment(path string) string {
 }
 
 func valuesEqual(a, b any) bool {
+	// Numbers must compare across Go types: a config value arrives as int
+	// from a Go literal (webhook defaulter) but as float64 after a JSON
+	// round-trip through the API server, so int 15000 and float64 15000
+	// must be equal — otherwise the diff reports a phantom change and the
+	// reconciler triggers an unnecessary restart.
+	if af, aIsNum := numericValue(a); aIsNum {
+		bf, bIsNum := numericValue(b)
+		return bIsNum && af == bf
+	}
 	switch aTyped := a.(type) {
 	case string:
 		bTyped, ok := b.(string)
 		return ok && aTyped == bTyped
-	case float64:
-		bTyped, ok := b.(float64)
-		return ok && aTyped == bTyped
 	case bool:
 		bTyped, ok := b.(bool)
-		return ok && aTyped == bTyped
-	case int:
-		bTyped, ok := b.(int)
 		return ok && aTyped == bTyped
 	case nil:
 		return b == nil
 	default:
 		return reflect.DeepEqual(a, b)
+	}
+}
+
+// numericValue converts any Go numeric type to float64 so values can be
+// compared regardless of the concrete type they were decoded as. The second
+// return is false when v is not a number.
+func numericValue(v any) (float64, bool) {
+	switch n := v.(type) {
+	case int:
+		return float64(n), true
+	case int32:
+		return float64(n), true
+	case int64:
+		return float64(n), true
+	case uint:
+		return float64(n), true
+	case uint32:
+		return float64(n), true
+	case uint64:
+		return float64(n), true
+	case float32:
+		return float64(n), true
+	case float64:
+		return n, true
+	default:
+		return 0, false
 	}
 }
 

--- a/internal/configdiff/diff_test.go
+++ b/internal/configdiff/diff_test.go
@@ -421,6 +421,19 @@ func TestValuesEqual(t *testing.T) {
 		{true, true, true},
 		{true, false, false},
 		{nil, nil, true},
+		// Cross-type numeric equality: a value decoded as int from a Go
+		// literal must equal the same value decoded as float64 after a
+		// JSON round-trip, otherwise the diff reports a phantom change.
+		{15000, float64(15000), true},
+		{float64(15000), 15000, true},
+		{int64(60), float64(60), true},
+		{int64(60), 60, true},
+		{float64(2), int32(2), true},
+		{1, float64(2), false},
+		{int64(15000), float64(15001), false},
+		// A number and a non-number are never equal.
+		{1, "1", false},
+		{0, false, false},
 	}
 	for _, tc := range tests {
 		if got := valuesEqual(tc.a, tc.b); got != tc.expected {

--- a/internal/template/validation.go
+++ b/internal/template/validation.go
@@ -172,8 +172,11 @@ func ValidateTemplateSpec(spec *ackov1alpha1.AerospikeClusterTemplateSpec) ([]st
 // silently inherit an enterprise image. Previously this was a warning only,
 // so the constraint could be bypassed via templateRef. We now reject:
 //  1. images whose lower-cased reference contains "aerospike-server-enterprise"
-//     (the canonical enterprise repository name on Docker Hub), and
-//  2. images whose tag/repository contains a generic "enterprise" substring.
+//     (the canonical enterprise repository name on Docker Hub),
+//  2. images with an Enterprise Edition tag prefix ("ee-"/"ent-"), matching
+//     the cluster webhook's isEnterpriseTag check so a custom registry name
+//     cannot smuggle an enterprise build past template validation, and
+//  3. images whose tag/repository contains a generic "enterprise" substring.
 //
 // CE images typically contain a "ce-" tag prefix (e.g. aerospike:ce-8.1.1.1);
 // retagged custom-registry CE images that omit "ce-" are reported as a
@@ -189,6 +192,12 @@ func validateTemplateImage(image string) (errs []string, warnings []string) {
 		errs = append(errs, fmt.Sprintf(
 			"template image %q references the enterprise repository "+
 				"(aerospike-server-enterprise); CE clusters must use a CE image (CE constraint)",
+			image,
+		))
+	case isEnterpriseTag(image):
+		errs = append(errs, fmt.Sprintf(
+			"template image %q has an Enterprise Edition tag (ee-/ent- prefix); "+
+				"CE clusters must use a CE image (CE constraint)",
 			image,
 		))
 	case strings.Contains(imageLower, "enterprise"):

--- a/internal/template/validation_test.go
+++ b/internal/template/validation_test.go
@@ -69,6 +69,32 @@ func TestValidateTemplateSpec_V_T06_NoWarningWhenImageEmpty(t *testing.T) {
 	}
 }
 
+func TestValidateTemplateSpec_V_T06_RejectsEnterpriseRepository(t *testing.T) {
+	spec := &ackov1alpha1.AerospikeClusterTemplateSpec{
+		Image: "aerospike/aerospike-server-enterprise:8.1.0.0",
+	}
+	errs, _ := ValidateTemplateSpec(spec)
+	if len(errs) == 0 {
+		t.Error("expected error for enterprise-repository image")
+	}
+}
+
+func TestValidateTemplateSpec_V_T06_RejectsEnterpriseEditionTag(t *testing.T) {
+	// A custom registry name with no "enterprise" substring must still be
+	// rejected when the tag carries an Enterprise Edition prefix, matching
+	// the cluster webhook's isEnterpriseTag check.
+	for _, img := range []string{
+		"myregistry.io/aerospike:ee-8.0.0.1_1",
+		"myregistry.io/aerospike:ent-8.0.0",
+	} {
+		spec := &ackov1alpha1.AerospikeClusterTemplateSpec{Image: img}
+		errs, _ := ValidateTemplateSpec(spec)
+		if len(errs) == 0 {
+			t.Errorf("expected error for Enterprise Edition tag %q", img)
+		}
+	}
+}
+
 // --- V-T07: Size range (1–8) ---
 
 func TestValidateTemplateSpec_V_T07_SizeBelowMinIsError(t *testing.T) {

--- a/internal/utils/merge.go
+++ b/internal/utils/merge.go
@@ -66,6 +66,10 @@ func DeepMerge(base, override map[string]any) map[string]any {
 
 // deepCopyValue returns a deep copy of an arbitrary config value, recursing
 // into map[string]any and []any. Scalars are immutable and returned as-is.
+// Only the map[string]any / []any shape produced by JSON and Kubernetes
+// unstructured decoding is recursed into — which is exactly what
+// AerospikeConfigSpec.Value holds; typed containers (e.g. []string) would
+// still be aliased, but that shape never reaches DeepMerge.
 func deepCopyValue(v any) any {
 	switch t := v.(type) {
 	case map[string]any:

--- a/internal/utils/merge.go
+++ b/internal/utils/merge.go
@@ -4,7 +4,6 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
-	"maps"
 )
 
 // IntFromAny extracts an int from a value that may be int, int64, or float64.
@@ -35,15 +34,20 @@ func ShortSHA256(v any) string {
 
 // DeepMerge merges override into base and returns the result.
 // Override values take precedence. Nested maps are merged recursively.
-// Neither base nor override is modified; the result is a new map.
+// Neither base nor override is modified, and the returned map shares no
+// mutable state with either input: nested maps and slices are deep-copied,
+// so a later mutation of the result cannot reach back into the source CR
+// spec (the common caller passes cluster/rack aerospikeConfig maps).
 func DeepMerge(base, override map[string]any) map[string]any {
 	result := make(map[string]any, len(base))
-	maps.Copy(result, base)
+	for k, v := range base {
+		result[k] = deepCopyValue(v)
+	}
 
 	for k, overrideVal := range override {
 		baseVal, exists := result[k]
 		if !exists {
-			result[k] = overrideVal
+			result[k] = deepCopyValue(overrideVal)
 			continue
 		}
 
@@ -53,9 +57,30 @@ func DeepMerge(base, override map[string]any) map[string]any {
 		if baseIsMap && overrideIsMap {
 			result[k] = DeepMerge(baseMap, overrideMap)
 		} else {
-			result[k] = overrideVal
+			result[k] = deepCopyValue(overrideVal)
 		}
 	}
 
 	return result
+}
+
+// deepCopyValue returns a deep copy of an arbitrary config value, recursing
+// into map[string]any and []any. Scalars are immutable and returned as-is.
+func deepCopyValue(v any) any {
+	switch t := v.(type) {
+	case map[string]any:
+		c := make(map[string]any, len(t))
+		for k, val := range t {
+			c[k] = deepCopyValue(val)
+		}
+		return c
+	case []any:
+		c := make([]any, len(t))
+		for i, val := range t {
+			c[i] = deepCopyValue(val)
+		}
+		return c
+	default:
+		return v
+	}
 }

--- a/internal/utils/merge_test.go
+++ b/internal/utils/merge_test.go
@@ -102,6 +102,48 @@ func TestDeepMerge_ScalarOverridesMap(t *testing.T) {
 	}
 }
 
+func TestDeepMerge_ResultDoesNotAliasNestedBaseMap(t *testing.T) {
+	base := map[string]any{
+		"service": map[string]any{"proto-fd-max": 15000},
+	}
+	override := map[string]any{}
+	result := DeepMerge(base, override)
+
+	// Mutating a nested map in the result must not reach back into base.
+	result["service"].(map[string]any)["proto-fd-max"] = 999
+	if base["service"].(map[string]any)["proto-fd-max"] != 15000 {
+		t.Error("mutating result aliased back into base map")
+	}
+}
+
+func TestDeepMerge_ResultDoesNotAliasNestedOverrideMap(t *testing.T) {
+	base := map[string]any{}
+	override := map[string]any{
+		"network": map[string]any{"port": 3000},
+	}
+	result := DeepMerge(base, override)
+
+	// A key present only in override must also be deep-copied.
+	result["network"].(map[string]any)["port"] = 9999
+	if override["network"].(map[string]any)["port"] != 3000 {
+		t.Error("mutating result aliased back into override map")
+	}
+}
+
+func TestDeepMerge_ResultDoesNotAliasSlices(t *testing.T) {
+	base := map[string]any{
+		"namespaces": []any{
+			map[string]any{"name": "test"},
+		},
+	}
+	result := DeepMerge(base, map[string]any{})
+
+	result["namespaces"].([]any)[0].(map[string]any)["name"] = "mutated"
+	if base["namespaces"].([]any)[0].(map[string]any)["name"] != "test" {
+		t.Error("mutating result aliased back into base slice element")
+	}
+}
+
 // --- IntFromAny tests ---
 
 func TestIntFromAny_Int(t *testing.T) {


### PR DESCRIPTION
## Summary

A project-wide review of ACKO surfaced several genuine, verified correctness gaps. Each fix is small, scoped, and covered by tests.

### Bug fixes
- **`configdiff.valuesEqual` — phantom config diffs.** Numbers were compared by exact Go type only: a value decoded as `int` from a Go literal (webhook defaulter) vs `float64` after a JSON round-trip through the API server compared *unequal*. That produced a phantom diff entry, which the reconciler classified as a config change and acted on — risking an unnecessary pod restart. `valuesEqual` now normalizes all numeric types before comparison.
- **`utils.DeepMerge` — aliased nested state.** The doc comment promised "the result is a new map", but `maps.Copy` is shallow and override-only keys were stored by reference. A later mutation of the merged config could reach back into the source `AerospikeCluster` CR spec. `DeepMerge` now deep-copies nested maps/slices, honoring its documented contract.
- **`template.validateTemplateImage` — CE-constraint inconsistency.** Template image validation rejected enterprise images by substring only, but did not apply the `ee-`/`ent-` tag-prefix check (`isEnterpriseTag`) the cluster webhook uses. A custom registry name with an EE tag could pass template validation. The check is now consistent with the webhook.

### Hardening
- **CI least-privilege.** Added `permissions: { contents: read }` to `lint.yml`, `test.yml`, and `test-e2e.yml`. The other workflows already scope their `GITHUB_TOKEN`; these three inherited the repo default.
- **`.dockerignore`.** `cover.out` → `cover*.out` to match the actual `cover-unit.out` / `cover-integration.out` artifacts.
- **Docs.** Corrected the stale `ui.postgresql.password` default in `helm-values.md` (EN + KO) — it listed the retired well-known credential `aerospike`; the chart now auto-generates a random password.

## Test plan
- [x] `make test-unit` — all packages pass
- [x] `make test-integration` (envtest) — all packages pass
- [x] `make lint` — 0 issues
- [x] New tests: cross-type numeric equality in `valuesEqual`; `DeepMerge` non-aliasing of nested base/override maps and slices; `validateTemplateImage` rejection of `ee-`/`ent-` tags
- [x] No CRD/RBAC manifest drift from `controller-gen`