### PR TITLE
feat(helm): SQLite embedded default, PostgreSQL external-only; drop embedded postgres sidecar

### DIFF
--- a/charts/aerospike-ce-kubernetes-operator/README.md
+++ b/charts/aerospike-ce-kubernetes-operator/README.md
@@ -233,6 +233,44 @@ in the cluster-manager repo for the full reference, including the
 migration table from the pre-0.X.0 `LOG_HANDLERS` / `LOGGING_CONFIG_FILE`
 in-process extension hooks.
 
+#### Database backend
+
+The api persists cluster connection metadata in a database. Two backends are
+supported via `ui.database.type`:
+
+| `ui.database.type` | Where the data lives | Use when |
+|--------------------|----------------------|----------|
+| `sqlite` (default) | Embedded SQLite file inside the api container, on a PVC (`ui.database.sqlite.persistence`) | Single-instance installs. Zero extra infrastructure. SQLite is single-writer, so `ui.replicaCount` must stay `1`. |
+| `postgresql`       | An **external** PostgreSQL instance you operate (RDS / Cloud SQL / AlloyDB / an in-cluster PostgreSQL operator) | HA / multi-replica. The chart never deploys PostgreSQL itself. |
+
+SQLite (default) — nothing to configure:
+
+```bash
+helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/acko \
+  --version 0.4.0 --namespace aerospike-operator --create-namespace \
+  --set ui.database.sqlite.persistence.size=2Gi
+```
+
+External PostgreSQL — supply the connection URL (or an existing Secret with a
+`DATABASE_URL` key via `ui.database.postgresql.existingSecret`):
+
+```bash
+helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/acko \
+  --version 0.4.0 --namespace aerospike-operator --create-namespace \
+  --set ui.database.type=postgresql \
+  --set ui.database.postgresql.databaseUrl='postgresql://user:pass@db-host:5432/aerospike_manager'
+```
+
+> **Migration (embedded sidecar removed):** earlier chart versions ran a
+> `postgres` container as a sidecar in the api pod. That sidecar is gone.
+> Map `ui.postgresql.enabled: true` → `ui.database.type: postgresql` +
+> `ui.database.postgresql.databaseUrl` (pointing at an external database),
+> `ui.postgresql.enabled: false` → `ui.database.type: sqlite`, and
+> `ui.persistence.*` → `ui.database.sqlite.persistence.*`. There is no
+> in-place data migration from the old embedded PostgreSQL PVC — `pg_dump`
+> it before upgrading if you need to keep that data. Stale `ui.postgresql.*`
+> / `ui.persistence.*` keys now fail the install with a migration message.
+
 #### Customizing the UI deployment
 
 You can customize the UI with service annotations, resource defaults, and extra environment variables:

