### PR TITLE
docs: fix stale UI Helm references after api/web Deployment split

### DIFF
--- a/docs/content/getting-started/cluster-manager-ui.md
+++ b/docs/content/getting-started/cluster-manager-ui.md
@@ -32,13 +32,13 @@ Verify the UI pod:
 kubectl -n aerospike-operator get pods -l app.kubernetes.io/component=ui
 ```
 
-Access via port-forwarding:
+Access via port-forwarding (the web frontend listens on port 3100):
 
 ```bash
-kubectl -n aerospike-operator port-forward svc/acko-aerospike-ce-kubernetes-operator-ui 3000:3000
+kubectl -n aerospike-operator port-forward svc/acko-aerospike-ce-kubernetes-operator-ui-web 3100:3100
 ```
 
-Open `http://localhost:3000` in your browser.
+Open `http://localhost:3100` in your browser.
 
 ---
 
@@ -528,22 +528,21 @@ After modifying a template, existing clusters that reference it are not automati
 |-----------|-------------|---------|
 | `ui.api.enabled` | Deploy the Cluster Manager API (FastAPI). Combine with `ui.web.enabled=false` for both-off (operator-only). | `true` |
 | `ui.web.enabled` | Deploy the Cluster Manager web (Next.js). Combine with `ui.api.enabled=false` for both-off (operator-only). | `true` |
-| `ui.replicaCount` | UI replica count | `1` |
-| `ui.image.repository` | UI container image | `ghcr.io/aerospike-ce-ecosystem/aerospike-cluster-manager` |
-| `ui.image.tag` | Image tag | `latest` |
-| `ui.service.type` | Service type | `ClusterIP` |
-| `ui.service.frontendPort` | Frontend (Next.js) port | `3000` |
-| `ui.service.backendPort` | Backend (FastAPI) port | `8000` |
-| `ui.service.annotations` | Service annotations (cloud LB configuration, etc.) | `{}` |
+| `ui.replicaCount` | Replica count for each UI Deployment (api / web) | `1` |
+| `ui.imageTag` | Default image tag for both UI components (api + web) | `"0.24.0"` |
+| `ui.api.image.repository` | API (FastAPI) container image | `ghcr.io/aerospike-ce-ecosystem/aerospike-cluster-manager-api` |
+| `ui.web.image.repository` | Web (Next.js) container image | `ghcr.io/aerospike-ce-ecosystem/aerospike-cluster-manager-web` |
+| `ui.api.service.type` / `ui.web.service.type` | Service type for each component | `ClusterIP` |
+| `ui.api.service.port` | API Service port (forwards to container port 8000) | `80` |
+| `ui.web.service.port` | Web Service port (browser access / Ingress target) | `3100` |
+| `ui.web.service.annotations` | Web Service annotations (cloud LB configuration, etc.) | `{}` |
 | `ui.ingress.enabled` | Create Ingress | `false` |
 | `ui.persistence.enabled` | Use PostgreSQL PVC | `true` |
 | `ui.persistence.size` | PVC storage size | `1Gi` |
 | `ui.k8s.enabled` | K8s cluster management feature | `true` |
 | `ui.rbac.create` | Auto-create ClusterRole/Binding (includes permissions for AerospikeCluster, Template, and HPA management) | `true` |
-| `ui.resources.requests.cpu` | UI container CPU request | `100m` |
-| `ui.resources.requests.memory` | UI container memory request | `256Mi` |
-| `ui.resources.limits.cpu` | UI container CPU limit | `200m` |
-| `ui.resources.limits.memory` | UI container memory limit | `512Mi` |
+| `ui.api.resources` | API container CPU/memory requests → limits | `100m`/`256Mi` → `200m`/`512Mi` |
+| `ui.web.resources` | Web container CPU/memory requests → limits | `50m`/`128Mi` → `150m`/`384Mi` |
 | `ui.postgresql.enabled` | Deploy embedded PostgreSQL sidecar | `true` |
 | `ui.env.databaseUrl` | External PostgreSQL URL (when `postgresql.enabled=false`) | `""` |
 | `ui.env.corsOrigins` | Backend CORS origins (empty string = disable CORS; frontend proxies via Next.js rewrites) | `""` |

--- a/docs/content/getting-started/install.md
+++ b/docs/content/getting-started/install.md
@@ -104,7 +104,7 @@ make run-local
 Once complete, access the UI:
 
 ```bash
-kubectl port-forward -n aerospike-operator svc/aerospike-ce-kubernetes-operator-ui 3000:3000
+kubectl port-forward -n aerospike-operator svc/aerospike-ce-kubernetes-operator-ui-web 3100:3100
 ```
 
 Other useful local development commands:
@@ -368,7 +368,7 @@ kubectl -n aerospike wait --for=condition=Ready pod/aerospike-basic-0-0 --timeou
 kubectl -n aerospike exec -it aerospike-basic-0-0 -- asinfo -v status
 
 # Access the UI
-kubectl -n aerospike-operator port-forward svc/aerospike-ce-kubernetes-operator-ui 3000:3000
+kubectl -n aerospike-operator port-forward svc/aerospike-ce-kubernetes-operator-ui-web 3100:3100
 ```
 
 </TabItem>
@@ -448,7 +448,7 @@ kubectl -n aerospike exec -it aerospike-basic-0-0 -- asinfo -v build
 # 7. Access
 # =============================================================================
 # UI
-kubectl -n aerospike-operator port-forward svc/aerospike-ce-kubernetes-operator-ui 3000:3000 &
+kubectl -n aerospike-operator port-forward svc/aerospike-ce-kubernetes-operator-ui-web 3100:3100 &
 
 # Grafana
 GRAFANA_PASSWORD=$(kubectl -n monitoring get secret grafana \

--- a/docs/content/quickstart.md
+++ b/docs/content/quickstart.md
@@ -123,10 +123,10 @@ aerospike-basic   1          1/1      Completed   60s   True
 ## Step 5: Access the Cluster Manager UI
 
 ```bash
-kubectl -n aerospike-operator port-forward svc/aerospike-ce-kubernetes-operator-ui 3000:3000
+kubectl -n aerospike-operator port-forward svc/aerospike-ce-kubernetes-operator-ui-web 3100:3100
 ```
 
-Open [http://localhost:3000](http://localhost:3000) in your browser. The UI provides a visual dashboard for managing clusters, browsing records, and running AQL queries.
+Open [http://localhost:3100](http://localhost:3100) in your browser. The UI provides a visual dashboard for managing clusters, browsing records, and running AQL queries.
 
 :::tip
 Keep this terminal open — port-forward runs in the foreground. Open a new terminal for the next step.

--- a/docs/content/reference/helm-values.md
+++ b/docs/content/reference/helm-values.md
@@ -27,7 +27,7 @@ This page documents all configurable values for the `aerospike-ce-kubernetes-ope
 |-----|------|---------|-------------|
 | `replicaCount` | int | `1` | Number of operator replicas. Typically 1 is sufficient as leader election handles HA. |
 | `image.repository` | string | `ghcr.io/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator` | Operator container image repository. |
-| `image.tag` | string | `"latest"` | Container image tag. |
+| `image.tag` | string | `""` | Container image tag. Empty falls through to `.Chart.AppVersion`. |
 | `image.pullPolicy` | string | `IfNotPresent` | Image pull policy: `Always`, `IfNotPresent`, or `Never`. |
 | `imagePullSecrets` | list | `[]` | Image pull secrets for private registries. |
 | `nameOverride` | string | `""` | Override the chart name used in resource names. |
@@ -44,9 +44,9 @@ This page documents all configurable values for the `aerospike-ce-kubernetes-ope
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `resources.limits.cpu` | string | `500m` | CPU limit for the operator pod. |
-| `resources.limits.memory` | string | `256Mi` | Memory limit for the operator pod. |
+| `resources.limits.memory` | string | `512Mi` | Memory limit for the operator pod. |
 | `resources.requests.cpu` | string | `100m` | CPU request for the operator pod. |
-| `resources.requests.memory` | string | `128Mi` | Memory request for the operator pod. |
+| `resources.requests.memory` | string | `256Mi` | Memory request for the operator pod. |
 
 ## Webhook
 
@@ -110,9 +110,9 @@ This page documents all configurable values for the `aerospike-ce-kubernetes-ope
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `podDisruptionBudget.enabled` | bool | `false` | Create a PodDisruptionBudget for the operator deployment. |
-| `podDisruptionBudget.minAvailable` | int | `1` | Minimum available pods. Mutually exclusive with `maxUnavailable`. |
-| `podDisruptionBudget.maxUnavailable` | int | — | Maximum unavailable pods. Mutually exclusive with `minAvailable`. |
+| `podDisruptionBudget.enabled` | bool | `true` | Create a PodDisruptionBudget for the operator deployment. |
+| `podDisruptionBudget.minAvailable` | int | `""` | Minimum available pods. Mutually exclusive with `maxUnavailable`. Leave empty unless `replicaCount` > 1. |
+| `podDisruptionBudget.maxUnavailable` | int | `1` | Maximum unavailable pods. Mutually exclusive with `minAvailable`. |
 
 ## Horizontal Pod Autoscaler
 