--- a/charts/aerospike-ce-kubernetes-operator/README.md
+++ b/charts/aerospike-ce-kubernetes-operator/README.md
@@ -260,15 +260,45 @@ helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/acko \
   --set ui.database.postgresql.databaseUrl='postgresql://user:pass@db-host:5432/aerospike_manager'
 ```
 
-> **Migration (embedded sidecar removed):** earlier chart versions ran a
-> `postgres` container as a sidecar in the api pod. That sidecar is gone.
-> Map `ui.postgresql.enabled: true` → `ui.database.type: postgresql` +
-> `ui.database.postgresql.databaseUrl` (pointing at an external database),
-> `ui.postgresql.enabled: false` → `ui.database.type: sqlite`, and
-> `ui.persistence.*` → `ui.database.sqlite.persistence.*`. There is no
-> in-place data migration from the old embedded PostgreSQL PVC — `pg_dump`
-> it before upgrading if you need to keep that data. Stale `ui.postgresql.*`
-> / `ui.persistence.*` keys now fail the install with a migration message.
+#### Migrating off the embedded PostgreSQL sidecar
+
+Earlier chart versions ran a `postgres` container as a sidecar in the api pod,
+with its data on the `<release>-…-ui-data` PVC. That sidecar is **removed**.
+There is **no automatic data migration**:
+
+- `ui.database.type=sqlite` → the old PostgreSQL files are stranded on the PVC; the api starts on a fresh, empty SQLite database.
+- `ui.database.type=postgresql` → Helm deletes the old PVC; with a `Delete` reclaim policy the data is destroyed.
+
+To protect against silent data loss, the chart **blocks any upgrade** from a
+release that still has the embedded-mode Secret (`<release>-…-ui-db` with a
+`POSTGRES_PASSWORD` key) until you set
+`ui.database.acknowledgeEmbeddedPostgresRemoval=true`.
+
+**Migration runbook (preserve your data → external PostgreSQL):**
+
+```bash
+# 1. Back up the embedded database (old release still running)
+kubectl exec -n <ns> deploy/<release>-aerospike-ce-kubernetes-operator-ui-api \
+  -c postgres -- pg_dump -U aerospike -d aerospike_manager --no-owner --no-privileges \
+  > acm-backup.sql
+
+# 2. Restore into your external PostgreSQL (RDS / Cloud SQL / AlloyDB / …)
+psql "postgresql://user:pass@db-host:5432/aerospike_manager" -v ON_ERROR_STOP=1 < acm-backup.sql
+
+# 3. Upgrade — point at the external DB and acknowledge the sidecar removal
+helm upgrade <release> oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kubernetes-operator \
+  -n <ns> --reuse-values \
+  --set ui.database.type=postgresql \
+  --set ui.database.postgresql.databaseUrl='postgresql://user:pass@db-host:5432/aerospike_manager' \
+  --set ui.database.acknowledgeEmbeddedPostgresRemoval=true
+```
+
+The api's `init_db()` uses `CREATE TABLE IF NOT EXISTS`, so restoring the full
+dump first and then starting the new api is safe. There is no automated
+PostgreSQL→SQLite path — to land on SQLite instead, re-add connections from the
+UI.
+
+**Value mapping:** `ui.postgresql.enabled: true` → `ui.database.type: postgresql` + `ui.database.postgresql.databaseUrl`; `ui.postgresql.enabled: false` → `ui.database.type: sqlite`; `ui.persistence.*` → `ui.database.sqlite.persistence.*`; `ui.env.databaseUrl` → `ui.database.postgresql.databaseUrl`. Stale `ui.postgresql.*` / `ui.persistence.*` keys fail the install with a migration message.
 
 #### Customizing the UI deployment
 

--- a/charts/aerospike-ce-kubernetes-operator/templates/NOTES.txt
+++ b/charts/aerospike-ce-kubernetes-operator/templates/NOTES.txt
@@ -98,6 +98,22 @@ Ensure acko-crds is installed separately before creating AerospikeCluster resour
   helm install acko-crds oci://ghcr.io/aerospike-ce-ecosystem/charts/acko-crds --version {{ .Chart.Version }}
 {{- end }}
 
+NOTE: The embedded PostgreSQL sidecar has been REMOVED. The api now runs on
+SQLite (embedded file on a PVC, the default) or an EXTERNAL PostgreSQL that
+you operate — the chart no longer ships a `postgres` container.
+  Migration of values:
+    ui.postgresql.enabled: true   -> ui.database.type: postgresql
+                                     + ui.database.postgresql.databaseUrl
+                                       (point at an external PostgreSQL)
+    ui.postgresql.enabled: false  -> ui.database.type: sqlite   (default)
+    ui.persistence.*              -> ui.database.sqlite.persistence.*
+    ui.env.databaseUrl            -> ui.database.postgresql.databaseUrl
+  There is NO in-place data migration from the old embedded PostgreSQL PVC.
+  If you need to keep that data, `pg_dump` it before upgrading and restore
+  into your external database (or export/re-add connections from the UI).
+  Stale `ui.postgresql.*` / `ui.persistence.*` keys now fail the install
+  with an explanatory message.
+
 NOTE: 0.4.0 removes the redundant `ui.enabled` master switch. The
 per-component `ui.api.enabled` / `ui.web.enabled` toggles are now the
 only UI on/off controls.
@@ -310,10 +326,26 @@ Check UI pod status:
 View UI logs:
   kubectl logs -l app.kubernetes.io/name=aerospike-cluster-manager,app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }} -f
 
-{{- if and .Values.ui.persistence.enabled .Values.ui.postgresql.enabled }}
+{{- if eq (include "aerospike-ce-kubernetes-operator.ui.api.enabled" .) "true" }}
+{{- if eq .Values.ui.database.type "postgresql" }}
 
-Persistent storage is enabled ({{ .Values.ui.persistence.size }}).
-PostgreSQL data will persist across pod restarts.
+Database backend: PostgreSQL (external).
+The chart does NOT deploy PostgreSQL — the api connects to the database via
+{{ if .Values.ui.database.postgresql.existingSecret }}DATABASE_URL in Secret "{{ .Values.ui.database.postgresql.existingSecret }}"{{ else }}ui.database.postgresql.databaseUrl{{ end }}.
+{{- else }}
+
+Database backend: SQLite (embedded).
+{{- if .Values.ui.database.sqlite.persistence.enabled }}
+The SQLite database is persisted on a {{ .Values.ui.database.sqlite.persistence.size }} PVC
+and survives pod restarts. SQLite is single-writer — keep ui.replicaCount=1
+(use ui.database.type=postgresql with an external DB for HA / autoscaling).
+{{- else }}
+
+WARNING: ui.database.sqlite.persistence.enabled=false — the SQLite database
+lives on an emptyDir and ALL stored connections are lost on pod restart.
+Enable persistence for anything beyond a throwaway demo.
+{{- end }}
+{{- end }}
 {{- end }}
 {{- end }}
 

--- a/charts/aerospike-ce-kubernetes-operator/templates/NOTES.txt
+++ b/charts/aerospike-ce-kubernetes-operator/templates/NOTES.txt
@@ -108,10 +108,18 @@ you operate — the chart no longer ships a `postgres` container.
     ui.postgresql.enabled: false  -> ui.database.type: sqlite   (default)
     ui.persistence.*              -> ui.database.sqlite.persistence.*
     ui.env.databaseUrl            -> ui.database.postgresql.databaseUrl
-  There is NO in-place data migration from the old embedded PostgreSQL PVC.
-  If you need to keep that data, `pg_dump` it before upgrading and restore
-  into your external database (or export/re-add connections from the UI).
-  Stale `ui.postgresql.*` / `ui.persistence.*` keys now fail the install
+  There is NO automatic data migration from the old embedded PostgreSQL.
+  Any upgrade from an embedded-sidecar release is BLOCKED until you set
+  ui.database.acknowledgeEmbeddedPostgresRemoval=true — set it only AFTER
+  backing the data up:
+    1. kubectl exec deploy/<release>-...-ui-api -c postgres --
+         pg_dump -U aerospike -d aerospike_manager > acm-backup.sql
+    2. restore acm-backup.sql into your external PostgreSQL
+    3. helm upgrade ... --set ui.database.type=postgresql
+         --set ui.database.postgresql.databaseUrl=<url>
+         --set ui.database.acknowledgeEmbeddedPostgresRemoval=true
+  See the chart README 'Database' section for the full runbook.
+  Stale `ui.postgresql.*` / `ui.persistence.*` keys also fail the install
   with an explanatory message.
 
 NOTE: 0.4.0 removes the redundant `ui.enabled` master switch. The

--- a/charts/aerospike-ce-kubernetes-operator/templates/_helpers.tpl
+++ b/charts/aerospike-ce-kubernetes-operator/templates/_helpers.tpl
@@ -399,11 +399,15 @@ stale sidecar-era value keys and on invalid backend combinations.
 {{- if hasKey .Values.ui.env "databaseUrl" -}}
 {{- fail "ui.env.databaseUrl has moved to ui.database.postgresql.databaseUrl (and requires ui.database.type=postgresql)." -}}
 {{- end -}}
-{{- if eq (include "aerospike-ce-kubernetes-operator.ui.api.enabled" .) "true" -}}
+{{- /* The backend enum is validated unconditionally: configmap.yaml renders
+       ENABLE_POSTGRES from ui.database.type even in web-only installs, so a
+       typo must not slip through (it would silently fall back to SQLite). */ -}}
 {{- $type := .Values.ui.database.type -}}
 {{- if not (has $type (list "sqlite" "postgresql")) -}}
 {{- fail (printf "ui.database.type must be \"sqlite\" or \"postgresql\", got %q." $type) -}}
 {{- end -}}
+{{- /* The remaining checks only matter when the api Deployment is rendered. */ -}}
+{{- if eq (include "aerospike-ce-kubernetes-operator.ui.api.enabled" .) "true" -}}
 {{- if eq $type "postgresql" -}}
 {{- if and (not .Values.ui.database.postgresql.databaseUrl) (not .Values.ui.database.postgresql.existingSecret) -}}
 {{- fail "ui.database.type=postgresql requires either ui.database.postgresql.databaseUrl or ui.database.postgresql.existingSecret — the chart connects to an external PostgreSQL and never provisions one." -}}

--- a/charts/aerospike-ce-kubernetes-operator/templates/_helpers.tpl
+++ b/charts/aerospike-ce-kubernetes-operator/templates/_helpers.tpl
@@ -384,6 +384,38 @@ preconditions are not met, so the helper is safe to call unconditionally.
 {{- end }}
 
 {{/*
+Database backend validation.
+The embedded PostgreSQL sidecar was removed: the api now runs on an embedded
+SQLite file (default) or connects to an EXTERNAL PostgreSQL. Fail fast on
+stale sidecar-era value keys and on invalid backend combinations.
+*/}}
+{{- define "aerospike-ce-kubernetes-operator.validate.databaseConfig" -}}
+{{- if hasKey .Values.ui "postgresql" -}}
+{{- fail "ui.postgresql.* has been removed: the embedded PostgreSQL sidecar is no longer shipped. Set ui.database.type=sqlite (embedded, default) or ui.database.type=postgresql with ui.database.postgresql.databaseUrl / existingSecret pointing at an EXTERNAL database. See the chart README 'Database' section for the migration table." -}}
+{{- end -}}
+{{- if hasKey .Values.ui "persistence" -}}
+{{- fail "ui.persistence.* has been renamed: SQLite persistence now lives under ui.database.sqlite.persistence.*" -}}
+{{- end -}}
+{{- if hasKey .Values.ui.env "databaseUrl" -}}
+{{- fail "ui.env.databaseUrl has moved to ui.database.postgresql.databaseUrl (and requires ui.database.type=postgresql)." -}}
+{{- end -}}
+{{- if eq (include "aerospike-ce-kubernetes-operator.ui.api.enabled" .) "true" -}}
+{{- $type := .Values.ui.database.type -}}
+{{- if not (has $type (list "sqlite" "postgresql")) -}}
+{{- fail (printf "ui.database.type must be \"sqlite\" or \"postgresql\", got %q." $type) -}}
+{{- end -}}
+{{- if eq $type "postgresql" -}}
+{{- if and (not .Values.ui.database.postgresql.databaseUrl) (not .Values.ui.database.postgresql.existingSecret) -}}
+{{- fail "ui.database.type=postgresql requires either ui.database.postgresql.databaseUrl or ui.database.postgresql.existingSecret — the chart connects to an external PostgreSQL and never provisions one." -}}
+{{- end -}}
+{{- end -}}
+{{- if and (eq $type "sqlite") (gt (int .Values.ui.replicaCount) 1) -}}
+{{- fail "ui.database.type=sqlite is single-writer and is incompatible with ui.replicaCount > 1. Switch to ui.database.type=postgresql with an external database for multi-replica / HA deployments." -}}
+{{- end -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Aggregate validation entry-point. Templates can `include` this helper once
 (typically from NOTES.txt or a dedicated _validations partial) to enforce
 all gates uniformly.
@@ -395,4 +427,5 @@ all gates uniformly.
 {{- include "aerospike-ce-kubernetes-operator.validate.webOidcClientId" . -}}
 {{- include "aerospike-ce-kubernetes-operator.validate.caSecretName" . -}}
 {{- include "aerospike-ce-kubernetes-operator.validate.webhookTlsSource" . -}}
+{{- include "aerospike-ce-kubernetes-operator.validate.databaseConfig" . -}}
 {{- end }}

--- a/charts/aerospike-ce-kubernetes-operator/templates/_helpers.tpl
+++ b/charts/aerospike-ce-kubernetes-operator/templates/_helpers.tpl
@@ -406,6 +406,20 @@ stale sidecar-era value keys and on invalid backend combinations.
 {{- if not (has $type (list "sqlite" "postgresql")) -}}
 {{- fail (printf "ui.database.type must be \"sqlite\" or \"postgresql\", got %q." $type) -}}
 {{- end -}}
+{{- /* Upgrade safety: chart versions before this one ran an embedded PostgreSQL
+       sidecar whose database lived in the "<ui.fullname>-db" Secret (carrying a
+       POSTGRES_PASSWORD key) + "<ui.fullname>-data" PVC. That sidecar is gone
+       and there is NO automatic data migration. Detect the leftover
+       embedded-mode Secret and refuse the upgrade until the operator
+       acknowledges it (after backing the data up). `lookup` is empty on fresh
+       installs and on `helm template`, so this fires only on a real upgrade. */ -}}
+{{- if not .Values.ui.database.acknowledgeEmbeddedPostgresRemoval -}}
+{{- $dbSecretName := printf "%s-db" (include "aerospike-ce-kubernetes-operator.ui.fullname" .) -}}
+{{- $dbSecret := lookup "v1" "Secret" .Release.Namespace $dbSecretName -}}
+{{- if and $dbSecret (hasKey (default (dict) $dbSecret.data) "POSTGRES_PASSWORD") -}}
+{{- fail (printf "Upgrade blocked: Secret %q carries a POSTGRES_PASSWORD key, so this release previously ran the embedded PostgreSQL sidecar (removed in this chart version). Upgrading does NOT migrate that data -- with ui.database.type=sqlite the old database is stranded on the PVC, with type=postgresql the PVC is deleted. Back it up first (pg_dump the embedded database), restore it into your chosen backend, then re-run with ui.database.acknowledgeEmbeddedPostgresRemoval=true. See the chart README 'Database' migration section." $dbSecretName) -}}
+{{- end -}}
+{{- end -}}
 {{- /* The remaining checks only matter when the api Deployment is rendered. */ -}}
 {{- if eq (include "aerospike-ce-kubernetes-operator.ui.api.enabled" .) "true" -}}
 {{- if eq $type "postgresql" -}}

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/configmap.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/configmap.yaml
@@ -18,15 +18,22 @@ data:
   API_URL: {{ if .Values.ui.web.env.apiUrl }}{{ .Values.ui.web.env.apiUrl | quote }}{{ else }}{{ printf "http://%s:%d" (include "aerospike-ce-kubernetes-operator.ui.api.fullname" .) (int .Values.ui.api.service.port) | quote }}{{ end }}
   WEB_PORT: {{ .Values.ui.web.service.port | quote }}
   API_PORT: {{ .Values.ui.api.service.targetPort | quote }}
-  DB_POOL_SIZE: {{ .Values.ui.env.dbPoolSize | quote }}
-  DB_POOL_OVERFLOW: {{ .Values.ui.env.dbPoolOverflow | quote }}
-  DB_POOL_TIMEOUT: {{ .Values.ui.env.dbPoolTimeout | quote }}
   K8S_API_TIMEOUT: {{ .Values.ui.env.k8sApiTimeout | quote }}
   K8S_VERIFY_SSL: {{ .Values.ui.k8s.verifySsl | quote }}
   {{- with .Values.ui.k8s.caFile }}
   K8S_CA_FILE: {{ . | quote }}
   {{- end }}
-  ENABLE_POSTGRES: {{ .Values.ui.postgresql.enabled | quote }}
+  # Database backend. SQLite (embedded file on a PVC) is the default;
+  # PostgreSQL is external-only — DATABASE_URL is supplied via the api Secret.
+  {{- if eq .Values.ui.database.type "postgresql" }}
+  ENABLE_POSTGRES: "true"
+  DB_POOL_MIN_SIZE: {{ .Values.ui.database.postgresql.poolMinSize | quote }}
+  DB_POOL_MAX_SIZE: {{ .Values.ui.database.postgresql.poolMaxSize | quote }}
+  DB_COMMAND_TIMEOUT: {{ .Values.ui.database.postgresql.commandTimeout | quote }}
+  {{- else }}
+  ENABLE_POSTGRES: "false"
+  SQLITE_PATH: /app/data/connections.db
+  {{- end }}
   DEFAULT_AEROSPIKE_IMAGE: {{ .Values.aerospikeImages.aerospike | quote }}
   DEFAULT_EXPORTER_IMAGE: {{ .Values.aerospikeImages.exporter | quote }}
 {{- end }}

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/deployment-api.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/deployment-api.yaml
@@ -1,7 +1,6 @@
 {{- if eq (include "aerospike-ce-kubernetes-operator.ui.api.enabled" .) "true" }}
-{{- if and .Values.ui.autoscaling.enabled .Values.ui.postgresql.enabled }}
-{{- fail "ui.autoscaling.enabled and ui.postgresql.enabled cannot both be true. The embedded PostgreSQL sidecar is single-instance only. Disable ui.postgresql.enabled and provide ui.env.databaseUrl for an external database when using HPA." }}
-{{- end }}
+{{- /* ui.database.type=sqlite vs ui.replicaCount>1 is validated centrally in
+       the "...validate.databaseConfig" helper (rendered via NOTES.txt). */}}
 {{- if and .Values.ui.api.logging.sidecar.enabled (not .Values.ui.api.logging.fileMirror.enabled) }}
 {{- fail "ui.api.logging.sidecar.enabled=true requires ui.api.logging.fileMirror.enabled=true. Without the file mirror the sidecar has nothing to tail. Either enable fileMirror, or rely on a node-level OTel Collector DaemonSet scraping container logs instead." }}
 {{- end }}
@@ -47,7 +46,9 @@ spec:
   */}}
   replicas: {{ .Values.ui.replicaCount }}
   strategy:
-    {{- if .Values.ui.postgresql.enabled }}
+    {{- if eq .Values.ui.database.type "sqlite" }}
+    {{- /* SQLite lives on a single ReadWriteOnce PVC; a RollingUpdate would
+           briefly schedule a surge pod that cannot attach the volume. */}}
     type: Recreate
     {{- else }}
     type: RollingUpdate
@@ -122,8 +123,10 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ include "aerospike-ce-kubernetes-operator.ui.fullname" . }}-config
+            {{- if eq .Values.ui.database.type "postgresql" }}
             - secretRef:
-                name: {{ .Values.ui.postgresql.existingSecret | default (printf "%s-db" (include "aerospike-ce-kubernetes-operator.ui.fullname" .)) }}
+                name: {{ .Values.ui.database.postgresql.existingSecret | default (printf "%s-db" (include "aerospike-ce-kubernetes-operator.ui.fullname" .)) }}
+            {{- end }}
             {{- with .Values.ui.api.extraEnvFrom }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -215,8 +218,13 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if or .Values.ui.api.extraVolumeMounts .Values.ui.api.extraPipPackages .Values.ui.api.logging.fileMirror.enabled .Values.ui.api.logging.sidecar.enabled }}
+          {{- if or (eq .Values.ui.database.type "sqlite") .Values.ui.api.extraVolumeMounts .Values.ui.api.extraPipPackages .Values.ui.api.logging.fileMirror.enabled .Values.ui.api.logging.sidecar.enabled }}
           volumeMounts:
+            {{- if eq .Values.ui.database.type "sqlite" }}
+            {{- /* SQLite database file (SQLITE_PATH=/app/data/connections.db). */}}
+            - name: acm-data
+              mountPath: /app/data
+            {{- end }}
             {{- with .Values.ui.api.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -266,84 +274,11 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
         {{- end }}
-        {{- if .Values.ui.postgresql.enabled }}
-        - name: postgres
-          image: "{{ .Values.ui.postgresql.image.repository }}:{{ .Values.ui.postgresql.image.tag }}"
-          imagePullPolicy: {{ .Values.ui.postgresql.image.pullPolicy }}
-          ports:
-            - name: postgres
-              containerPort: 5432
-              protocol: TCP
-          env:
-            - name: POSTGRES_DB
-              value: {{ .Values.ui.postgresql.database | quote }}
-            - name: POSTGRES_USER
-              value: {{ .Values.ui.postgresql.username | quote }}
-            - name: POSTGRES_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.ui.postgresql.existingSecret | default (printf "%s-db" (include "aerospike-ce-kubernetes-operator.ui.fullname" .)) }}
-                  key: POSTGRES_PASSWORD
-            - name: PGDATA
-              value: /var/lib/postgresql/data/pgdata
-          readinessProbe:
-            exec:
-              command:
-                - pg_isready
-                - -U
-                - {{ .Values.ui.postgresql.username }}
-                - -d
-                - {{ .Values.ui.postgresql.database }}
-            initialDelaySeconds: 5
-            periodSeconds: 10
-            timeoutSeconds: 5
-          livenessProbe:
-            exec:
-              command:
-                - pg_isready
-                - -U
-                - {{ .Values.ui.postgresql.username }}
-                - -d
-                - {{ .Values.ui.postgresql.database }}
-            initialDelaySeconds: 15
-            periodSeconds: 20
-            timeoutSeconds: 5
-          startupProbe:
-            exec:
-              command:
-                - pg_isready
-                - -U
-                - {{ .Values.ui.postgresql.username }}
-                - -d
-                - {{ .Values.ui.postgresql.database }}
-            periodSeconds: 5
-            timeoutSeconds: 3
-            failureThreshold: 20
-          securityContext:
-            runAsUser: 70
-            runAsGroup: 70
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
-              add:
-                - CHOWN
-                - FOWNER
-                - SETGID
-                - SETUID
-          {{- with .Values.ui.postgresql.resources }}
-          resources:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          volumeMounts:
-            - name: data
-              mountPath: /var/lib/postgresql/data
-        {{- end }}
-      {{- if or .Values.ui.postgresql.enabled .Values.ui.api.extraVolumes .Values.ui.api.extraPipPackages .Values.ui.api.logging.fileMirror.enabled .Values.ui.api.logging.sidecar.enabled }}
+      {{- if or (eq .Values.ui.database.type "sqlite") .Values.ui.api.extraVolumes .Values.ui.api.extraPipPackages .Values.ui.api.logging.fileMirror.enabled .Values.ui.api.logging.sidecar.enabled }}
       volumes:
-        {{- if .Values.ui.postgresql.enabled }}
-        - name: data
-          {{- if .Values.ui.persistence.enabled }}
+        {{- if eq .Values.ui.database.type "sqlite" }}
+        - name: acm-data
+          {{- if .Values.ui.database.sqlite.persistence.enabled }}
           persistentVolumeClaim:
             claimName: {{ include "aerospike-ce-kubernetes-operator.ui.fullname" . }}-data
           {{- else }}

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/networkpolicy.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/networkpolicy.yaml
@@ -52,7 +52,7 @@ spec:
           protocol: TCP
         - port: {{ .Values.ui.aerospikePorts.heartbeat }}
           protocol: TCP
-    {{- if not .Values.ui.postgresql.enabled }}
+    {{- if eq .Values.ui.database.type "postgresql" }}
     # External PostgreSQL
     - ports:
         - port: 5432

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/pvc.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/pvc.yaml
@@ -1,4 +1,11 @@
-{{- if and (eq (include "aerospike-ce-kubernetes-operator.ui.api.enabled" .) "true") .Values.ui.persistence.enabled .Values.ui.postgresql.enabled }}
+{{- /*
+PersistentVolumeClaim for the embedded SQLite database.
+
+Rendered only when ui.database.type=sqlite and persistence is enabled. The
+api container mounts this at /app/data (SQLITE_PATH=/app/data/connections.db).
+The PostgreSQL backend is external-only and provisions no storage here.
+*/}}
+{{- if and (eq (include "aerospike-ce-kubernetes-operator.ui.api.enabled" .) "true") (eq .Values.ui.database.type "sqlite") .Values.ui.database.sqlite.persistence.enabled }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -8,11 +15,11 @@ metadata:
     {{- include "aerospike-ce-kubernetes-operator.ui.labels" . | nindent 4 }}
 spec:
   accessModes:
-    - {{ .Values.ui.persistence.accessMode }}
-  {{- if not (kindIs "invalid" .Values.ui.persistence.storageClassName) }}
-  storageClassName: {{ .Values.ui.persistence.storageClassName | quote }}
+    - {{ .Values.ui.database.sqlite.persistence.accessMode }}
+  {{- if not (kindIs "invalid" .Values.ui.database.sqlite.persistence.storageClassName) }}
+  storageClassName: {{ .Values.ui.database.sqlite.persistence.storageClassName | quote }}
   {{- end }}
   resources:
     requests:
-      storage: {{ .Values.ui.persistence.size }}
+      storage: {{ .Values.ui.database.sqlite.persistence.size }}
 {{- end }}

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/secret.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/secret.yaml
@@ -1,42 +1,26 @@
-{{- if and (eq (include "aerospike-ce-kubernetes-operator.ui.api.enabled" .) "true") (not .Values.ui.postgresql.existingSecret) }}
 {{- /*
-Resolve the embedded PostgreSQL password.
-Precedence:
-  1. Existing Secret on the cluster — preserved across upgrades so we never
-     rotate the password underneath a running database (which would lock the
-     API out of its own data).
-  2. User-supplied .Values.ui.postgresql.password (explicit override).
-  3. Auto-generated 24-char alphanumeric password on first install.
-The previous default of "aerospike" was a well-known credential and has been
-removed; values.yaml now ships an empty password to trigger auto-generation.
+DATABASE_URL Secret for the external PostgreSQL backend.
+
+Rendered only when ui.database.type=postgresql AND the operator did not
+bring their own Secret via ui.database.postgresql.existingSecret. The chart
+never provisions PostgreSQL itself — this Secret simply carries the
+connection URL of an external instance into the api container's environment.
+
+For the default SQLite backend no Secret is needed (the database is a local
+file on a PVC), so nothing is rendered.
+
+Backend / value validation (databaseUrl-or-existingSecret presence) lives in
+the "...validate.databaseConfig" helper so the failure message is uniform.
 */}}
-{{- $secretName := printf "%s-db" (include "aerospike-ce-kubernetes-operator.ui.fullname" .) -}}
-{{- $existing := lookup "v1" "Secret" .Release.Namespace $secretName -}}
-{{- $password := "" -}}
-{{- if and $existing (index (default (dict) $existing.data) "POSTGRES_PASSWORD") -}}
-{{-   $password = index $existing.data "POSTGRES_PASSWORD" | b64dec -}}
-{{- else if .Values.ui.postgresql.password -}}
-{{-   $password = .Values.ui.postgresql.password -}}
-{{- else -}}
-{{-   $password = randAlphaNum 24 -}}
-{{- end -}}
+{{- if and (eq (include "aerospike-ce-kubernetes-operator.ui.api.enabled" .) "true") (eq .Values.ui.database.type "postgresql") (not .Values.ui.database.postgresql.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ $secretName }}
+  name: {{ printf "%s-db" (include "aerospike-ce-kubernetes-operator.ui.fullname" .) }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "aerospike-ce-kubernetes-operator.ui.labels" . | nindent 4 }}
 type: Opaque
 stringData:
-  {{- if .Values.ui.postgresql.enabled }}
-  POSTGRES_PASSWORD: {{ $password | quote }}
-  DATABASE_URL: {{ printf "postgresql://%s:%s@localhost:5432/%s" (.Values.ui.postgresql.username | urlquery) ($password | urlquery) .Values.ui.postgresql.database | quote }}
-  {{- else }}
-  {{- if .Values.ui.env.databaseUrl }}
-  DATABASE_URL: {{ .Values.ui.env.databaseUrl | quote }}
-  {{- else }}
-  {{- fail "ui.postgresql.enabled is false but ui.env.databaseUrl is not set. Provide an external database URL via ui.env.databaseUrl or set ui.postgresql.existingSecret." }}
-  {{- end }}
-  {{- end }}
+  DATABASE_URL: {{ required "ui.database.type=postgresql requires ui.database.postgresql.databaseUrl (or ui.database.postgresql.existingSecret)." .Values.ui.database.postgresql.databaseUrl | quote }}
 {{- end }}

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/secret.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/secret.yaml
@@ -22,5 +22,7 @@ metadata:
     {{- include "aerospike-ce-kubernetes-operator.ui.labels" . | nindent 4 }}
 type: Opaque
 stringData:
-  DATABASE_URL: {{ required "ui.database.type=postgresql requires ui.database.postgresql.databaseUrl (or ui.database.postgresql.existingSecret)." .Values.ui.database.postgresql.databaseUrl | quote }}
+  {{- /* databaseUrl presence is enforced by validate.databaseConfig (rendered
+         via NOTES.txt) so the failure message stays uniform across the chart. */}}
+  DATABASE_URL: {{ .Values.ui.database.postgresql.databaseUrl | quote }}
 {{- end }}

--- a/charts/aerospike-ce-kubernetes-operator/values-common.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/values-common.yaml
@@ -74,11 +74,8 @@ ui:
         paths:
           - path: /
             pathType: Prefix
-  # Persistent Postgres / DB sidecar belongs on the api side, not on common.
-  postgresql:
-    enabled: false
-  persistence:
-    enabled: false
+  # The common cluster is web-only (ui.api.enabled=false) — no database is
+  # provisioned, so the ui.database.* defaults are left untouched here.
   k8s:
     # Web-only cluster has no in-cluster ACKO operator to talk to.
     enabled: false

--- a/charts/aerospike-ce-kubernetes-operator/values.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/values.yaml
@@ -332,10 +332,10 @@ podLabels: {}
 #                                            |
 #                                     [AerospikeCluster Pods]
 #
-# The UI requires a PostgreSQL database for storing session and configuration data.
-# By default, an embedded PostgreSQL sidecar is deployed. For production, consider
-# using an external PostgreSQL instance (set ui.postgresql.enabled=false and
-# provide ui.env.databaseUrl).
+# The UI api persists connection metadata in a database. The default backend is
+# an embedded SQLite file on a PVC; for HA / multi-replica, point it at an
+# external PostgreSQL instance (set ui.database.type=postgresql and provide
+# ui.database.postgresql.databaseUrl). The chart never deploys PostgreSQL itself.
 # =============================================================================
 ui:
   # -- Aerospike Cluster Manager web UI deployment toggles.
@@ -769,64 +769,58 @@ ui:
     tls: []
 
   # =============================================================================
-  # PostgreSQL (Embedded Sidecar)
+  # Database
   # =============================================================================
-  # The UI api requires a PostgreSQL database for storing cluster connection
-  # metadata and session data. By default, a PostgreSQL container runs as a
-  # sidecar in the same pod. For production deployments, disable this sidecar
-  # and point ui.env.databaseUrl to a managed PostgreSQL instance (e.g., RDS,
-  # Cloud SQL, AlloyDB).
-  # NOTE: The embedded sidecar is single-instance only and incompatible with HPA.
+  # The UI api persists cluster connection metadata, workspaces, and notes.
+  # Two backends are supported:
+  #
+  #   sqlite (default) — an embedded SQLite file inside the api container,
+  #     persisted on a PersistentVolumeClaim. Zero extra infrastructure.
+  #     SQLite is single-writer: keep ui.replicaCount=1 (the chart fails the
+  #     install otherwise). Best for single-instance / small deployments.
+  #
+  #   postgresql — an EXTERNAL PostgreSQL instance that you operate (managed
+  #     services such as RDS / Cloud SQL / AlloyDB, an in-cluster PostgreSQL
+  #     operator, etc.). Required for HA / multi-replica. This chart never
+  #     deploys PostgreSQL itself — there is no embedded sidecar.
   # =============================================================================
-  postgresql:
-    # -- Deploy an embedded PostgreSQL sidecar container.
-    # Disable this and set env.databaseUrl to use an external PostgreSQL instance.
-    enabled: true
-    # -- PostgreSQL container image
-    image:
-      repository: postgres
-      tag: "17-alpine"
-      pullPolicy: IfNotPresent
-    # -- Database name
-    database: aerospike_manager
-    # -- Database user
-    username: aerospike
-    # -- Database password (used for embedded sidecar only).
-    # When empty (default), the chart auto-generates a 24-character random
-    # password on first install via Helm's `lookup` + `randAlphaNum`. The
-    # generated value is preserved across `helm upgrade` by re-reading the
-    # existing Secret, so the password remains stable for the life of the
-    # release. To override, set this to your own value or supply a complete
-    # Secret via `ui.postgresql.existingSecret`. The previous default of
-    # "aerospike" was a well-known credential and is no longer shipped.
-    password: ""
-    # -- Use an existing Secret instead of creating one.
-    # The Secret must contain POSTGRES_PASSWORD and DATABASE_URL keys.
-    existingSecret: ""
-    # -- Resource requests and limits for the PostgreSQL sidecar
-    resources:
-      requests:
-        cpu: 50m
-        memory: 128Mi
-      limits:
-        cpu: 250m
-        memory: 256Mi
+  database:
+    # -- Database backend: "sqlite" (embedded, default) or "postgresql" (external).
+    type: sqlite
 
-  # =============================================================================
-  # Persistence (PostgreSQL data)
-  # =============================================================================
-  persistence:
-    # -- Enable persistent storage for the embedded PostgreSQL database
-    enabled: true
-    # -- Storage class name for the PostgreSQL PVC.
-    # null  = use cluster default StorageClass
-    # ""    = disable dynamic provisioning (use pre-provisioned PV)
-    # "name" = use the specified StorageClass (e.g., "rbd-ssd-user", "gp3")
-    storageClassName: null
-    # -- Access mode
-    accessMode: ReadWriteOnce
-    # -- Volume size
-    size: 1Gi
+    # -- SQLite backend settings. Used only when database.type=sqlite.
+    sqlite:
+      persistence:
+        # -- Persist the SQLite database file on a PersistentVolumeClaim.
+        # When false an emptyDir is used and every stored connection is lost
+        # on pod restart — acceptable only for throwaway demos.
+        enabled: true
+        # -- Storage class name for the SQLite PVC.
+        # null  = use cluster default StorageClass
+        # ""    = disable dynamic provisioning (use pre-provisioned PV)
+        # "name" = use the specified StorageClass (e.g., "rbd-ssd-user", "gp3")
+        storageClassName: null
+        # -- Access mode. SQLite is single-writer; keep ReadWriteOnce.
+        accessMode: ReadWriteOnce
+        # -- Volume size
+        size: 1Gi
+
+    # -- PostgreSQL backend settings. Used only when database.type=postgresql.
+    # The chart connects to an external database; it does not provision one.
+    postgresql:
+      # -- Full connection URL of the external PostgreSQL instance.
+      # Example: "postgresql://user:pass@db-host:5432/aerospike_manager"
+      # Leave empty and set existingSecret to keep credentials out of values.
+      databaseUrl: ""
+      # -- Use an existing Secret instead of databaseUrl.
+      # The Secret must contain a DATABASE_URL key.
+      existingSecret: ""
+      # -- Connection pool minimum size (DB_POOL_MIN_SIZE)
+      poolMinSize: 2
+      # -- Connection pool maximum size (DB_POOL_MAX_SIZE)
+      poolMaxSize: 10
+      # -- SQL command execution timeout in seconds (DB_COMMAND_TIMEOUT)
+      commandTimeout: 30
 
   # =============================================================================
   # K8s Cluster Management
@@ -873,16 +867,6 @@ ui:
     logLevel: "INFO"
     # -- Log format: "text" for human-readable output, "json" for structured logging
     logFormat: "text"
-    # -- External PostgreSQL connection URL.
-    # Only used when postgresql.enabled is false.
-    # Example: "postgresql://user:pass@db-host:5432/aerospike_manager"
-    databaseUrl: ""
-    # -- DB connection pool size
-    dbPoolSize: 5
-    # -- Max overflow connections beyond pool size
-    dbPoolOverflow: 10
-    # -- Pool checkout timeout in seconds
-    dbPoolTimeout: 30
     # -- Kubernetes API request timeout in seconds
     k8sApiTimeout: 30
 

--- a/charts/aerospike-ce-kubernetes-operator/values.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/values.yaml
@@ -790,6 +790,15 @@ ui:
     # -- Database backend: "sqlite" (embedded, default) or "postgresql" (external).
     type: sqlite
 
+    # -- Upgrade-safety gate. Chart versions before the embedded PostgreSQL
+    # sidecar was removed stored data in an in-pod PostgreSQL. Upgrading does
+    # NOT migrate that data automatically: with type=sqlite the old database is
+    # stranded on the volume, with type=postgresql its PVC is deleted. When the
+    # chart detects a leftover embedded-mode Secret it BLOCKS the upgrade until
+    # this is set to true — set it only AFTER backing the data up (see the
+    # chart README "Database" migration section). No effect on fresh installs.
+    acknowledgeEmbeddedPostgresRemoval: false
+
     # -- SQLite backend settings. Used only when database.type=sqlite.
     sqlite:
       persistence:

--- a/docs/content/getting-started/cluster-manager-ui.md
+++ b/docs/content/getting-started/cluster-manager-ui.md
@@ -536,22 +536,23 @@ After modifying a template, existing clusters that reference it are not automati
 | `ui.service.backendPort` | Backend (FastAPI) port | `8000` |
 | `ui.service.annotations` | Service annotations (cloud LB configuration, etc.) | `{}` |
 | `ui.ingress.enabled` | Create Ingress | `false` |
-| `ui.persistence.enabled` | Use PostgreSQL PVC | `true` |
-| `ui.persistence.size` | PVC storage size | `1Gi` |
 | `ui.k8s.enabled` | K8s cluster management feature | `true` |
 | `ui.rbac.create` | Auto-create ClusterRole/Binding (includes permissions for AerospikeCluster, Template, and HPA management) | `true` |
 | `ui.resources.requests.cpu` | UI container CPU request | `100m` |
 | `ui.resources.requests.memory` | UI container memory request | `256Mi` |
 | `ui.resources.limits.cpu` | UI container CPU limit | `200m` |
 | `ui.resources.limits.memory` | UI container memory limit | `512Mi` |
-| `ui.postgresql.enabled` | Deploy embedded PostgreSQL sidecar | `true` |
-| `ui.env.databaseUrl` | External PostgreSQL URL (when `postgresql.enabled=false`) | `""` |
+| `ui.database.type` | Database backend: `sqlite` (embedded, default) or `postgresql` (external) | `sqlite` |
+| `ui.database.sqlite.persistence.enabled` | Persist the SQLite database file on a PVC | `true` |
+| `ui.database.sqlite.persistence.size` | SQLite PVC storage size | `1Gi` |
+| `ui.database.postgresql.databaseUrl` | External PostgreSQL connection URL (when `type=postgresql`) | `""` |
+| `ui.database.postgresql.existingSecret` | Existing Secret with a `DATABASE_URL` key (alternative to `databaseUrl`) | `""` |
 | `ui.env.corsOrigins` | Backend CORS origins (empty string = disable CORS; frontend proxies via Next.js rewrites) | `""` |
 | `ui.env.logLevel` | Log level (`DEBUG`, `INFO`, `WARNING`, `ERROR`) | `"INFO"` |
 | `ui.env.logFormat` | Log format: `"text"` (human-readable), `"json"` (structured logging) | `"text"` |
-| `ui.env.dbPoolSize` | DB connection pool size | `5` |
-| `ui.env.dbPoolOverflow` | Maximum additional connections when pool is full | `10` |
-| `ui.env.dbPoolTimeout` | Timeout for acquiring a connection from the pool (seconds) | `30` |
+| `ui.database.postgresql.poolMinSize` | PostgreSQL connection pool minimum size (when `type=postgresql`) | `2` |
+| `ui.database.postgresql.poolMaxSize` | PostgreSQL connection pool maximum size (when `type=postgresql`) | `10` |
+| `ui.database.postgresql.commandTimeout` | PostgreSQL SQL command timeout in seconds (when `type=postgresql`) | `30` |
 | `ui.env.k8sApiTimeout` | Kubernetes API request timeout (seconds) | `30` |
 | `ui.extraEnv` | Additional environment variables for the UI container | `[]` |
 | `ui.metrics.serviceMonitor.enabled` | Create ServiceMonitor for UI backend metrics | `false` |
@@ -573,24 +574,25 @@ You can tune the UI backend's environment variables via Helm values. These setti
 
 ### Database Connection Pool
 
-Tune the connection pool for the embedded PostgreSQL sidecar or an external PostgreSQL instance:
+When `ui.database.type=postgresql`, tune the connection pool for the external
+PostgreSQL instance. These settings have no effect on the default SQLite backend:
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| `ui.env.dbPoolSize` | `5` | Base connection pool size. Adjust to match the number of concurrent requests. |
-| `ui.env.dbPoolOverflow` | `10` | Maximum additional connections that can be created when the pool is full. Useful for handling traffic spikes. |
-| `ui.env.dbPoolTimeout` | `30` | Maximum time (seconds) to wait for an idle connection from the pool. Returns an error if the timeout is exceeded. |
+| `ui.database.postgresql.poolMinSize` | `2` | Minimum number of connections kept open in the pool (`DB_POOL_MIN_SIZE`). |
+| `ui.database.postgresql.poolMaxSize` | `10` | Maximum number of connections the pool may open (`DB_POOL_MAX_SIZE`). Useful for handling traffic spikes. |
+| `ui.database.postgresql.commandTimeout` | `30` | Maximum time (seconds) a single SQL command may run before timing out (`DB_COMMAND_TIMEOUT`). |
 
 ```bash
 helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kubernetes-operator \
   --namespace aerospike-operator --create-namespace \
-  --set ui.env.dbPoolSize=10 \
-  --set ui.env.dbPoolOverflow=20 \
-  --set ui.env.dbPoolTimeout=60
+  --set ui.database.type=postgresql \
+  --set ui.database.postgresql.databaseUrl='postgresql://user:pass@db-host:5432/aerospike_manager' \
+  --set ui.database.postgresql.poolMaxSize=20
 ```
 
 :::tip
-In environments with many concurrent users, increase `dbPoolSize`. A good rule of thumb is to set `dbPoolSize` close to the expected number of concurrent requests and `dbPoolOverflow` to roughly double that.
+In environments with many concurrent users, increase `poolMaxSize`. A good rule of thumb is to set `poolMaxSize` close to the expected number of concurrent requests.
 :::
 
 ### Kubernetes API Timeout

--- a/docs/content/getting-started/cluster-manager-ui.md
+++ b/docs/content/getting-started/cluster-manager-ui.md
@@ -522,6 +522,48 @@ After modifying a template, existing clusters that reference it are not automati
 
 ---
 
+## Database backend
+
+The api persists cluster connection metadata, workspaces, and notes in a
+database. The backend is selected with `ui.database.type`:
+
+- **`sqlite`** (default) — an embedded SQLite file inside the api container,
+  persisted on a PersistentVolumeClaim. No extra infrastructure. SQLite is
+  single-writer, so `ui.replicaCount` must stay `1` (the chart fails the
+  install otherwise).
+- **`postgresql`** — connects to an **external** PostgreSQL instance you
+  operate (RDS, Cloud SQL, AlloyDB, an in-cluster PostgreSQL operator, …).
+  Required for HA / multi-replica. The chart never deploys PostgreSQL itself.
+
+To use an external PostgreSQL, supply the connection URL:
+
+```bash
+helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kubernetes-operator \
+  --namespace aerospike-operator --create-namespace \
+  --set ui.database.type=postgresql \
+  --set ui.database.postgresql.databaseUrl="postgresql://user:pass@db-host:5432/aerospike_manager"
+```
+
+:::tip
+To keep credentials out of values, set `ui.database.postgresql.existingSecret`
+to an existing Kubernetes Secret name. The Secret must contain a `DATABASE_URL` key.
+:::
+
+:::warning
+The embedded PostgreSQL sidecar has been **removed**. Stale `ui.postgresql.*` /
+`ui.persistence.*` keys fail the install with a migration message. Map
+`ui.postgresql.enabled: true` → `ui.database.type: postgresql` +
+`ui.database.postgresql.databaseUrl`, `ui.postgresql.enabled: false` →
+`ui.database.type: sqlite`, and `ui.persistence.*` →
+`ui.database.sqlite.persistence.*`. There is no automatic data migration —
+any upgrade from an embedded-sidecar release is blocked until
+`ui.database.acknowledgeEmbeddedPostgresRemoval=true`. See the chart README
+section "Migrating off the embedded PostgreSQL sidecar" for the `pg_dump` →
+restore → upgrade runbook.
+:::
+
+---
+
 ## Configuration Options
 
 | Parameter | Description | Default |

--- a/docs/content/reference/helm-values.md
+++ b/docs/content/reference/helm-values.md
@@ -212,6 +212,7 @@ sidecar of earlier chart versions has been removed.
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `ui.database.type` | string | `sqlite` | Database backend: `sqlite` (embedded file on a PVC) or `postgresql` (external instance). |
+| `ui.database.acknowledgeEmbeddedPostgresRemoval` | bool | `false` | Upgrade-safety gate. The chart blocks any upgrade from a release that still carries the embedded-PostgreSQL Secret until this is `true`. Set it only after backing the embedded database up (see the migration note below). No effect on fresh installs. |
 | `ui.database.sqlite.persistence.enabled` | bool | `true` | Persist the SQLite database file on a PVC. When `false`, an `emptyDir` is used and stored connections are lost on pod restart. |
 | `ui.database.sqlite.persistence.storageClassName` | string | `null` | Storage class. `null` = cluster default StorageClass, `""` = pre-provisioned PV, `"name"` = specified StorageClass. |
 | `ui.database.sqlite.persistence.accessMode` | string | `ReadWriteOnce` | PVC access mode. SQLite is single-writer; keep `ReadWriteOnce`. |
@@ -231,13 +232,16 @@ services such as RDS / Cloud SQL / AlloyDB, or an in-cluster PostgreSQL
 operator). Required for HA / multi-replica deployments.
 
 > **Migration:** stale `ui.postgresql.*` and `ui.persistence.*` keys from the
-> embedded-sidecar era now fail the install with a migration message. Map
+> embedded-sidecar era fail the install with a migration message. Map
 > `ui.postgresql.enabled: true` → `ui.database.type: postgresql` +
 > `ui.database.postgresql.databaseUrl`, `ui.postgresql.enabled: false` →
 > `ui.database.type: sqlite`, `ui.persistence.*` →
 > `ui.database.sqlite.persistence.*`, and `ui.env.databaseUrl` →
-> `ui.database.postgresql.databaseUrl`. There is no in-place data migration
-> from the old embedded PostgreSQL PVC.
+> `ui.database.postgresql.databaseUrl`. There is no automatic data migration
+> from the old embedded PostgreSQL — any upgrade from an embedded-sidecar
+> release is blocked until `ui.database.acknowledgeEmbeddedPostgresRemoval=true`.
+> See the chart README "Migrating off the embedded PostgreSQL sidecar" for the
+> `pg_dump` → restore → upgrade runbook.
 
 ### Deployment Strategy & Graceful Shutdown
 

--- a/docs/content/reference/helm-values.md
+++ b/docs/content/reference/helm-values.md
@@ -202,40 +202,49 @@ When `ui.rbac.create=true`, the generated ClusterRole includes the following per
 | `ui.ingress.hosts` | list | See values.yaml | Ingress host rules. |
 | `ui.ingress.tls` | list | `[]` | Ingress TLS configuration. |
 
-### PostgreSQL (Embedded Sidecar)
+### Database
+
+The api persists cluster connection metadata in a database. The backend is
+selected by `ui.database.type` — `sqlite` (embedded, default) or `postgresql`
+(external). The chart never deploys PostgreSQL itself; the embedded PostgreSQL
+sidecar of earlier chart versions has been removed.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `ui.postgresql.enabled` | bool | `true` | Deploy an embedded PostgreSQL sidecar container. Disable to use an external PostgreSQL instance. |
-| `ui.postgresql.image.repository` | string | `postgres` | PostgreSQL container image. |
-| `ui.postgresql.image.tag` | string | `"17-alpine"` | PostgreSQL image tag. |
-| `ui.postgresql.image.pullPolicy` | string | `IfNotPresent` | Image pull policy. |
-| `ui.postgresql.database` | string | `aerospike_manager` | Database name. |
-| `ui.postgresql.username` | string | `aerospike` | Database user. |
-| `ui.postgresql.password` | string | `aerospike` | Database password (embedded sidecar only). |
-| `ui.postgresql.existingSecret` | string | `""` | Existing Secret name containing `POSTGRES_PASSWORD` and `DATABASE_URL` keys. |
-| `ui.postgresql.resources.requests.cpu` | string | `50m` | CPU request. |
-| `ui.postgresql.resources.requests.memory` | string | `128Mi` | Memory request. |
-| `ui.postgresql.resources.limits.cpu` | string | `250m` | CPU limit. |
-| `ui.postgresql.resources.limits.memory` | string | `256Mi` | Memory limit. |
+| `ui.database.type` | string | `sqlite` | Database backend: `sqlite` (embedded file on a PVC) or `postgresql` (external instance). |
+| `ui.database.sqlite.persistence.enabled` | bool | `true` | Persist the SQLite database file on a PVC. When `false`, an `emptyDir` is used and stored connections are lost on pod restart. |
+| `ui.database.sqlite.persistence.storageClassName` | string | `null` | Storage class. `null` = cluster default StorageClass, `""` = pre-provisioned PV, `"name"` = specified StorageClass. |
+| `ui.database.sqlite.persistence.accessMode` | string | `ReadWriteOnce` | PVC access mode. SQLite is single-writer; keep `ReadWriteOnce`. |
+| `ui.database.sqlite.persistence.size` | string | `1Gi` | SQLite PVC volume size. |
+| `ui.database.postgresql.databaseUrl` | string | `""` | Connection URL of the external PostgreSQL instance. Required (or `existingSecret`) when `type=postgresql`. |
+| `ui.database.postgresql.existingSecret` | string | `""` | Existing Secret name containing a `DATABASE_URL` key. Use instead of `databaseUrl` to keep credentials out of values. |
+| `ui.database.postgresql.poolMinSize` | int | `2` | Connection pool minimum size (`DB_POOL_MIN_SIZE`). |
+| `ui.database.postgresql.poolMaxSize` | int | `10` | Connection pool maximum size (`DB_POOL_MAX_SIZE`). |
+| `ui.database.postgresql.commandTimeout` | int | `30` | SQL command execution timeout in seconds (`DB_COMMAND_TIMEOUT`). |
 
-The embedded PostgreSQL sidecar includes a **startup probe** that runs `pg_isready` to verify database readiness before the UI container begins accepting traffic. This prevents the backend from attempting database connections before PostgreSQL has finished initialization.
+**SQLite (default)** stores data in a single file inside the api container,
+backed by a PersistentVolumeClaim. It is single-writer, so `ui.replicaCount`
+must stay `1` — the chart fails the install otherwise.
 
-### Persistence
+**PostgreSQL** mode connects to an external database that you operate (managed
+services such as RDS / Cloud SQL / AlloyDB, or an in-cluster PostgreSQL
+operator). Required for HA / multi-replica deployments.
 
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| `ui.persistence.enabled` | bool | `true` | Enable persistent storage for the embedded PostgreSQL database. |
-| `ui.persistence.storageClassName` | string | `null` | Storage class name. `null` = use cluster default StorageClass, `""` = disable dynamic provisioning, `"name"` = use specified StorageClass. |
-| `ui.persistence.accessMode` | string | `ReadWriteOnce` | Access mode. |
-| `ui.persistence.size` | string | `1Gi` | Volume size. |
+> **Migration:** stale `ui.postgresql.*` and `ui.persistence.*` keys from the
+> embedded-sidecar era now fail the install with a migration message. Map
+> `ui.postgresql.enabled: true` → `ui.database.type: postgresql` +
+> `ui.database.postgresql.databaseUrl`, `ui.postgresql.enabled: false` →
+> `ui.database.type: sqlite`, `ui.persistence.*` →
+> `ui.database.sqlite.persistence.*`, and `ui.env.databaseUrl` →
+> `ui.database.postgresql.databaseUrl`. There is no in-place data migration
+> from the old embedded PostgreSQL PVC.
 
 ### Deployment Strategy & Graceful Shutdown
 
-The UI Deployment uses an explicit update strategy based on the PostgreSQL configuration:
+The api Deployment uses an explicit update strategy based on the database backend:
 
-- **With embedded PostgreSQL** (`ui.postgresql.enabled=true`): Uses `Recreate` strategy because the PVC can only be mounted by one pod at a time.
-- **Without embedded PostgreSQL** (`ui.postgresql.enabled=false`): Uses `RollingUpdate` strategy with `maxSurge: 1` and `maxUnavailable: 0` for zero-downtime deployments.
+- **SQLite** (`ui.database.type=sqlite`): Uses `Recreate` strategy — the SQLite PVC is `ReadWriteOnce` and can only be mounted by one pod at a time.
+- **PostgreSQL** (`ui.database.type=postgresql`): Uses `RollingUpdate` strategy with `maxSurge: 1` and `maxUnavailable: 0` for zero-downtime deployments.
 
 The UI container includes a **preStop lifecycle hook** (`sleep 5`) to allow in-flight requests to complete before the pod is terminated. Combined with `terminationGracePeriodSeconds` (default: 45), this ensures graceful shutdown during rollouts and node drains.
 
@@ -296,10 +305,6 @@ The UI container includes a **preStop lifecycle hook** (`sleep 5`) to allow in-f
 | `ui.env.corsOrigins` | string | `""` | Backend CORS origins. Empty means no CORS (frontend proxies via Next.js rewrites). |
 | `ui.env.logLevel` | string | `"INFO"` | Log level: `DEBUG`, `INFO`, `WARNING`, `ERROR`. |
 | `ui.env.logFormat` | string | `"text"` | Log format: `text` for human-readable, `json` for structured logging. |
-| `ui.env.databaseUrl` | string | `""` | External PostgreSQL connection URL. Only used when `postgresql.enabled` is `false`. |
-| `ui.env.dbPoolSize` | int | `5` | DB connection pool size. |
-| `ui.env.dbPoolOverflow` | int | `10` | Max overflow connections beyond pool size. |
-| `ui.env.dbPoolTimeout` | int | `30` | Pool checkout timeout in seconds. |
 | `ui.env.k8sApiTimeout` | int | `30` | Kubernetes API request timeout in seconds. |
 
 ### UI Monitoring

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/getting-started/cluster-manager-ui.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/getting-started/cluster-manager-ui.md
@@ -7,7 +7,7 @@ title: 클러스터 매니저 UI
 
 [Aerospike Cluster Manager](https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager)는 Aerospike CE 클러스터를 관리하기 위한 웹 기반 GUI입니다. 오퍼레이터 Helm 차트에 번들로 포함되어 있으며, 오퍼레이터와 함께 선택적 컴포넌트로 배포할 수 있습니다.
 
-UI에는 클러스터 연결 프로파일을 저장하기 위한 PostgreSQL 사이드카(PVC 포함)가 내장되어 있습니다.
+UI는 클러스터 연결 프로파일을 데이터베이스에 저장합니다. 기본 백엔드는 api 컨테이너에 내장된 SQLite 파일(PVC에 영속 저장)이며, HA·다중 레플리카가 필요하면 외부 PostgreSQL 인스턴스를 사용할 수 있습니다. 차트는 PostgreSQL을 직접 배포하지 않습니다.
 
 ---
 
@@ -81,12 +81,14 @@ helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kuber
 | `ui.service.type` | 서비스 타입 (`ClusterIP`, `NodePort`, `LoadBalancer`) | `ClusterIP` |
 | `ui.service.frontendPort` | 프론트엔드 (Next.js) 포트 | `3000` |
 | `ui.service.backendPort` | 백엔드 (FastAPI) 포트 | `8000` |
-| `ui.postgresql.enabled` | 내장 PostgreSQL 사이드카 배포 | `true` |
+| `ui.database.type` | 데이터베이스 백엔드: `sqlite`(내장, 기본값) 또는 `postgresql`(외부) | `sqlite` |
+| `ui.database.sqlite.persistence.enabled` | SQLite 데이터베이스 파일을 PVC에 영속 저장 | `true` |
+| `ui.database.sqlite.persistence.size` | SQLite PVC 스토리지 크기 | `1Gi` |
+| `ui.database.sqlite.persistence.storageClassName` | SQLite PVC 스토리지 클래스 | `null` |
+| `ui.database.postgresql.databaseUrl` | 외부 PostgreSQL 연결 URL (`type=postgresql` 일 때) | `""` |
+| `ui.database.postgresql.existingSecret` | `DATABASE_URL` 키를 포함하는 기존 Secret (`databaseUrl` 대안) | `""` |
 | `ui.k8s.enabled` | K8s 클러스터 관리 기능 활성화 | `true` |
 | `ui.ingress.enabled` | 외부 접근용 Ingress 생성 | `false` |
-| `ui.persistence.enabled` | PostgreSQL 데이터용 PVC 활성화 | `true` |
-| `ui.persistence.size` | PVC 스토리지 크기 | `1Gi` |
-| `ui.env.databaseUrl` | 외부 PostgreSQL URL (`postgresql.enabled=false` 일 때) | `""` |
 | `ui.rbac.create` | K8s API 접근용 ClusterRole 및 ClusterRoleBinding 생성 (AerospikeCluster, Template, HPA 관리 권한 포함) | `true` |
 | `ui.serviceAccount.create` | UI Pod용 ServiceAccount 생성 | `true` |
 | `ui.networkPolicy.enabled` | UI Pod 네트워크 트래픽 제한 | `false` |
@@ -96,8 +98,6 @@ helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kuber
 | `ui.resources.requests.memory` | UI 컨테이너 메모리 요청 | `256Mi` |
 | `ui.resources.limits.cpu` | UI 컨테이너 CPU 제한 | `200m` |
 | `ui.resources.limits.memory` | UI 컨테이너 메모리 제한 | `512Mi` |
-| `ui.persistence.storageClassName` | PostgreSQL PVC 스토리지 클래스 | `""` (기본값) |
-| `ui.postgresql.existingSecret` | 데이터베이스 자격 증명에 기존 Secret 사용 | `""` |
 | `ui.extraEnv` | UI 컨테이너에 추가할 환경 변수 목록 | `[]` |
 
 :::tip
@@ -113,7 +113,7 @@ helm show values oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kubern
 
 ### 연결 관리
 
-색상 코드가 있는 프로파일로 여러 Aerospike 클러스터 연결을 관리합니다. 각 연결은 호스트, 포트, 선택적 인증 정보를 저장하며, 프로파일은 내장 PostgreSQL 데이터베이스에 영속 저장됩니다.
+색상 코드가 있는 프로파일로 여러 Aerospike 클러스터 연결을 관리합니다. 각 연결은 호스트, 포트, 선택적 인증 정보를 저장하며, 프로파일은 데이터베이스(기본값 내장 SQLite, 또는 외부 PostgreSQL)에 영속 저장됩니다.
 
 ### 클러스터 모니터링
 
@@ -312,19 +312,28 @@ Aerospike 클러스터에 등록된 사용자 정의 함수(Lua 모듈)를 업�
 
 ---
 
-## 외부 PostgreSQL 사용
+## 데이터베이스 백엔드
 
-내장 사이드카 대신 기존 PostgreSQL 인스턴스를 사용하려면:
+api는 클러스터 연결 메타데이터를 데이터베이스에 저장하며, `ui.database.type`으로 백엔드를 선택합니다.
+
+- **`sqlite`** (기본값) — api 컨테이너에 내장된 SQLite 파일을 PVC에 영속 저장합니다. 추가 인프라가 필요 없습니다. SQLite는 단일 라이터(single-writer)이므로 `ui.replicaCount`는 `1`이어야 합니다(그렇지 않으면 차트가 설치를 실패시킵니다).
+- **`postgresql`** — 직접 운영하는 **외부** PostgreSQL 인스턴스(RDS, Cloud SQL, AlloyDB, 클러스터 내 PostgreSQL 오퍼레이터 등)에 연결합니다. HA·다중 레플리카에 필요합니다. 차트는 PostgreSQL을 직접 배포하지 않습니다.
+
+외부 PostgreSQL을 사용하려면 연결 URL을 지정합니다:
 
 ```bash
 helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kubernetes-operator \
   --namespace aerospike-operator --create-namespace \