@@ -143,7 +143,7 @@ This page documents all configurable values for the `aerospike-ce-kubernetes-ope
 
 ## UI - Aerospike Cluster Manager
 
-The Aerospike Cluster Manager is a full-stack web dashboard deployed alongside the operator. It provides a visual interface for monitoring and managing Aerospike clusters.
+The Aerospike Cluster Manager is a full-stack web dashboard deployed alongside the operator as two independent Deployments — `api` (FastAPI backend) and `web` (Next.js frontend). It provides a visual interface for monitoring and managing Aerospike clusters.
 
 ### General
 
@@ -151,11 +151,15 @@ The Aerospike Cluster Manager is a full-stack web dashboard deployed alongside t
 |-----|------|---------|-------------|
 | `ui.api.enabled` | bool | `true` | Deploy the Cluster Manager API (FastAPI) component. Set to false together with `ui.web.enabled=false` to skip the UI entirely. |
 | `ui.web.enabled` | bool | `true` | Deploy the Cluster Manager web (Next.js) component. Set to false together with `ui.api.enabled=false` to skip the UI entirely. |
-| `ui.replicaCount` | int | `1` | Number of UI replicas. |
-| `ui.image.repository` | string | `ghcr.io/aerospike-ce-ecosystem/aerospike-cluster-manager` | UI container image repository. |
-| `ui.image.tag` | string | `"latest"` | UI container image tag. UI is versioned independently from the operator. |
-| `ui.image.pullPolicy` | string | `IfNotPresent` | Image pull policy. |
-| `ui.imagePullSecrets` | list | `[]` | Image pull secrets for private registries. |
+| `ui.replicaCount` | int | `1` | Number of replicas for each UI Deployment (api / web). |
+| `ui.imageTag` | string | `"0.24.0"` | Default image tag for both UI components. `aerospike-cluster-manager` is versioned independently from the operator, so the chart pins a known-good release here. Set to `""` to fall through to `.Chart.AppVersion`. |
+| `ui.api.image.repository` | string | `ghcr.io/aerospike-ce-ecosystem/aerospike-cluster-manager-api` | API (FastAPI) container image repository. |
+| `ui.api.image.tag` | string | `""` | API image tag. Empty falls through to `ui.imageTag`. |
+| `ui.api.image.pullPolicy` | string | `IfNotPresent` | API image pull policy. |
+| `ui.web.image.repository` | string | `ghcr.io/aerospike-ce-ecosystem/aerospike-cluster-manager-web` | Web (Next.js) container image repository. |
+| `ui.web.image.tag` | string | `""` | Web image tag. Empty falls through to `ui.imageTag`. |
+| `ui.web.image.pullPolicy` | string | `IfNotPresent` | Web image pull policy. |
+| `ui.imagePullSecrets` | list | `[]` | Image pull secrets for private registries (applied to all UI Deployments). |
 
 ### Service Account & RBAC
 
@@ -185,12 +189,18 @@ When `ui.rbac.create=true`, the generated ClusterRole includes the following per
 
 ### Service
 
+Each UI component has its own Service.
+
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `ui.service.type` | string | `ClusterIP` | Service type: `ClusterIP`, `NodePort`, or `LoadBalancer`. |
-| `ui.service.frontendPort` | int | `3000` | Frontend port (Next.js web UI). |
-| `ui.service.backendPort` | int | `8000` | Backend port (FastAPI REST API). |
-| `ui.service.annotations` | object | `{}` | Annotations for the UI Service. |
+| `ui.api.service.type` | string | `ClusterIP` | API Service type: `ClusterIP`, `NodePort`, or `LoadBalancer`. |
+| `ui.api.service.port` | int | `80` | API Service port. Traffic is forwarded to container port 8000. |
+| `ui.api.service.targetPort` | int | `8000` | API container port (non-privileged; the container runs as non-root). |
+| `ui.api.service.annotations` | object | `{}` | Annotations for the API Service. |
+| `ui.web.service.type` | string | `ClusterIP` | Web Service type: `ClusterIP`, `NodePort`, or `LoadBalancer`. |
+| `ui.web.service.port` | int | `3100` | Web Service port. This is the port to port-forward (or route an Ingress to) for browser access. |
+| `ui.web.service.annotations` | object | `{}` | Annotations for the Web Service. |
+| `ui.web.env.apiUrl` | string | `""` | External API URL. When set, the web pod's `proxy.js` forwards `/api/*` there instead of the in-cluster API Service. Required when `ui.api.enabled=false`. |
 
 ### Ingress
 
@@ -248,12 +258,18 @@ The UI container includes a **preStop lifecycle hook** (`sleep 5`) to allow in-f
 
 ### UI Resources
 
+The api and web Deployments have independent resource settings.
+
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `ui.resources.requests.cpu` | string | `100m` | CPU request. |
-| `ui.resources.requests.memory` | string | `256Mi` | Memory request. |
-| `ui.resources.limits.cpu` | string | `200m` | CPU limit. |
-| `ui.resources.limits.memory` | string | `512Mi` | Memory limit. |
+| `ui.api.resources.requests.cpu` | string | `100m` | API CPU request. |
+| `ui.api.resources.requests.memory` | string | `256Mi` | API memory request. |
+| `ui.api.resources.limits.cpu` | string | `200m` | API CPU limit. |
+| `ui.api.resources.limits.memory` | string | `512Mi` | API memory limit. |
+| `ui.web.resources.requests.cpu` | string | `50m` | Web CPU request. |
+| `ui.web.resources.requests.memory` | string | `128Mi` | Web memory request. |
+| `ui.web.resources.limits.cpu` | string | `150m` | Web CPU limit. |
+| `ui.web.resources.limits.memory` | string | `384Mi` | Web memory limit. |
 
 ### Security Context
 
@@ -269,31 +285,41 @@ The UI container includes a **preStop lifecycle hook** (`sleep 5`) to allow in-f
 
 ### Probes
 
+The api Deployment has liveness / readiness / startup probes; the web Deployment has liveness / readiness probes.
+
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `ui.livenessProbe.httpGet.path` | string | `/api/health` | Liveness probe path. |
-| `ui.livenessProbe.httpGet.port` | string | `backend` | Liveness probe port. |
-| `ui.livenessProbe.initialDelaySeconds` | int | `15` | Initial delay. |
-| `ui.livenessProbe.periodSeconds` | int | `20` | Check period. |
-| `ui.livenessProbe.timeoutSeconds` | int | `5` | Timeout. |
-| `ui.readinessProbe.httpGet.path` | string | `/api/health` | Readiness probe path. |
-| `ui.readinessProbe.httpGet.port` | string | `backend` | Readiness probe port. |
-| `ui.readinessProbe.initialDelaySeconds` | int | `5` | Initial delay. |
-| `ui.readinessProbe.periodSeconds` | int | `10` | Check period. |
-| `ui.readinessProbe.timeoutSeconds` | int | `5` | Timeout. |
-| `ui.startupProbe.httpGet.path` | string | `/api/health` | Startup probe path. |
-| `ui.startupProbe.httpGet.port` | string | `backend` | Startup probe port. |
-| `ui.startupProbe.periodSeconds` | int | `5` | Check period. |
-| `ui.startupProbe.timeoutSeconds` | int | `3` | Timeout. |
-| `ui.startupProbe.failureThreshold` | int | `30` | Max failures before giving up (allows 150s startup). |
+| `ui.api.livenessProbe.httpGet.path` | string | `/api/health` | API liveness probe path. |
+| `ui.api.livenessProbe.httpGet.port` | string | `api` | API liveness probe port. |
+| `ui.api.livenessProbe.initialDelaySeconds` | int | `15` | Initial delay. |
+| `ui.api.livenessProbe.periodSeconds` | int | `20` | Check period. |
+| `ui.api.livenessProbe.timeoutSeconds` | int | `5` | Timeout. |
+| `ui.api.readinessProbe.httpGet.path` | string | `/api/health` | API readiness probe path. |
+| `ui.api.readinessProbe.httpGet.port` | string | `api` | API readiness probe port. |
+| `ui.api.readinessProbe.initialDelaySeconds` | int | `5` | Initial delay. |
+| `ui.api.readinessProbe.periodSeconds` | int | `10` | Check period. |
+| `ui.api.readinessProbe.timeoutSeconds` | int | `5` | Timeout. |
+| `ui.api.startupProbe.httpGet.path` | string | `/api/health` | API startup probe path. |
+| `ui.api.startupProbe.httpGet.port` | string | `api` | API startup probe port. |
+| `ui.api.startupProbe.periodSeconds` | int | `5` | Check period. |
+| `ui.api.startupProbe.timeoutSeconds` | int | `3` | Timeout. |
+| `ui.api.startupProbe.failureThreshold` | int | `30` | Max failures before giving up (allows 150s startup). |
+| `ui.web.livenessProbe.httpGet.path` | string | `/` | Web liveness probe path. |
+| `ui.web.livenessProbe.httpGet.port` | string | `web` | Web liveness probe port. |
+| `ui.web.livenessProbe.initialDelaySeconds` | int | `15` | Initial delay. |
+| `ui.web.livenessProbe.periodSeconds` | int | `20` | Check period. |
+| `ui.web.livenessProbe.timeoutSeconds` | int | `5` | Timeout. |
+| `ui.web.readinessProbe.httpGet.path` | string | `/` | Web readiness probe path. |
+| `ui.web.readinessProbe.httpGet.port` | string | `web` | Web readiness probe port. |
+| `ui.web.readinessProbe.initialDelaySeconds` | int | `5` | Initial delay. |
+| `ui.web.readinessProbe.periodSeconds` | int | `10` | Check period. |
+| `ui.web.readinessProbe.timeoutSeconds` | int | `5` | Timeout. |
 
 ### Environment
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `ui.env.frontendPort` | string | (from `ui.service.frontendPort`) | Frontend port injected into the ConfigMap as `FRONTEND_PORT`. Automatically derived from the service port configuration. |
-| `ui.env.backendPort` | string | (from `ui.service.backendPort`) | Backend port injected into the ConfigMap as `BACKEND_PORT`. Automatically derived from the service port configuration. |
-| `ui.env.corsOrigins` | string | `""` | Backend CORS origins. Empty means no CORS (frontend proxies via Next.js rewrites). |
+| `ui.env.corsOrigins` | string | `""` | Backend CORS origins. Empty means no CORS (the web pod proxies `/api/*` instead). |
 | `ui.env.logLevel` | string | `"INFO"` | Log level: `DEBUG`, `INFO`, `WARNING`, `ERROR`. |
 | `ui.env.logFormat` | string | `"text"` | Log format: `text` for human-readable, `json` for structured logging. |
 | `ui.env.databaseUrl` | string | `""` | External PostgreSQL connection URL. Only used when `postgresql.enabled` is `false`. |
@@ -382,6 +408,6 @@ The UI ServiceMonitor scrapes the backend metrics endpoint at `/api/metrics`. Th
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `defaultTemplates.enabled` | bool | `true` | Create pre-built AerospikeClusterTemplate resources (minimal, soft-rack, hard-rack). Templates are cluster-scoped and accessible from all namespaces. |
+| `defaultTemplates.enabled` | bool | `false` | Create pre-built AerospikeClusterTemplate resources (minimal, soft-rack, hard-rack). Default `false` because the templates need the AerospikeClusterTemplate CRD to be registered first — enable via `helm upgrade` after the initial install. Templates are cluster-scoped and accessible from all namespaces. |
 
 The three default template tiers are configured under `defaultTemplates.templates.minimal`, `defaultTemplates.templates.soft-rack`, and `defaultTemplates.templates.hard-rack`. See [Template Management](../configuration/templates.md) for details on each tier.

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/getting-started/cluster-manager-ui.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/getting-started/cluster-manager-ui.md
@@ -40,16 +40,18 @@ kubectl -n aerospike-operator get pods -l app.kubernetes.io/component=ui
 
 ### 포트 포워딩 (개발용)
 
+웹 프론트엔드는 3100 포트로 서비스됩니다.
+
 ```bash
-kubectl -n aerospike-operator port-forward svc/acko-aerospike-ce-kubernetes-operator-ui 3000:3000
+kubectl -n aerospike-operator port-forward svc/acko-aerospike-ce-kubernetes-operator-ui-web 3100:3100
 ```
 
-브라우저에서 [http://localhost:3000](http://localhost:3000)을 엽니다.
+브라우저에서 [http://localhost:3100](http://localhost:3100)을 엽니다.
 
 :::tip
-서비스 이름은 `<릴리스명>-aerospike-ce-kubernetes-operator-ui` 패턴을 따릅니다. 다른 릴리스 이름을 사용한 경우 그에 맞게 조정하세요.
+웹 서비스 이름은 `<릴리스명>-aerospike-ce-kubernetes-operator-ui-web` 패턴을 따릅니다. 다른 릴리스 이름을 사용한 경우 그에 맞게 조정하세요.
 ```bash
-kubectl -n aerospike-operator port-forward svc/<릴리스명>-aerospike-ce-kubernetes-operator-ui 3000:3000
+kubectl -n aerospike-operator port-forward svc/<릴리스명>-aerospike-ce-kubernetes-operator-ui-web 3100:3100
 ```
 :::
 
@@ -75,12 +77,13 @@ helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kuber
 |----------|------|--------|
 | `ui.api.enabled` | Cluster Manager API (FastAPI) 컴포넌트 배포. `ui.web.enabled=false`와 함께 false로 설정하면 UI를 완전히 끔 (operator-only). | `true` |
 | `ui.web.enabled` | Cluster Manager web (Next.js) 컴포넌트 배포. `ui.api.enabled=false`와 함께 false로 설정하면 UI를 완전히 끔 (operator-only). | `true` |
-| `ui.replicaCount` | UI 레플리카 수 | `1` |
-| `ui.image.repository` | UI 컨테이너 이미지 | `ghcr.io/aerospike-ce-ecosystem/aerospike-cluster-manager` |
-| `ui.image.tag` | 이미지 태그 (비어 있으면 Chart appVersion 사용) | `""` |
-| `ui.service.type` | 서비스 타입 (`ClusterIP`, `NodePort`, `LoadBalancer`) | `ClusterIP` |
-| `ui.service.frontendPort` | 프론트엔드 (Next.js) 포트 | `3000` |
-| `ui.service.backendPort` | 백엔드 (FastAPI) 포트 | `8000` |
+| `ui.replicaCount` | 각 UI Deployment(api / web)의 레플리카 수 | `1` |
+| `ui.imageTag` | api/web 두 컴포넌트의 기본 이미지 태그 | `"0.24.0"` |
+| `ui.api.image.repository` | API(FastAPI) 컨테이너 이미지 | `ghcr.io/aerospike-ce-ecosystem/aerospike-cluster-manager-api` |
+| `ui.web.image.repository` | Web(Next.js) 컨테이너 이미지 | `ghcr.io/aerospike-ce-ecosystem/aerospike-cluster-manager-web` |
+| `ui.api.service.type` / `ui.web.service.type` | 컴포넌트별 서비스 타입 | `ClusterIP` |
+| `ui.api.service.port` | API 서비스 포트 (컨테이너 8000으로 전달) | `80` |
+| `ui.web.service.port` | Web 서비스 포트 (브라우저 접근 / Ingress 대상) | `3100` |
 | `ui.postgresql.enabled` | 내장 PostgreSQL 사이드카 배포 | `true` |
 | `ui.k8s.enabled` | K8s 클러스터 관리 기능 활성화 | `true` |
 | `ui.ingress.enabled` | 외부 접근용 Ingress 생성 | `false` |
@@ -90,13 +93,11 @@ helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kuber
 | `ui.rbac.create` | K8s API 접근용 ClusterRole 및 ClusterRoleBinding 생성 (AerospikeCluster, Template, HPA 관리 권한 포함) | `true` |
 | `ui.serviceAccount.create` | UI Pod용 ServiceAccount 생성 | `true` |
 | `ui.networkPolicy.enabled` | UI Pod 네트워크 트래픽 제한 | `false` |
-| `ui.image.pullPolicy` | 이미지 풀 정책 | `IfNotPresent` |
-| `ui.service.annotations` | 서비스 어노테이션 (클라우드 LB 설정 등) | `{}` |
-| `ui.resources.requests.cpu` | UI 컨테이너 CPU 요청 | `100m` |
-| `ui.resources.requests.memory` | UI 컨테이너 메모리 요청 | `256Mi` |
-| `ui.resources.limits.cpu` | UI 컨테이너 CPU 제한 | `200m` |
-| `ui.resources.limits.memory` | UI 컨테이너 메모리 제한 | `512Mi` |
-| `ui.persistence.storageClassName` | PostgreSQL PVC 스토리지 클래스 | `""` (기본값) |
+| `ui.api.image.pullPolicy` / `ui.web.image.pullPolicy` | 이미지 풀 정책 | `IfNotPresent` |
+| `ui.web.service.annotations` | Web 서비스 어노테이션 (클라우드 LB 설정 등) | `{}` |
+| `ui.api.resources` | API 컨테이너 CPU/메모리 requests → limits | `100m`/`256Mi` → `200m`/`512Mi` |
+| `ui.web.resources` | Web 컨테이너 CPU/메모리 requests → limits | `50m`/`128Mi` → `150m`/`384Mi` |
+| `ui.persistence.storageClassName` | PostgreSQL PVC 스토리지 클래스 (`null`=클러스터 기본 StorageClass) | `null` |
 | `ui.postgresql.existingSecret` | 데이터베이스 자격 증명에 기존 Secret 사용 | `""` |
 | `ui.extraEnv` | UI 컨테이너에 추가할 환경 변수 목록 | `[]` |
 

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/getting-started/install.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/getting-started/install.md
@@ -402,16 +402,18 @@ UI를 끄려면 `--set ui.api.enabled=false --set ui.web.enabled=false`.
 
 ### Port-Forward로 접근
 
+웹 프론트엔드는 3100 포트로 서비스됩니다.
+
 ```bash
-kubectl -n aerospike-operator port-forward svc/aerospike-operator-ui 3000:3000
+kubectl -n aerospike-operator port-forward svc/aerospike-ce-kubernetes-operator-ui-web 3100:3100
 ```
 
-브라우저에서 [http://localhost:3000](http://localhost:3000)을 열면 UI에 접근할 수 있습니다.
+브라우저에서 [http://localhost:3100](http://localhost:3100)을 열면 UI에 접근할 수 있습니다.
 
 :::tip
-서비스 이름은 `<release>-aerospike-operator-ui` 형식입니다. 릴리스 이름을 커스텀으로 지정한 경우 아래와 같이 조정하세요:
+웹 서비스 이름은 `<release>-aerospike-ce-kubernetes-operator-ui-web` 형식입니다. 릴리스 이름을 커스텀으로 지정한 경우 아래와 같이 조정하세요:
 ```bash
-kubectl -n aerospike-operator port-forward svc/<release>-aerospike-operator-ui 3000:3000
+kubectl -n aerospike-operator port-forward svc/<release>-aerospike-ce-kubernetes-operator-ui-web 3100:3100
 ```
 :::
 
@@ -436,9 +438,8 @@ helm install aerospike-ce-kubernetes-operator oci://ghcr.io/aerospike-ce-ecosyst
 | `ui.api.enabled` | `true` | Cluster Manager API (FastAPI) 컴포넌트 배포. `ui.web.enabled=false`와 함께 false로 설정하면 UI 전체 비활성. |
 | `ui.web.enabled` | `true` | Cluster Manager web (Next.js) 컴포넌트 배포. `ui.api.enabled=false`와 함께 false로 설정하면 UI 전체 비활성. |
 | `ui.replicaCount` | `1` | UI 레플리카 수 |
-| `ui.service.type` | `ClusterIP` | 서비스 타입 (`ClusterIP`, `NodePort`, `LoadBalancer`) |
-| `ui.service.frontendPort` | `3000` | Frontend(Next.js) 포트 |
-| `ui.service.backendPort` | `8000` | Backend(FastAPI) 포트 |
+| `ui.api.service.port` | `80` | API 서비스 포트 (컨테이너 포트 8000으로 전달) |
+| `ui.web.service.port` | `3100` | Web 서비스 포트 (브라우저 접근 / Ingress 대상) |
 | `ui.ingress.enabled` | `false` | 외부 접근을 위한 Ingress 생성 |
 | `ui.postgresql.enabled` | `true` | 임베디드 PostgreSQL 사이드카 배포 |
 | `ui.persistence.enabled` | `true` | PostgreSQL 데이터용 PVC 활성화 |

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/quickstart.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/quickstart.md
@@ -123,10 +123,10 @@ aerospike-basic   1          1/1      Completed   60s   True
 ## Step 5: 클러스터 매니저 UI 접속
 
 ```bash
-kubectl -n aerospike-operator port-forward svc/aerospike-ce-kubernetes-operator-ui 3000:3000
+kubectl -n aerospike-operator port-forward svc/aerospike-ce-kubernetes-operator-ui-web 3100:3100
 ```
 
-브라우저에서 [http://localhost:3000](http://localhost:3000)을 엽니다. UI에서 클러스터 관리, 레코드 탐색, AQL 쿼리 실행 등을 할 수 있습니다.
+브라우저에서 [http://localhost:3100](http://localhost:3100)을 엽니다. UI에서 클러스터 관리, 레코드 탐색, AQL 쿼리 실행 등을 할 수 있습니다.
 
 :::tip
 이 터미널은 열어두세요 — port-forward는 포그라운드에서 실행됩니다. 다음 단계를 위해 새 터미널을 여세요.

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/reference/helm-values.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/reference/helm-values.md
@@ -37,9 +37,9 @@ title: Helm Values 레퍼런스
 | 키 | 타입 | 기본값 | 설명 |
 |-----|------|---------|-------------|
 | `resources.limits.cpu` | string | `500m` | 오퍼레이터 파드 CPU 제한. |
-| `resources.limits.memory` | string | `256Mi` | 오퍼레이터 파드 메모리 제한. |
+| `resources.limits.memory` | string | `512Mi` | 오퍼레이터 파드 메모리 제한. |
 | `resources.requests.cpu` | string | `100m` | 오퍼레이터 파드 CPU 요청. |
-| `resources.requests.memory` | string | `128Mi` | 오퍼레이터 파드 메모리 요청. |
+| `resources.requests.memory` | string | `256Mi` | 오퍼레이터 파드 메모리 요청. |
 
 ## 웹훅
 
@@ -103,9 +103,9 @@ title: Helm Values 레퍼런스
 
 | 키 | 타입 | 기본값 | 설명 |
 |-----|------|---------|-------------|
-| `podDisruptionBudget.enabled` | bool | `false` | 오퍼레이터 디플로이먼트용 PodDisruptionBudget 생성. |
-| `podDisruptionBudget.minAvailable` | int | `1` | 최소 가용 파드 수. `maxUnavailable`과 상호 배타적. |
-| `podDisruptionBudget.maxUnavailable` | int | — | 최대 비가용 파드 수. `minAvailable`과 상호 배타적. |
+| `podDisruptionBudget.enabled` | bool | `true` | 오퍼레이터 디플로이먼트용 PodDisruptionBudget 생성. |
+| `podDisruptionBudget.minAvailable` | int | `""` | 최소 가용 파드 수. `maxUnavailable`과 상호 배타적. `replicaCount`가 1보다 클 때만 설정. |
+| `podDisruptionBudget.maxUnavailable` | int | `1` | 최대 비가용 파드 수. `minAvailable`과 상호 배타적. |
 
 ## Horizontal Pod Autoscaler
 
@@ -136,7 +136,7 @@ title: Helm Values 레퍼런스
 
 ## UI - Aerospike Cluster Manager
 
-Aerospike Cluster Manager는 오퍼레이터와 함께 배포되는 풀스택 웹 대시보드입니다. Aerospike 클러스터를 모니터링하고 관리하기 위한 시각적 인터페이스를 제공합니다.
+Aerospike Cluster Manager는 오퍼레이터와 함께 두 개의 독립적인 Deployment — `api`(FastAPI 백엔드)와 `web`(Next.js 프론트엔드) — 로 배포되는 풀스택 웹 대시보드입니다. Aerospike 클러스터를 모니터링하고 관리하기 위한 시각적 인터페이스를 제공합니다.
 
 ### 일반
 
@@ -144,11 +144,15 @@ Aerospike Cluster Manager는 오퍼레이터와 함께 배포되는 풀스택 �
 |-----|------|---------|-------------|
 | `ui.api.enabled` | bool | `true` | Cluster Manager API (FastAPI) 컴포넌트 배포. `ui.web.enabled=false`와 함께 false로 설정하면 UI를 완전히 끔. |
 | `ui.web.enabled` | bool | `true` | Cluster Manager web (Next.js) 컴포넌트 배포. `ui.api.enabled=false`와 함께 false로 설정하면 UI를 완전히 끔. |
-| `ui.replicaCount` | int | `1` | UI 레플리카 수. |
-| `ui.image.repository` | string | `ghcr.io/aerospike-ce-ecosystem/aerospike-cluster-manager` | UI 컨테이너 이미지 리포지토리. |
-| `ui.image.tag` | string | `"latest"` | UI 컨테이너 이미지 태그. UI는 오퍼레이터와 독립적으로 버전 관리. |
-| `ui.image.pullPolicy` | string | `IfNotPresent` | 이미지 풀 정책. |
-| `ui.imagePullSecrets` | list | `[]` | 프라이빗 레지스트리용 이미지 풀 시크릿. |
+| `ui.replicaCount` | int | `1` | 각 UI Deployment(api / web)의 레플리카 수. |
+| `ui.imageTag` | string | `"0.24.0"` | api/web 두 컴포넌트의 기본 이미지 태그. `aerospike-cluster-manager`는 오퍼레이터와 독립적으로 버전 관리되므로 차트가 검증된 릴리스를 여기에 핀. `""`로 설정 시 `.Chart.AppVersion` 사용. |
+| `ui.api.image.repository` | string | `ghcr.io/aerospike-ce-ecosystem/aerospike-cluster-manager-api` | API(FastAPI) 컨테이너 이미지 리포지토리. |
+| `ui.api.image.tag` | string | `""` | API 이미지 태그. 비어 있으면 `ui.imageTag` 사용. |
+| `ui.api.image.pullPolicy` | string | `IfNotPresent` | API 이미지 풀 정책. |
+| `ui.web.image.repository` | string | `ghcr.io/aerospike-ce-ecosystem/aerospike-cluster-manager-web` | Web(Next.js) 컨테이너 이미지 리포지토리. |
+| `ui.web.image.tag` | string | `""` | Web 이미지 태그. 비어 있으면 `ui.imageTag` 사용. |
+| `ui.web.image.pullPolicy` | string | `IfNotPresent` | Web 이미지 풀 정책. |
+| `ui.imagePullSecrets` | list | `[]` | 프라이빗 레지스트리용 이미지 풀 시크릿 (모든 UI Deployment에 적용). |
 
 ### 서비스 어카운트 & RBAC
 
@@ -178,12 +182,18 @@ Aerospike Cluster Manager는 오퍼레이터와 함께 배포되는 풀스택 �
 
 ### 서비스
 
+UI 컴포넌트별로 각각의 서비스가 생성됩니다.
+
 | 키 | 타입 | 기본값 | 설명 |
 |-----|------|---------|-------------|
-| `ui.service.type` | string | `ClusterIP` | 서비스 타입: `ClusterIP`, `NodePort`, 또는 `LoadBalancer`. |
-| `ui.service.frontendPort` | int | `3000` | 프론트엔드 포트 (Next.js 웹 UI). |
-| `ui.service.backendPort` | int | `8000` | 백엔드 포트 (FastAPI REST API). |
-| `ui.service.annotations` | object | `{}` | UI 서비스 어노테이션. |
+| `ui.api.service.type` | string | `ClusterIP` | API 서비스 타입: `ClusterIP`, `NodePort`, 또는 `LoadBalancer`. |
+| `ui.api.service.port` | int | `80` | API 서비스 포트. 트래픽은 컨테이너 포트 8000으로 전달됨. |
+| `ui.api.service.targetPort` | int | `8000` | API 컨테이너 포트 (non-root 실행이므로 비특권 포트). |
+| `ui.api.service.annotations` | object | `{}` | API 서비스 어노테이션. |
+| `ui.web.service.type` | string | `ClusterIP` | Web 서비스 타입: `ClusterIP`, `NodePort`, 또는 `LoadBalancer`. |
+| `ui.web.service.port` | int | `3100` | Web 서비스 포트. 브라우저 접근 시 port-forward(또는 Ingress 라우팅) 대상 포트. |
+| `ui.web.service.annotations` | object | `{}` | Web 서비스 어노테이션. |
+| `ui.web.env.apiUrl` | string | `""` | 외부 API URL. 설정 시 web 파드의 `proxy.js`가 in-cluster API 서비스 대신 이 주소로 `/api/*`를 전달. `ui.api.enabled=false`일 때 필수. |
 
 ### Ingress
 
@@ -219,7 +229,7 @@ Aerospike Cluster Manager는 오퍼레이터와 함께 배포되는 풀스택 �
 | 키 | 타입 | 기본값 | 설명 |
 |-----|------|---------|-------------|
 | `ui.persistence.enabled` | bool | `true` | 내장 PostgreSQL 데이터베이스용 영구 스토리지 활성화. |
-| `ui.persistence.storageClassName` | string | `""` | 스토리지 클래스 이름 (비어있으면 기본값). |
+| `ui.persistence.storageClassName` | string | `null` | 스토리지 클래스 이름. `null`=클러스터 기본 StorageClass, `""`=동적 프로비저닝 비활성화, `"이름"`=지정한 StorageClass 사용. |
 | `ui.persistence.accessMode` | string | `ReadWriteOnce` | 접근 모드. |
 | `ui.persistence.size` | string | `1Gi` | 볼륨 크기. |
 
@@ -240,12 +250,18 @@ UI 컨테이너에는 **preStop 라이프사이클 훅** (`sleep 5`)이 포함�
 
 ### UI 리소스
 
+api와 web Deployment는 각각 독립적인 리소스 설정을 가집니다.
+
 | 키 | 타입 | 기본값 | 설명 |
 |-----|------|---------|-------------|
-| `ui.resources.requests.cpu` | string | `100m` | CPU 요청. |
-| `ui.resources.requests.memory` | string | `256Mi` | 메모리 요청. |
-| `ui.resources.limits.cpu` | string | `200m` | CPU 제한. |
-| `ui.resources.limits.memory` | string | `512Mi` | 메모리 제한. |
+| `ui.api.resources.requests.cpu` | string | `100m` | API CPU 요청. |
+| `ui.api.resources.requests.memory` | string | `256Mi` | API 메모리 요청. |
+| `ui.api.resources.limits.cpu` | string | `200m` | API CPU 제한. |
+| `ui.api.resources.limits.memory` | string | `512Mi` | API 메모리 제한. |
+| `ui.web.resources.requests.cpu` | string | `50m` | Web CPU 요청. |
+| `ui.web.resources.requests.memory` | string | `128Mi` | Web 메모리 요청. |
+| `ui.web.resources.limits.cpu` | string | `150m` | Web CPU 제한. |
+| `ui.web.resources.limits.memory` | string | `384Mi` | Web 메모리 제한. |
 
 ### 보안 컨텍스트
 
@@ -261,31 +277,41 @@ UI 컨테이너에는 **preStop 라이프사이클 훅** (`sleep 5`)이 포함�
 
 ### 프로브
 
+api Deployment는 liveness / readiness / startup 프로브를, web Deployment는 liveness / readiness 프로브를 가집니다.
+
 | 키 | 타입 | 기본값 | 설명 |
 |-----|------|---------|-------------|
-| `ui.livenessProbe.httpGet.path` | string | `/api/health` | Liveness 프로브 경로. |
-| `ui.livenessProbe.httpGet.port` | string | `backend` | Liveness 프로브 포트. |
-| `ui.livenessProbe.initialDelaySeconds` | int | `15` | 초기 대기 시간. |
-| `ui.livenessProbe.periodSeconds` | int | `20` | 점검 주기. |
-| `ui.livenessProbe.timeoutSeconds` | int | `5` | 타임아웃. |
-| `ui.readinessProbe.httpGet.path` | string | `/api/health` | Readiness 프로브 경로. |
-| `ui.readinessProbe.httpGet.port` | string | `backend` | Readiness 프로브 포트. |
-| `ui.readinessProbe.initialDelaySeconds` | int | `5` | 초기 대기 시간. |
-| `ui.readinessProbe.periodSeconds` | int | `10` | 점검 주기. |
-| `ui.readinessProbe.timeoutSeconds` | int | `5` | 타임아웃. |
-| `ui.startupProbe.httpGet.path` | string | `/api/health` | Startup 프로브 경로. |
-| `ui.startupProbe.httpGet.port` | string | `backend` | Startup 프로브 포트. |
-| `ui.startupProbe.periodSeconds` | int | `5` | 점검 주기. |
-| `ui.startupProbe.timeoutSeconds` | int | `3` | 타임아웃. |
-| `ui.startupProbe.failureThreshold` | int | `30` | 포기 전 최대 실패 횟수 (150초 시작 허용). |
+| `ui.api.livenessProbe.httpGet.path` | string | `/api/health` | API liveness 프로브 경로. |
+| `ui.api.livenessProbe.httpGet.port` | string | `api` | API liveness 프로브 포트. |
+| `ui.api.livenessProbe.initialDelaySeconds` | int | `15` | 초기 대기 시간. |
+| `ui.api.livenessProbe.periodSeconds` | int | `20` | 점검 주기. |
+| `ui.api.livenessProbe.timeoutSeconds` | int | `5` | 타임아웃. |
+| `ui.api.readinessProbe.httpGet.path` | string | `/api/health` | API readiness 프로브 경로. |
+| `ui.api.readinessProbe.httpGet.port` | string | `api` | API readiness 프로브 포트. |
+| `ui.api.readinessProbe.initialDelaySeconds` | int | `5` | 초기 대기 시간. |
+| `ui.api.readinessProbe.periodSeconds` | int | `10` | 점검 주기. |
+| `ui.api.readinessProbe.timeoutSeconds` | int | `5` | 타임아웃. |
+| `ui.api.startupProbe.httpGet.path` | string | `/api/health` | API startup 프로브 경로. |
+| `ui.api.startupProbe.httpGet.port` | string | `api` | API startup 프로브 포트. |
+| `ui.api.startupProbe.periodSeconds` | int | `5` | 점검 주기. |
+| `ui.api.startupProbe.timeoutSeconds` | int | `3` | 타임아웃. |
+| `ui.api.startupProbe.failureThreshold` | int | `30` | 포기 전 최대 실패 횟수 (150초 시작 허용). |
+| `ui.web.livenessProbe.httpGet.path` | string | `/` | Web liveness 프로브 경로. |
+| `ui.web.livenessProbe.httpGet.port` | string | `web` | Web liveness 프로브 포트. |
+| `ui.web.livenessProbe.initialDelaySeconds` | int | `15` | 초기 대기 시간. |
+| `ui.web.livenessProbe.periodSeconds` | int | `20` | 점검 주기. |
+| `ui.web.livenessProbe.timeoutSeconds` | int | `5` | 타임아웃. |
+| `ui.web.readinessProbe.httpGet.path` | string | `/` | Web readiness 프로브 경로. |
+| `ui.web.readinessProbe.httpGet.port` | string | `web` | Web readiness 프로브 포트. |
+| `ui.web.readinessProbe.initialDelaySeconds` | int | `5` | 초기 대기 시간. |
+| `ui.web.readinessProbe.periodSeconds` | int | `10` | 점검 주기. |
+| `ui.web.readinessProbe.timeoutSeconds` | int | `5` | 타임아웃. |
 
 ### 환경 변수
 
 | 키 | 타입 | 기본값 | 설명 |
 |-----|------|---------|-------------|
-| `ui.env.frontendPort` | string | (`ui.service.frontendPort`에서 파생) | ConfigMap에 `FRONTEND_PORT`로 주입되는 프론트엔드 포트. 서비스 포트 설정에서 자동 파생. |
-| `ui.env.backendPort` | string | (`ui.service.backendPort`에서 파생) | ConfigMap에 `BACKEND_PORT`로 주입되는 백엔드 포트. 서비스 포트 설정에서 자동 파생. |
-| `ui.env.corsOrigins` | string | `""` | 백엔드 CORS 오리진. 비어있으면 CORS 없음 (프론트엔드가 Next.js rewrites로 프록시). |
+| `ui.env.corsOrigins` | string | `""` | 백엔드 CORS 오리진. 비어있으면 CORS 없음 (web 파드가 `/api/*`를 프록시). |
 | `ui.env.logLevel` | string | `"INFO"` | 로그 레벨: `DEBUG`, `INFO`, `WARNING`, `ERROR`. |
 | `ui.env.logFormat` | string | `"text"` | 로그 형식: `text`(사람이 읽기 쉬운), `json`(구조화된 로깅). |
 | `ui.env.databaseUrl` | string | `""` | 외부 PostgreSQL 연결 URL. `postgresql.enabled`가 `false`일 때만 사용. |
@@ -366,6 +392,6 @@ UI ServiceMonitor는 `/api/metrics` 경로에서 백엔드 메트릭을 스크�
 
 | 키 | 타입 | 기본값 | 설명 |
 |-----|------|---------|-------------|
-| `defaultTemplates.enabled` | bool | `true` | 사전 구축된 AerospikeClusterTemplate 리소스 생성 (minimal, soft-rack, hard-rack). 템플릿은 클러스터 범위이며 모든 네임스페이스에서 접근 가능. |
+| `defaultTemplates.enabled` | bool | `false` | 사전 구축된 AerospikeClusterTemplate 리소스 생성 (minimal, soft-rack, hard-rack). 템플릿은 AerospikeClusterTemplate CRD가 먼저 등록되어야 하므로 기본값은 `false` — 최초 설치 후 `helm upgrade`로 활성화. 템플릿은 클러스터 범위이며 모든 네임스페이스에서 접근 가능. |
 
 세 가지 기본 템플릿 티어는 `defaultTemplates.templates.minimal`, `defaultTemplates.templates.soft-rack`, `defaultTemplates.templates.hard-rack` 아래에 설정됩니다. 각 티어에 대한 자세한 내용은 [템플릿 관리](../configuration/templates.md)를 참조하세요.


### PR DESCRIPTION
## Summary

The Cluster Manager UI Helm chart was split into two independent Deployments — `api` (FastAPI) and `web` (Next.js) — in #231 (`ui.backend`→`ui.api`, drop `ui.frontend`) and #238 (remove `ui.enabled` master switch). The documentation was never fully updated for that split, so it still references pre-split values keys that no longer exist in `values.yaml`.

This PR fixes the stale references across both `en` and `ko` locales.

## What was wrong

| Doc said | Actual chart (1.3.x) |
|---|---|
| `ui.image.repository` / `ui.image.tag` / `ui.image.pullPolicy` | `ui.imageTag` + `ui.api.image.*` / `ui.web.image.*` |
| `ui.service.frontendPort` (3000) / `ui.service.backendPort` (8000) | `ui.api.service.port` (80) / `ui.web.service.port` (3100) |
| `ui.resources.*` | `ui.api.resources.*` / `ui.web.resources.*` |
| `ui.{liveness,readiness,startup}Probe` (port `backend`) | `ui.api.*Probe` (port `api`) / `ui.web.*Probe` (port `web`) |
| `ui.env.frontendPort` / `ui.env.backendPort` | removed (no longer rendered) |
| `port-forward svc/...-ui 3000:3000` | `svc/...-ui-web 3100:3100` |

## Files changed

- `reference/helm-values.md` (en + ko) — UI section rewritten for the api/web split
- `getting-started/cluster-manager-ui.md` (en + ko) — config table + port-forward
- `getting-started/install.md` (en + ko) — port-forward commands + param table
- `quickstart.md` (en + ko) — Step 5 UI port-forward

## Also corrected (factual drift in `helm-values.md`)

- operator `resources`: limit `256Mi`→`512Mi`, request `128Mi`→`256Mi` (matches `values.yaml`)
- `podDisruptionBudget`: `enabled` `false`→`true`, `minAvailable` `1`→`""`, `maxUnavailable` `—`→`1`
- `defaultTemplates.enabled`: `true`→`false`
- `image.tag`: `"latest"`→`""`

## Verification

`npm run build` (Docusaurus) passes for both `en` and `ko` locales — no broken links.

## Out of scope (follow-up)

`helm-values.md` is still missing sections for newer values (`operator.enabled`, `multiCluster.*`, `ui.api.otel.*`, `ui.api.auth.oidc.*` / `ui.web.auth.oidc.*`, `ui.api.logging.*`, `ui.k8s.caFile`). This PR only corrects what was *wrong*; completing the reference can be a separate PR.