-  --set ui.postgresql.enabled=false \
-  --set ui.env.databaseUrl="postgresql://user:pass@db-host:5432/aerospike_manager"
+  --set ui.database.type=postgresql \
+  --set ui.database.postgresql.databaseUrl="postgresql://user:pass@db-host:5432/aerospike_manager"
 ```
 
 :::tip
-`ui.postgresql.existingSecret`에 Secret 이름을 설정하여 기존 Kubernetes Secret의 데이터베이스 자격 증명을 사용할 수도 있습니다. Secret에는 `POSTGRES_PASSWORD`와 `DATABASE_URL` 키가 포함되어야 합니다.
+자격 증명을 values에 노출하지 않으려면 `ui.database.postgresql.existingSecret`에 기존 Kubernetes Secret 이름을 지정합니다. Secret에는 `DATABASE_URL` 키가 포함되어야 합니다.
+:::
+
+:::warning
+임베디드 PostgreSQL 사이드카는 제거되었습니다. 구버전의 `ui.postgresql.*` / `ui.persistence.*` 키는 이제 설치 시 마이그레이션 안내 메시지와 함께 실패합니다. `ui.postgresql.enabled: true` → `ui.database.type: postgresql` + `ui.database.postgresql.databaseUrl`, `ui.postgresql.enabled: false` → `ui.database.type: sqlite`, `ui.persistence.*` → `ui.database.sqlite.persistence.*`로 매핑하세요. 기존 임베디드 PostgreSQL PVC에서 자동 데이터 마이그레이션은 제공되지 않습니다.
 :::
 
 ---

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/getting-started/install.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/getting-started/install.md
@@ -440,22 +440,27 @@ helm install aerospike-ce-kubernetes-operator oci://ghcr.io/aerospike-ce-ecosyst
 | `ui.service.frontendPort` | `3000` | Frontend(Next.js) 포트 |
 | `ui.service.backendPort` | `8000` | Backend(FastAPI) 포트 |
 | `ui.ingress.enabled` | `false` | 외부 접근을 위한 Ingress 생성 |
-| `ui.postgresql.enabled` | `true` | 임베디드 PostgreSQL 사이드카 배포 |
-| `ui.persistence.enabled` | `true` | PostgreSQL 데이터용 PVC 활성화 |
-| `ui.persistence.size` | `1Gi` | PVC 스토리지 크기 |
+| `ui.database.type` | `sqlite` | 데이터베이스 백엔드: `sqlite`(내장, 기본값) 또는 `postgresql`(외부) |
+| `ui.database.sqlite.persistence.enabled` | `true` | SQLite 데이터베이스 파일을 PVC에 영속 저장 |
+| `ui.database.sqlite.persistence.size` | `1Gi` | SQLite PVC 스토리지 크기 |
+| `ui.database.postgresql.databaseUrl` | `""` | 외부 PostgreSQL 연결 URL (`type=postgresql`일 때) |
+| `ui.database.postgresql.existingSecret` | `""` | `DATABASE_URL` 키를 포함하는 기존 Secret (`databaseUrl` 대안) |
 | `ui.k8s.enabled` | `true` | K8s 클러스터 관리 기능 활성화 (UI에서 클러스터 생성) |
-| `ui.env.databaseUrl` | `""` | 외부 PostgreSQL URL (`postgresql.enabled=false`일 때 사용) |
 
 ### 외부 PostgreSQL 사용
 
-임베디드 사이드카 대신 기존 PostgreSQL 인스턴스를 사용하려면:
+기본 백엔드는 내장 SQLite입니다. 임베디드 PostgreSQL 사이드카는 제거되었으며, PostgreSQL은 외부 인스턴스로만 사용할 수 있습니다. 직접 운영하는 외부 PostgreSQL에 연결하려면:
 
 ```bash
 helm install aerospike-ce-kubernetes-operator oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kubernetes-operator \
   -n aerospike-operator --create-namespace \
-  --set ui.postgresql.enabled=false \
-  --set ui.env.databaseUrl="postgresql://user:pass@db-host:5432/aerospike_manager"
+  --set ui.database.type=postgresql \
+  --set ui.database.postgresql.databaseUrl="postgresql://user:pass@db-host:5432/aerospike_manager"
 ```
+
+:::warning
+구버전의 `ui.postgresql.*` / `ui.persistence.*` 키는 이제 설치 시 마이그레이션 안내 메시지와 함께 실패합니다. `ui.postgresql.enabled: true` → `ui.database.type: postgresql` + `ui.database.postgresql.databaseUrl`, `ui.postgresql.enabled: false` → `ui.database.type: sqlite`, `ui.persistence.*` → `ui.database.sqlite.persistence.*`로 매핑하세요.
+:::
 
 ## 설치 확인
 

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/reference/helm-values.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/reference/helm-values.md
@@ -202,6 +202,7 @@ api는 클러스터 연결 메타데이터를 데이터베이스에 저장합니
 | 키 | 타입 | 기본값 | 설명 |
 |-----|------|---------|-------------|
 | `ui.database.type` | string | `sqlite` | 데이터베이스 백엔드: `sqlite`(PVC에 저장되는 내장 파일) 또는 `postgresql`(외부 인스턴스). |
+| `ui.database.acknowledgeEmbeddedPostgresRemoval` | bool | `false` | 업그레이드 안전 게이트. 임베디드 PostgreSQL Secret이 남아 있는 릴리스에서의 업그레이드를 이 값이 `true`가 될 때까지 차단. 임베디드 데이터를 백업한 뒤에만 설정(아래 마이그레이션 안내 참조). 신규 설치에는 영향 없음. |
 | `ui.database.sqlite.persistence.enabled` | bool | `true` | SQLite 데이터베이스 파일을 PVC에 영속 저장. `false`이면 `emptyDir`을 사용하며 Pod 재시작 시 저장된 연결이 사라짐. |
 | `ui.database.sqlite.persistence.storageClassName` | string | `null` | 스토리지 클래스. `null` = 클러스터 기본 StorageClass, `""` = 사전 프로비저닝된 PV, `"name"` = 지정한 StorageClass. |
 | `ui.database.sqlite.persistence.accessMode` | string | `ReadWriteOnce` | PVC 접근 모드. SQLite는 단일 라이터이므로 `ReadWriteOnce` 유지. |
@@ -216,7 +217,7 @@ api는 클러스터 연결 메타데이터를 데이터베이스에 저장합니
 
 **PostgreSQL** 모드는 직접 운영하는 외부 데이터베이스(RDS / Cloud SQL / AlloyDB 같은 관리형 서비스, 또는 클러스터 내 PostgreSQL 오퍼레이터)에 연결합니다. HA·다중 레플리카 배포에 필요합니다.
 
-> **마이그레이션:** 임베디드 사이드카 시절의 구버전 `ui.postgresql.*` / `ui.persistence.*` 키는 이제 설치 시 마이그레이션 안내 메시지와 함께 실패합니다. `ui.postgresql.enabled: true` → `ui.database.type: postgresql` + `ui.database.postgresql.databaseUrl`, `ui.postgresql.enabled: false` → `ui.database.type: sqlite`, `ui.persistence.*` → `ui.database.sqlite.persistence.*`, `ui.env.databaseUrl` → `ui.database.postgresql.databaseUrl`로 매핑하세요. 기존 임베디드 PostgreSQL PVC에서 자동 데이터 마이그레이션은 제공되지 않습니다.
+> **마이그레이션:** 임베디드 사이드카 시절의 구버전 `ui.postgresql.*` / `ui.persistence.*` 키는 설치 시 마이그레이션 안내 메시지와 함께 실패합니다. `ui.postgresql.enabled: true` → `ui.database.type: postgresql` + `ui.database.postgresql.databaseUrl`, `ui.postgresql.enabled: false` → `ui.database.type: sqlite`, `ui.persistence.*` → `ui.database.sqlite.persistence.*`, `ui.env.databaseUrl` → `ui.database.postgresql.databaseUrl`로 매핑하세요. 임베디드 PostgreSQL에서 자동 데이터 마이그레이션은 제공되지 않으며, 임베디드 사이드카 릴리스에서의 업그레이드는 `ui.database.acknowledgeEmbeddedPostgresRemoval=true`를 설정할 때까지 차단됩니다. `pg_dump` → 복원 → 업그레이드 런북은 차트 README의 "Migrating off the embedded PostgreSQL sidecar" 절을 참고하세요.
 
 ### 배포 전략 및 정상 종료
 

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/reference/helm-values.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/reference/helm-values.md
@@ -195,40 +195,35 @@ Aerospike Cluster Manager는 오퍼레이터와 함께 배포되는 풀스택 �
 | `ui.ingress.hosts` | list | values.yaml 참조 | Ingress 호스트 규칙. |
 | `ui.ingress.tls` | list | `[]` | Ingress TLS 설정. |
 
-### PostgreSQL (내장 사이드카)
+### 데이터베이스
+
+api는 클러스터 연결 메타데이터를 데이터베이스에 저장합니다. 백엔드는 `ui.database.type`으로 선택하며, `sqlite`(내장, 기본값) 또는 `postgresql`(외부) 중 하나입니다. 차트는 PostgreSQL을 직접 배포하지 않습니다 — 이전 차트 버전의 임베디드 PostgreSQL 사이드카는 제거되었습니다.
 
 | 키 | 타입 | 기본값 | 설명 |
 |-----|------|---------|-------------|
-| `ui.postgresql.enabled` | bool | `true` | 내장 PostgreSQL 사이드카 컨테이너 배포. 비활성화하여 외부 PostgreSQL 인스턴스 사용. |
-| `ui.postgresql.image.repository` | string | `postgres` | PostgreSQL 컨테이너 이미지. |
-| `ui.postgresql.image.tag` | string | `"17-alpine"` | PostgreSQL 이미지 태그. |
-| `ui.postgresql.image.pullPolicy` | string | `IfNotPresent` | 이미지 풀 정책. |
-| `ui.postgresql.database` | string | `aerospike_manager` | 데이터베이스 이름. |
-| `ui.postgresql.username` | string | `aerospike` | 데이터베이스 사용자. |
-| `ui.postgresql.password` | string | `aerospike` | 데이터베이스 비밀번호 (내장 사이드카 전용). |
-| `ui.postgresql.existingSecret` | string | `""` | `POSTGRES_PASSWORD`와 `DATABASE_URL` 키를 포함하는 기존 Secret 이름. |
-| `ui.postgresql.resources.requests.cpu` | string | `50m` | CPU 요청. |
-| `ui.postgresql.resources.requests.memory` | string | `128Mi` | 메모리 요청. |
-| `ui.postgresql.resources.limits.cpu` | string | `250m` | CPU 제한. |
-| `ui.postgresql.resources.limits.memory` | string | `256Mi` | 메모리 제한. |
+| `ui.database.type` | string | `sqlite` | 데이터베이스 백엔드: `sqlite`(PVC에 저장되는 내장 파일) 또는 `postgresql`(외부 인스턴스). |
+| `ui.database.sqlite.persistence.enabled` | bool | `true` | SQLite 데이터베이스 파일을 PVC에 영속 저장. `false`이면 `emptyDir`을 사용하며 Pod 재시작 시 저장된 연결이 사라짐. |
+| `ui.database.sqlite.persistence.storageClassName` | string | `null` | 스토리지 클래스. `null` = 클러스터 기본 StorageClass, `""` = 사전 프로비저닝된 PV, `"name"` = 지정한 StorageClass. |
+| `ui.database.sqlite.persistence.accessMode` | string | `ReadWriteOnce` | PVC 접근 모드. SQLite는 단일 라이터이므로 `ReadWriteOnce` 유지. |
+| `ui.database.sqlite.persistence.size` | string | `1Gi` | SQLite PVC 볼륨 크기. |
+| `ui.database.postgresql.databaseUrl` | string | `""` | 외부 PostgreSQL 인스턴스의 연결 URL. `type=postgresql`일 때 필수(또는 `existingSecret`). |
+| `ui.database.postgresql.existingSecret` | string | `""` | `DATABASE_URL` 키를 포함하는 기존 Secret 이름. `databaseUrl` 대신 사용해 자격 증명을 values 밖에 둠. |
+| `ui.database.postgresql.poolMinSize` | int | `2` | 커넥션 풀 최소 크기 (`DB_POOL_MIN_SIZE`). |
+| `ui.database.postgresql.poolMaxSize` | int | `10` | 커넥션 풀 최대 크기 (`DB_POOL_MAX_SIZE`). |
+| `ui.database.postgresql.commandTimeout` | int | `30` | SQL 명령 실행 타임아웃 (초, `DB_COMMAND_TIMEOUT`). |
 
-내장 PostgreSQL 사이드카에는 `pg_isready`를 실행하는 **startup probe**가 포함되어 있어, UI 컨테이너가 트래픽을 수신하기 전에 데이터베이스가 준비되었는지 확인합니다.
+**SQLite (기본값)** 는 api 컨테이너 내부의 단일 파일에 데이터를 저장하며 PersistentVolumeClaim으로 백업됩니다. 단일 라이터이므로 `ui.replicaCount`는 `1`이어야 합니다 — 그렇지 않으면 차트가 설치를 실패시킵니다.
 
-### 영속성
+**PostgreSQL** 모드는 직접 운영하는 외부 데이터베이스(RDS / Cloud SQL / AlloyDB 같은 관리형 서비스, 또는 클러스터 내 PostgreSQL 오퍼레이터)에 연결합니다. HA·다중 레플리카 배포에 필요합니다.
 
-| 키 | 타입 | 기본값 | 설명 |
-|-----|------|---------|-------------|
-| `ui.persistence.enabled` | bool | `true` | 내장 PostgreSQL 데이터베이스용 영구 스토리지 활성화. |
-| `ui.persistence.storageClassName` | string | `""` | 스토리지 클래스 이름 (비어있으면 기본값). |
-| `ui.persistence.accessMode` | string | `ReadWriteOnce` | 접근 모드. |
-| `ui.persistence.size` | string | `1Gi` | 볼륨 크기. |
+> **마이그레이션:** 임베디드 사이드카 시절의 구버전 `ui.postgresql.*` / `ui.persistence.*` 키는 이제 설치 시 마이그레이션 안내 메시지와 함께 실패합니다. `ui.postgresql.enabled: true` → `ui.database.type: postgresql` + `ui.database.postgresql.databaseUrl`, `ui.postgresql.enabled: false` → `ui.database.type: sqlite`, `ui.persistence.*` → `ui.database.sqlite.persistence.*`, `ui.env.databaseUrl` → `ui.database.postgresql.databaseUrl`로 매핑하세요. 기존 임베디드 PostgreSQL PVC에서 자동 데이터 마이그레이션은 제공되지 않습니다.
 
 ### 배포 전략 및 정상 종료
 
-UI Deployment는 PostgreSQL 설정에 따라 명시적인 업데이트 전략을 사용합니다:
+api Deployment는 데이터베이스 백엔드에 따라 명시적인 업데이트 전략을 사용합니다:
 
-- **내장 PostgreSQL 사용 시** (`ui.postgresql.enabled=true`): PVC가 한 번에 하나의 Pod에만 마운트될 수 있으므로 `Recreate` 전략 사용.
-- **외부 PostgreSQL 사용 시** (`ui.postgresql.enabled=false`): 무중단 배포를 위해 `RollingUpdate` 전략 사용 (`maxSurge: 1`, `maxUnavailable: 0`).
+- **SQLite** (`ui.database.type=sqlite`): SQLite PVC는 `ReadWriteOnce`이며 한 번에 하나의 Pod에만 마운트될 수 있으므로 `Recreate` 전략 사용.
+- **PostgreSQL** (`ui.database.type=postgresql`): 무중단 배포를 위해 `RollingUpdate` 전략 사용 (`maxSurge: 1`, `maxUnavailable: 0`).
 
 UI 컨테이너에는 **preStop 라이프사이클 훅** (`sleep 5`)이 포함되어 Pod 종료 전 진행 중인 요청이 완료될 수 있도록 합니다. `terminationGracePeriodSeconds` (기본값: 45)와 함께 롤아웃 및 노드 드레인 시 정상 종료를 보장합니다.
 
@@ -288,10 +283,6 @@ UI 컨테이너에는 **preStop 라이프사이클 훅** (`sleep 5`)이 포함�
 | `ui.env.corsOrigins` | string | `""` | 백엔드 CORS 오리진. 비어있으면 CORS 없음 (프론트엔드가 Next.js rewrites로 프록시). |
 | `ui.env.logLevel` | string | `"INFO"` | 로그 레벨: `DEBUG`, `INFO`, `WARNING`, `ERROR`. |
 | `ui.env.logFormat` | string | `"text"` | 로그 형식: `text`(사람이 읽기 쉬운), `json`(구조화된 로깅). |
-| `ui.env.databaseUrl` | string | `""` | 외부 PostgreSQL 연결 URL. `postgresql.enabled`가 `false`일 때만 사용. |
-| `ui.env.dbPoolSize` | int | `5` | DB 커넥션 풀 크기. |
-| `ui.env.dbPoolOverflow` | int | `10` | 풀 크기 초과 시 최대 오버플로 커넥션. |
-| `ui.env.dbPoolTimeout` | int | `30` | 풀 체크아웃 타임아웃 (초). |
 | `ui.env.k8sApiTimeout` | int | `30` | Kubernetes API 요청 타임아웃 (초). |
 
 ### UI 모니터링


### PR DESCRIPTION
## Summary

The cluster-manager **api** Deployment used to run a `postgres` container as a **sidecar in the same pod** (`ui.postgresql.enabled`, default `true`). This coupled the api's lifecycle to a single-instance database, forced `Recreate` rollouts, and — because `ENABLE_POSTGRES` was wired to the sidecar toggle — left the "external PostgreSQL" path **non-functional** (the api silently fell back to SQLite and ignored `ui.env.databaseUrl`).

This PR removes the embedded sidecar entirely and introduces an explicit backend selector.

## What changed

- **`ui.database.type`** — `sqlite` (default) or `postgresql`.
  - **`sqlite`**: embedded SQLite file in the api container, persisted on a PVC mounted at `/app/data`. Zero extra infra. Single-writer — the chart fails the install when `ui.replicaCount > 1`.
  - **`postgresql`**: connects to an **external** PostgreSQL instance via `ui.database.postgresql.databaseUrl` / `existingSecret`. The chart never deploys PostgreSQL itself.
- `ENABLE_POSTGRES` is now driven by `ui.database.type` (fixes the broken external-PG path).
- `Recreate` strategy for SQLite (RWO PVC), `RollingUpdate` for PostgreSQL.
- New `validate.databaseConfig` helper: fails fast on stale `ui.postgresql.*` / `ui.persistence.*` / `ui.env.databaseUrl` keys, on invalid `type` (validated unconditionally), on `postgresql` without a URL/secret, and on `sqlite` + `replicaCount > 1`.
- Docs updated (EN + ko: `helm-values.md`, `cluster-manager-ui.md`, `install.md`) + chart `README.md` / `NOTES.txt`.

## Breaking change — values migration

This is a breaking change to the chart values contract. Stale keys now fail the install with a migration message.

| Old | New |
|-----|-----|
| `ui.postgresql.enabled: true` | `ui.database.type: postgresql` + `ui.database.postgresql.databaseUrl` |
| `ui.postgresql.enabled: false` | `ui.database.type: sqlite` |
| `ui.persistence.*` | `ui.database.sqlite.persistence.*` |
| `ui.env.databaseUrl` | `ui.database.postgresql.databaseUrl` |

There is **no in-place data migration** from the old embedded PostgreSQL PVC — `pg_dump` it before upgrading if you need to keep that data.

> **Versioning:** intentionally committed as `feat` (not `feat!` / no `BREAKING CHANGE:` footer) so the daily release lands as a MINOR bump, per maintainer direction — no chart MAJOR bump.

## Verification

- `helm lint` — default + postgresql values
- `helm template` — sqlite default, postgresql + databaseUrl, postgresql + existingSecret, web-only, and all validation guards (stale keys / missing URL / invalid type / sqlite multi-replica)
- Docusaurus build — EN + ko both succeed
- **Local kind cluster** — both backends verified end-to-end (SQLite: PVC bound + `connections.db` written, `Recreate`, health 200; PostgreSQL: external DB connected + schema created, `RollingUpdate`, no PVC, health 200). See the [verification comment](https://github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/pull/274#issuecomment-4494021682).

🤖 Generated with [Claude Code](https://claude.com/claude-code)