### PR TITLE
feat(helm): optional chart-managed PostgreSQL StatefulSet

### DIFF
--- a/charts/aerospike-ce-kubernetes-operator/templates/NOTES.txt
+++ b/charts/aerospike-ce-kubernetes-operator/templates/NOTES.txt
@@ -98,13 +98,15 @@ Ensure acko-crds is installed separately before creating AerospikeCluster resour
   helm install acko-crds oci://ghcr.io/aerospike-ce-ecosystem/charts/acko-crds --version {{ .Chart.Version }}
 {{- end }}
 
-NOTE: The embedded PostgreSQL sidecar has been REMOVED. The api now runs on
-SQLite (embedded file on a PVC, the default) or an EXTERNAL PostgreSQL that
-you operate — the chart no longer ships a `postgres` container.
+NOTE: The embedded PostgreSQL *sidecar* has been REMOVED. The api now runs on
+SQLite (embedded file on a PVC, the default), an EXTERNAL PostgreSQL that you
+operate, or a chart-managed PostgreSQL StatefulSet
+(ui.database.postgresql.deploy=true).
   Migration of values:
-    ui.postgresql.enabled: true   -> ui.database.type: postgresql
-                                     + ui.database.postgresql.databaseUrl
-                                       (point at an external PostgreSQL)
+    ui.postgresql.enabled: true   -> ui.database.type: postgresql, then either
+                                     ui.database.postgresql.databaseUrl (external)
+                                     or ui.database.postgresql.deploy=true
+                                     (chart-managed PostgreSQL StatefulSet)
     ui.postgresql.enabled: false  -> ui.database.type: sqlite   (default)
     ui.persistence.*              -> ui.database.sqlite.persistence.*
     ui.env.databaseUrl            -> ui.database.postgresql.databaseUrl
@@ -336,10 +338,18 @@ View UI logs:
 
 {{- if eq (include "aerospike-ce-kubernetes-operator.ui.api.enabled" .) "true" }}
 {{- if eq .Values.ui.database.type "postgresql" }}
+{{- if .Values.ui.database.postgresql.deploy }}
+
+Database backend: PostgreSQL (chart-managed).
+The chart deployed a single-replica PostgreSQL StatefulSet "{{ include "aerospike-ce-kubernetes-operator.ui.postgres.fullname" . }}"
+(data on a {{ .Values.ui.database.postgresql.persistence.size }} PVC). Convenient, but NOT highly
+available — use an external database (deploy=false) for production HA.
+{{- else }}
 
 Database backend: PostgreSQL (external).
 The chart does NOT deploy PostgreSQL — the api connects to the database via
 {{ if .Values.ui.database.postgresql.existingSecret }}DATABASE_URL in Secret "{{ .Values.ui.database.postgresql.existingSecret }}"{{ else }}ui.database.postgresql.databaseUrl{{ end }}.
+{{- end }}
 {{- else }}
 
 Database backend: SQLite (embedded).

--- a/charts/aerospike-ce-kubernetes-operator/templates/_helpers.tpl
+++ b/charts/aerospike-ce-kubernetes-operator/templates/_helpers.tpl
@@ -198,6 +198,41 @@ app.kubernetes.io/component: ui-web
 {{- end }}
 
 {{/*
+Chart-managed PostgreSQL (ui.database.postgresql.deploy=true) name & labels.
+*/}}
+{{- define "aerospike-ce-kubernetes-operator.ui.postgres.fullname" -}}
+{{- include "aerospike-ce-kubernetes-operator.ui.fullname" . }}-postgres
+{{- end }}
+
+{{- define "aerospike-ce-kubernetes-operator.ui.postgres.selectorLabels" -}}
+{{ include "aerospike-ce-kubernetes-operator.ui.selectorLabels" . }}
+app.kubernetes.io/component: ui-postgres
+{{- end }}
+
+{{- define "aerospike-ce-kubernetes-operator.ui.postgres.labels" -}}
+helm.sh/chart: {{ include "aerospike-ce-kubernetes-operator.chart" . }}
+{{ include "aerospike-ce-kubernetes-operator.ui.postgres.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Name of the Secret carrying the api's DATABASE_URL.
+- deploy=true  -> the chart's own "<ui.fullname>-postgres" Secret.
+- deploy=false -> the user's existingSecret, else the chart's "<ui.fullname>-db"
+  Secret built from databaseUrl.
+*/}}
+{{- define "aerospike-ce-kubernetes-operator.ui.database.secretName" -}}
+{{- if .Values.ui.database.postgresql.deploy -}}
+{{- include "aerospike-ce-kubernetes-operator.ui.postgres.fullname" . -}}
+{{- else -}}
+{{- .Values.ui.database.postgresql.existingSecret | default (printf "%s-db" (include "aerospike-ce-kubernetes-operator.ui.fullname" .)) -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 UI component-specific common labels.
 */}}
 {{- define "aerospike-ce-kubernetes-operator.ui.api.labels" -}}
@@ -423,9 +458,30 @@ stale sidecar-era value keys and on invalid backend combinations.
 {{- /* The remaining checks only matter when the api Deployment is rendered. */ -}}
 {{- if eq (include "aerospike-ce-kubernetes-operator.ui.api.enabled" .) "true" -}}
 {{- if eq $type "postgresql" -}}
-{{- if and (not .Values.ui.database.postgresql.databaseUrl) (not .Values.ui.database.postgresql.existingSecret) -}}
-{{- fail "ui.database.type=postgresql requires either ui.database.postgresql.databaseUrl or ui.database.postgresql.existingSecret — the chart connects to an external PostgreSQL and never provisions one." -}}
+{{- if .Values.ui.database.postgresql.deploy -}}
+{{- /* Chart-managed PostgreSQL: the chart provisions the database and builds
+       DATABASE_URL itself, so the external-connection keys must be unset. */ -}}
+{{- if .Values.ui.database.postgresql.existingSecret -}}
+{{- fail "ui.database.postgresql.deploy=true provisions a chart-managed PostgreSQL and builds its own Secret — unset ui.database.postgresql.existingSecret (it applies only to an external database)." -}}
 {{- end -}}
+{{- if .Values.ui.database.postgresql.databaseUrl -}}
+{{- fail "ui.database.postgresql.deploy=true provisions a chart-managed PostgreSQL and builds DATABASE_URL itself — unset ui.database.postgresql.databaseUrl (it applies only to an external database)." -}}
+{{- end -}}
+{{- /* The password is embedded verbatim in DATABASE_URL; reject characters
+       that would corrupt the connection string (the auto-generated default
+       is always safe). */ -}}
+{{- if and .Values.ui.database.postgresql.auth.password (not (regexMatch "^[A-Za-z0-9._~-]+$" .Values.ui.database.postgresql.auth.password)) -}}
+{{- fail "ui.database.postgresql.auth.password contains a character outside [A-Za-z0-9._~-]. The chart embeds it verbatim in DATABASE_URL, so URL-special characters (@ : / ? # ...) would corrupt the connection string. Use a password from that set, or leave it empty to auto-generate one." -}}
+{{- end -}}
+{{- else -}}
+{{- /* External PostgreSQL: a connection URL is mandatory. */ -}}
+{{- if and (not .Values.ui.database.postgresql.databaseUrl) (not .Values.ui.database.postgresql.existingSecret) -}}
+{{- fail "ui.database.type=postgresql requires either ui.database.postgresql.databaseUrl or ui.database.postgresql.existingSecret for an external database — or set ui.database.postgresql.deploy=true to let the chart provision a PostgreSQL StatefulSet." -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- if and (eq $type "sqlite") .Values.ui.database.postgresql.deploy -}}
+{{- fail "ui.database.postgresql.deploy=true has no effect with ui.database.type=sqlite. Set ui.database.type=postgresql to deploy the chart-managed PostgreSQL, or unset the deploy flag." -}}
 {{- end -}}
 {{- if and (eq $type "sqlite") (gt (int .Values.ui.replicaCount) 1) -}}
 {{- fail "ui.database.type=sqlite is single-writer and is incompatible with ui.replicaCount > 1. Switch to ui.database.type=postgresql with an external database for multi-replica / HA deployments." -}}

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/deployment-api.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/deployment-api.yaml
@@ -69,6 +69,9 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/ui/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/ui/secret.yaml") . | sha256sum }}
+        {{- if .Values.ui.database.postgresql.deploy }}
+        checksum/db-secret: {{ include (print $.Template.BasePath "/ui/postgres-secret.yaml") . | sha256sum }}
+        {{- end }}
         {{- if .Values.ui.api.logging.sidecar.enabled }}
         checksum/log-shipper-config: {{ include (print $.Template.BasePath "/ui/configmap-log-shipper.yaml") . | sha256sum }}
         {{- end }}
@@ -96,8 +99,41 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.ui.terminationGracePeriodSeconds | default 45 }}
-      {{- if .Values.ui.api.extraPipPackages }}
+      {{- $pgManaged := and (eq .Values.ui.database.type "postgresql") .Values.ui.database.postgresql.deploy -}}
+      {{- if or .Values.ui.api.extraPipPackages $pgManaged }}
       initContainers:
+        {{- if $pgManaged }}
+        {{- /* Block api startup until the chart-managed PostgreSQL accepts
+               connections, so the api does not crash-loop on first install
+               while the database is still initialising. `-U` is passed
+               explicitly: this container inherits the UI pod's runAsUser
+               (1001), which has no /etc/passwd entry in the postgres image,
+               and libpq tools report "no attempt" if they must look the
+               current uid up to derive a default user. */}}
+        - name: wait-for-postgres
+          image: "{{ .Values.ui.database.postgresql.image.repository }}:{{ .Values.ui.database.postgresql.image.tag }}"
+          imagePullPolicy: {{ .Values.ui.database.postgresql.image.pullPolicy }}
+          command:
+            - sh
+            - -c
+            - |
+              until pg_isready -h {{ include "aerospike-ce-kubernetes-operator.ui.postgres.fullname" . }} -p 5432 -U '{{ .Values.ui.database.postgresql.auth.username }}'; do
+                echo "waiting for PostgreSQL to accept connections..."
+                sleep 2
+              done
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 50m
+              memory: 32Mi
+          {{- with .Values.ui.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        {{- end }}
+        {{- if .Values.ui.api.extraPipPackages }}
         - name: install-extra-packages
           image: {{ include "aerospike-ce-kubernetes-operator.ui.api.image" . }}
           imagePullPolicy: {{ .Values.ui.api.image.pullPolicy }}
@@ -111,6 +147,7 @@ spec:
           volumeMounts:
             - name: extra-packages
               mountPath: /extra-packages
+        {{- end }}
       {{- end }}
       containers:
         - name: api
@@ -123,14 +160,28 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ include "aerospike-ce-kubernetes-operator.ui.fullname" . }}-config
-            {{- if eq .Values.ui.database.type "postgresql" }}
+            {{- if and (eq .Values.ui.database.type "postgresql") (not .Values.ui.database.postgresql.deploy) }}
+            {{- /* External PostgreSQL: the -db / existingSecret carries only
+                   DATABASE_URL, so envFrom is safe. The chart-managed Secret
+                   also holds POSTGRES_PASSWORD, so that case injects just
+                   DATABASE_URL explicitly below instead of envFrom. */}}
             - secretRef:
-                name: {{ .Values.ui.database.postgresql.existingSecret | default (printf "%s-db" (include "aerospike-ce-kubernetes-operator.ui.fullname" .)) }}
+                name: {{ include "aerospike-ce-kubernetes-operator.ui.database.secretName" . }}
             {{- end }}
             {{- with .Values.ui.api.extraEnvFrom }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
           env:
+            {{- if and (eq .Values.ui.database.type "postgresql") .Values.ui.database.postgresql.deploy }}
+            {{- /* Chart-managed PostgreSQL: inject only DATABASE_URL — the
+                   shared Secret also holds POSTGRES_PASSWORD, which the api
+                   does not need, so it is not pulled in via envFrom. */}}
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "aerospike-ce-kubernetes-operator.ui.database.secretName" . }}
+                  key: DATABASE_URL
+            {{- end }}
             {{- if .Values.ui.api.extraPipPackages }}
             - name: PYTHONPATH
               value: /extra-packages

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/networkpolicy.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/networkpolicy.yaml
@@ -23,6 +23,13 @@ spec:
         - port: {{ .Values.ui.web.service.port }}
           protocol: TCP
         {{- end }}
+        {{- if and (eq .Values.ui.database.type "postgresql") .Values.ui.database.postgresql.deploy }}
+        {{- /* This NetworkPolicy's podSelector also matches the chart-managed
+               PostgreSQL pod (it shares the ui.selectorLabels); allow the
+               api -> PostgreSQL connection on 5432. */}}
+        - port: 5432
+          protocol: TCP
+        {{- end }}
       {{- with .Values.ui.networkPolicy.ingressFrom }}
       from:
         {{- toYaml . | nindent 8 }}
@@ -53,7 +60,7 @@ spec:
         - port: {{ .Values.ui.aerospikePorts.heartbeat }}
           protocol: TCP
     {{- if eq .Values.ui.database.type "postgresql" }}
-    # External PostgreSQL
+    # PostgreSQL (external instance or chart-managed pod)
     - ports:
         - port: 5432
           protocol: TCP

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/postgres-secret.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/postgres-secret.yaml
@@ -1,0 +1,39 @@
+{{- /*
+Secret for the chart-managed PostgreSQL StatefulSet
+(ui.database.postgresql.deploy=true).
+
+Carries POSTGRES_PASSWORD (consumed by the postgres container) and the
+assembled DATABASE_URL (consumed by the api container via envFrom). When
+ui.database.postgresql.auth.password is empty the password is generated once
+and preserved across `helm upgrade` by re-reading the existing Secret
+(`lookup` is empty on fresh installs and on `helm template`).
+
+Not rendered for an external PostgreSQL (deploy=false) — see secret.yaml.
+*/}}
+{{- if and (eq (include "aerospike-ce-kubernetes-operator.ui.api.enabled" .) "true") (eq .Values.ui.database.type "postgresql") .Values.ui.database.postgresql.deploy }}
+{{- $pg := .Values.ui.database.postgresql -}}
+{{- $name := include "aerospike-ce-kubernetes-operator.ui.postgres.fullname" . -}}
+{{- $password := $pg.auth.password -}}
+{{- if not $password -}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace $name -}}
+{{- if and $existing (hasKey (default (dict) $existing.data) "POSTGRES_PASSWORD") -}}
+{{- $password = index $existing.data "POSTGRES_PASSWORD" | b64dec -}}
+{{- else -}}
+{{- $password = randAlphaNum 24 -}}
+{{- end -}}
+{{- end -}}
+{{- /* randAlphaNum / a sane user password is URL-safe, so no escaping is
+       needed when embedding it in the connection URL. */ -}}
+{{- $url := printf "postgresql://%s:%s@%s:5432/%s" $pg.auth.username $password $name $pg.auth.database -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "aerospike-ce-kubernetes-operator.ui.postgres.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  POSTGRES_PASSWORD: {{ $password | quote }}
+  DATABASE_URL: {{ $url | quote }}
+{{- end }}

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/postgres-service.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/postgres-service.yaml
@@ -1,0 +1,25 @@
+{{- /*
+ClusterIP Service for the chart-managed PostgreSQL StatefulSet
+(ui.database.postgresql.deploy=true). Doubles as the StatefulSet's
+serviceName. The api reaches PostgreSQL at "<name>:5432" via this stable VIP.
+
+Not rendered for an external PostgreSQL (deploy=false).
+*/}}
+{{- if and (eq (include "aerospike-ce-kubernetes-operator.ui.api.enabled" .) "true") (eq .Values.ui.database.type "postgresql") .Values.ui.database.postgresql.deploy }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "aerospike-ce-kubernetes-operator.ui.postgres.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "aerospike-ce-kubernetes-operator.ui.postgres.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: postgres
+      protocol: TCP
+  selector:
+    {{- include "aerospike-ce-kubernetes-operator.ui.postgres.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/postgres-statefulset.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/postgres-statefulset.yaml
@@ -1,0 +1,128 @@
+{{- /*
+Chart-managed PostgreSQL StatefulSet (ui.database.postgresql.deploy=true).
+
+A single-replica PostgreSQL running the official postgres image with its data
+directory (PGDATA) on a per-pod PersistentVolumeClaim. The api consumes
+DATABASE_URL from the "<ui.fullname>-postgres" Secret (postgres-secret.yaml).
+
+This is a convenience backend — single-replica, NOT highly available. For
+production HA use an external managed PostgreSQL (deploy=false).
+*/}}
+{{- if and (eq (include "aerospike-ce-kubernetes-operator.ui.api.enabled" .) "true") (eq .Values.ui.database.type "postgresql") .Values.ui.database.postgresql.deploy }}
+{{- $pg := .Values.ui.database.postgresql -}}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "aerospike-ce-kubernetes-operator.ui.postgres.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "aerospike-ce-kubernetes-operator.ui.postgres.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  serviceName: {{ include "aerospike-ce-kubernetes-operator.ui.postgres.fullname" . }}
+  selector:
+    matchLabels:
+      {{- include "aerospike-ce-kubernetes-operator.ui.postgres.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "aerospike-ce-kubernetes-operator.ui.postgres.selectorLabels" . | nindent 8 }}
+      {{- with .Values.ui.podLabels }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      annotations:
+        checksum/secret: {{ include (print $.Template.BasePath "/ui/postgres-secret.yaml") . | sha256sum }}
+      {{- with .Values.ui.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.ui.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $pg.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.ui.terminationGracePeriodSeconds | default 45 }}
+      containers:
+        - name: postgres
+          image: "{{ $pg.image.repository }}:{{ $pg.image.tag }}"
+          imagePullPolicy: {{ $pg.image.pullPolicy }}
+          ports:
+            - name: postgres
+              containerPort: 5432
+              protocol: TCP
+          env:
+            - name: POSTGRES_DB
+              value: {{ $pg.auth.database | quote }}
+            - name: POSTGRES_USER
+              value: {{ $pg.auth.username | quote }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "aerospike-ce-kubernetes-operator.ui.postgres.fullname" . }}
+                  key: POSTGRES_PASSWORD
+            {{- /* PGDATA is a sub-directory of the mounted volume so the
+                   volume root (which may carry a lost+found) is never the
+                   data directory. */}}
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          {{- with $pg.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          livenessProbe:
+            exec:
+              command: ["pg_isready", "-U", {{ $pg.auth.username | quote }}, "-d", {{ $pg.auth.database | quote }}]
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 6
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", {{ $pg.auth.username | quote }}, "-d", {{ $pg.auth.database | quote }}]
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+          {{- with $pg.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+      {{- with $pg.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $pg.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $pg.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if not $pg.persistence.enabled }}
+      volumes:
+        - name: data
+          emptyDir: {}
+      {{- end }}
+  {{- if $pg.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+        labels:
+          {{- include "aerospike-ce-kubernetes-operator.ui.postgres.labels" . | nindent 10 }}
+      spec:
+        accessModes:
+          - {{ $pg.persistence.accessMode }}
+        {{- if not (kindIs "invalid" $pg.persistence.storageClassName) }}
+        storageClassName: {{ $pg.persistence.storageClassName | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ $pg.persistence.size }}
+  {{- end }}
+{{- end }}

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/secret.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/secret.yaml
@@ -1,18 +1,18 @@
 {{- /*
-DATABASE_URL Secret for the external PostgreSQL backend.
+DATABASE_URL Secret for an EXTERNAL PostgreSQL backend.
 
-Rendered only when ui.database.type=postgresql AND the operator did not
-bring their own Secret via ui.database.postgresql.existingSecret. The chart
-never provisions PostgreSQL itself — this Secret simply carries the
-connection URL of an external instance into the api container's environment.
+Rendered only when ui.database.type=postgresql with deploy=false and no
+ui.database.postgresql.existingSecret — it simply carries the connection URL
+of an external instance into the api container's environment.
 
-For the default SQLite backend no Secret is needed (the database is a local
-file on a PVC), so nothing is rendered.
+When ui.database.postgresql.deploy=true the chart-managed PostgreSQL ships
+its own Secret (postgres-secret.yaml) instead. For the default SQLite backend
+no Secret is needed (the database is a local file on a PVC).
 
 Backend / value validation (databaseUrl-or-existingSecret presence) lives in
 the "...validate.databaseConfig" helper so the failure message is uniform.
 */}}
-{{- if and (eq (include "aerospike-ce-kubernetes-operator.ui.api.enabled" .) "true") (eq .Values.ui.database.type "postgresql") (not .Values.ui.database.postgresql.existingSecret) }}
+{{- if and (eq (include "aerospike-ce-kubernetes-operator.ui.api.enabled" .) "true") (eq .Values.ui.database.type "postgresql") (not .Values.ui.database.postgresql.deploy) (not .Values.ui.database.postgresql.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/aerospike-ce-kubernetes-operator/values.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/values.yaml
@@ -781,10 +781,12 @@ ui:
   #     SQLite is single-writer: keep ui.replicaCount=1 (the chart fails the
   #     install otherwise). Best for single-instance / small deployments.
   #
-  #   postgresql — an EXTERNAL PostgreSQL instance that you operate (managed
-  #     services such as RDS / Cloud SQL / AlloyDB, an in-cluster PostgreSQL
-  #     operator, etc.). Required for HA / multi-replica. This chart never
-  #     deploys PostgreSQL itself — there is no embedded sidecar.
+  #   postgresql — a PostgreSQL database. Either an EXTERNAL instance you
+  #     operate (managed services such as RDS / Cloud SQL / AlloyDB, an
+  #     in-cluster PostgreSQL operator, etc.), or — when
+  #     database.postgresql.deploy=true — a single-replica PostgreSQL
+  #     StatefulSet that this chart provisions and wires up for you.
+  #     Required for HA / multi-replica. There is no embedded sidecar.
   # =============================================================================
   database:
     # -- Database backend: "sqlite" (embedded, default) or "postgresql" (external).
@@ -817,21 +819,100 @@ ui:
         size: 1Gi
 
     # -- PostgreSQL backend settings. Used only when database.type=postgresql.
-    # The chart connects to an external database; it does not provision one.
     postgresql:
+      # -- Deploy a chart-managed PostgreSQL StatefulSet instead of connecting
+      # to an external instance.
+      #   false (default) — connect to an EXTERNAL PostgreSQL via databaseUrl /
+      #     existingSecret; the chart provisions no database.
+      #   true            — the chart renders a single-replica PostgreSQL
+      #     StatefulSet + Service + Secret and wires the api's DATABASE_URL to
+      #     it automatically (databaseUrl / existingSecret are then ignored).
+      # NOTE: the StatefulSet is single-replica — convenient, not
+      # highly-available. For production HA run an external managed database
+      # and leave deploy=false.
+      deploy: false
+
       # -- Full connection URL of the external PostgreSQL instance.
-      # Example: "postgresql://user:pass@db-host:5432/aerospike_manager"
+      # Used only when deploy=false. Example:
+      #   "postgresql://user:pass@db-host:5432/aerospike_manager"
       # Leave empty and set existingSecret to keep credentials out of values.
       databaseUrl: ""
-      # -- Use an existing Secret instead of databaseUrl.
-      # The Secret must contain a DATABASE_URL key.
+      # -- Use an existing Secret (with a DATABASE_URL key) instead of
+      # databaseUrl. Used only when deploy=false.
       existingSecret: ""
+
       # -- Connection pool minimum size (DB_POOL_MIN_SIZE)
       poolMinSize: 2
       # -- Connection pool maximum size (DB_POOL_MAX_SIZE)
       poolMaxSize: 10
       # -- SQL command execution timeout in seconds (DB_COMMAND_TIMEOUT)
       commandTimeout: 30
+
+      # -----------------------------------------------------------------------
+      # Chart-managed PostgreSQL — every setting below applies only when
+      # deploy=true. The chart renders a StatefulSet running the official
+      # postgres image with its data directory on a PersistentVolumeClaim.
+      # -----------------------------------------------------------------------
+      # -- PostgreSQL container image (used only when deploy=true).
+      image:
+        repository: postgres
+        tag: "17"
+        pullPolicy: IfNotPresent
+      # -- Database name / credentials created on first start (deploy=true).
+      auth:
+        # -- Database name.
+        database: aerospike_manager
+        # -- Database user.
+        username: aerospike
+        # -- Password. When empty the chart generates a 24-character random
+        # password on first install and preserves it across `helm upgrade` by
+        # re-reading the existing Secret. `helm uninstall` deletes the Secret;
+        # set an explicit password if credentials must survive a full
+        # uninstall/reinstall against a retained data volume.
+        password: ""
+      # -- Data directory persistence for the PostgreSQL StatefulSet.
+      persistence:
+        # -- Persist the data directory on a PVC (volumeClaimTemplate). When
+        # false an emptyDir is used and all data is lost on pod restart.
+        enabled: true
+        # -- Storage class. null = cluster default StorageClass,
+        # "" = pre-provisioned PV, "name" = a specific StorageClass.
+        storageClassName: null
+        # -- Access mode.
+        accessMode: ReadWriteOnce
+        # -- Volume size.
+        size: 8Gi
+      # -- Resource requests / limits for the PostgreSQL container.
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          cpu: 500m
+          memory: 512Mi
+      # -- Pod-level securityContext. The official postgres image runs as
+      # uid/gid 999; fsGroup makes the data volume group-writable so the
+      # container can run non-root.
+      podSecurityContext:
+        runAsUser: 999
+        runAsGroup: 999
+        fsGroup: 999
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      # -- Container-level securityContext for the PostgreSQL container.
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: false
+        capabilities:
+          drop:
+            - ALL
+      # -- Node selector for the PostgreSQL pod.
+      nodeSelector: {}
+      # -- Tolerations for the PostgreSQL pod.
+      tolerations: []
+      # -- Affinity rules for the PostgreSQL pod.
+      affinity: {}
 
   # =============================================================================
   # K8s Cluster Management

--- a/docs/content/getting-started/cluster-manager-ui.md
+++ b/docs/content/getting-started/cluster-manager-ui.md
@@ -531,11 +531,38 @@ database. The backend is selected with `ui.database.type`:
   persisted on a PersistentVolumeClaim. No extra infrastructure. SQLite is
   single-writer, so `ui.replicaCount` must stay `1` (the chart fails the
   install otherwise).
-- **`postgresql`** — connects to an **external** PostgreSQL instance you
-  operate (RDS, Cloud SQL, AlloyDB, an in-cluster PostgreSQL operator, …).
-  Required for HA / multi-replica. The chart never deploys PostgreSQL itself.
+- **`postgresql`** — a PostgreSQL database, in one of two sub-modes:
+  - **chart-managed** (`ui.database.postgresql.deploy=true`) — the chart
+    provisions a single-replica PostgreSQL StatefulSet (data on a PVC) and
+    wires the api to it automatically. Turnkey, but not highly available.
+  - **external** (`deploy=false`, default) — connects to a PostgreSQL
+    instance you operate (RDS, Cloud SQL, AlloyDB, an in-cluster operator, …).
+    The right choice for HA / multi-replica.
 
-To use an external PostgreSQL, supply the connection URL:
+### Chart-managed PostgreSQL
+
+Let the chart run PostgreSQL for you — no external database required:
+
+```bash
+helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kubernetes-operator \
+  --namespace aerospike-operator --create-namespace \
+  --set ui.database.type=postgresql \
+  --set ui.database.postgresql.deploy=true
+```
+
+This renders a `<release>-...-ui-postgres` StatefulSet (official `postgres`
+image, data on an 8Gi PVC), a Service, and a Secret holding an auto-generated
+password. The api's `DATABASE_URL` is wired automatically. Tune the database
+via `ui.database.postgresql.image` / `.auth` / `.persistence` / `.resources`.
+
+:::warning
+The chart-managed StatefulSet is **single-replica** — convenient, not highly
+available. For production HA, use an external PostgreSQL instead (below).
+:::
+
+### External PostgreSQL
+
+To connect to a PostgreSQL instance you operate, supply the connection URL:
 
 ```bash
 helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kubernetes-operator \
@@ -584,10 +611,11 @@ restore → upgrade runbook.
 | `ui.resources.requests.memory` | UI container memory request | `256Mi` |
 | `ui.resources.limits.cpu` | UI container CPU limit | `200m` |
 | `ui.resources.limits.memory` | UI container memory limit | `512Mi` |
-| `ui.database.type` | Database backend: `sqlite` (embedded, default) or `postgresql` (external) | `sqlite` |
+| `ui.database.type` | Database backend: `sqlite` (embedded, default) or `postgresql` | `sqlite` |
 | `ui.database.sqlite.persistence.enabled` | Persist the SQLite database file on a PVC | `true` |
 | `ui.database.sqlite.persistence.size` | SQLite PVC storage size | `1Gi` |
-| `ui.database.postgresql.databaseUrl` | External PostgreSQL connection URL (when `type=postgresql`) | `""` |
+| `ui.database.postgresql.deploy` | Provision a chart-managed PostgreSQL StatefulSet (when `type=postgresql`) | `false` |
+| `ui.database.postgresql.databaseUrl` | External PostgreSQL connection URL (when `type=postgresql`, `deploy=false`) | `""` |
 | `ui.database.postgresql.existingSecret` | Existing Secret with a `DATABASE_URL` key (alternative to `databaseUrl`) | `""` |
 | `ui.env.corsOrigins` | Backend CORS origins (empty string = disable CORS; frontend proxies via Next.js rewrites) | `""` |
 | `ui.env.logLevel` | Log level (`DEBUG`, `INFO`, `WARNING`, `ERROR`) | `"INFO"` |

--- a/docs/content/reference/helm-values.md
+++ b/docs/content/reference/helm-values.md
@@ -205,9 +205,11 @@ When `ui.rbac.create=true`, the generated ClusterRole includes the following per
 ### Database
 
 The api persists cluster connection metadata in a database. The backend is
-selected by `ui.database.type` — `sqlite` (embedded, default) or `postgresql`
-(external). The chart never deploys PostgreSQL itself; the embedded PostgreSQL
-sidecar of earlier chart versions has been removed.
+selected by `ui.database.type` — `sqlite` (embedded, default) or `postgresql`.
+For `postgresql` you can either connect to an external instance, or set
+`ui.database.postgresql.deploy=true` to have the chart provision a
+single-replica PostgreSQL StatefulSet for you. The embedded PostgreSQL
+*sidecar* of earlier chart versions has been removed.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
@@ -223,13 +225,38 @@ sidecar of earlier chart versions has been removed.
 | `ui.database.postgresql.poolMaxSize` | int | `10` | Connection pool maximum size (`DB_POOL_MAX_SIZE`). |
 | `ui.database.postgresql.commandTimeout` | int | `30` | SQL command execution timeout in seconds (`DB_COMMAND_TIMEOUT`). |
 
+The keys below provision a **chart-managed** PostgreSQL and apply only when `ui.database.postgresql.deploy=true`.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `ui.database.postgresql.deploy` | bool | `false` | When `true`, the chart provisions a single-replica PostgreSQL StatefulSet + Service + Secret and wires the api's `DATABASE_URL` to it automatically (`databaseUrl` / `existingSecret` are then ignored and rejected). When `false`, connect to an external instance. |
+| `ui.database.postgresql.image.repository` | string | `postgres` | Chart-managed PostgreSQL image repository. |
+| `ui.database.postgresql.image.tag` | string | `"17"` | PostgreSQL image tag. |
+| `ui.database.postgresql.image.pullPolicy` | string | `IfNotPresent` | PostgreSQL image pull policy. |
+| `ui.database.postgresql.auth.database` | string | `aerospike_manager` | Database name created on first start. |
+| `ui.database.postgresql.auth.username` | string | `aerospike` | Database user. |
+| `ui.database.postgresql.auth.password` | string | `""` | Database password. Empty = a 24-character random password is generated on first install and preserved across `helm upgrade`. |
+| `ui.database.postgresql.persistence.enabled` | bool | `true` | Persist the data directory on a PVC (`volumeClaimTemplate`). When `false`, an `emptyDir` is used and all data is lost on pod restart. |
+| `ui.database.postgresql.persistence.storageClassName` | string | `null` | Storage class for the PostgreSQL PVC. `null` = cluster default, `""` = pre-provisioned PV, `"name"` = specified StorageClass. |
+| `ui.database.postgresql.persistence.accessMode` | string | `ReadWriteOnce` | PostgreSQL PVC access mode. |
+| `ui.database.postgresql.persistence.size` | string | `8Gi` | PostgreSQL PVC volume size. |
+| `ui.database.postgresql.resources` | object | `100m`/`256Mi` → `500m`/`512Mi` | Resource requests / limits for the PostgreSQL container. |
+| `ui.database.postgresql.podSecurityContext` | object | `runAsUser/runAsGroup/fsGroup: 999` | Pod-level securityContext for the PostgreSQL pod. |
+| `ui.database.postgresql.securityContext` | object | drops all capabilities | Container-level securityContext for the PostgreSQL container. |
+| `ui.database.postgresql.nodeSelector` | object | `{}` | Node selector for the PostgreSQL pod. |
+| `ui.database.postgresql.tolerations` | list | `[]` | Tolerations for the PostgreSQL pod. |
+| `ui.database.postgresql.affinity` | object | `{}` | Affinity rules for the PostgreSQL pod. |
+
 **SQLite (default)** stores data in a single file inside the api container,
 backed by a PersistentVolumeClaim. It is single-writer, so `ui.replicaCount`
 must stay `1` — the chart fails the install otherwise.
 
-**PostgreSQL** mode connects to an external database that you operate (managed
-services such as RDS / Cloud SQL / AlloyDB, or an in-cluster PostgreSQL
-operator). Required for HA / multi-replica deployments.
+**PostgreSQL** mode has two sub-modes. With `deploy=false` (default) it
+connects to an **external** database that you operate (managed services such
+as RDS / Cloud SQL / AlloyDB, or an in-cluster PostgreSQL operator) — the
+right choice for HA / multi-replica. With `deploy=true` the chart provisions a
+**single-replica** PostgreSQL StatefulSet (data on a PVC) and wires the api to
+it automatically — turnkey, but not highly available.
 
 > **Migration:** stale `ui.postgresql.*` and `ui.persistence.*` keys from the
 > embedded-sidecar era fail the install with a migration message. Map

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/getting-started/cluster-manager-ui.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/getting-started/cluster-manager-ui.md
@@ -7,7 +7,7 @@ title: 클러스터 매니저 UI
 
 [Aerospike Cluster Manager](https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager)는 Aerospike CE 클러스터를 관리하기 위한 웹 기반 GUI입니다. 오퍼레이터 Helm 차트에 번들로 포함되어 있으며, 오퍼레이터와 함께 선택적 컴포넌트로 배포할 수 있습니다.
 
-UI는 클러스터 연결 프로파일을 데이터베이스에 저장합니다. 기본 백엔드는 api 컨테이너에 내장된 SQLite 파일(PVC에 영속 저장)이며, HA·다중 레플리카가 필요하면 외부 PostgreSQL 인스턴스를 사용할 수 있습니다. 차트는 PostgreSQL을 직접 배포하지 않습니다.
+UI는 클러스터 연결 프로파일을 데이터베이스에 저장합니다. 기본 백엔드는 api 컨테이너에 내장된 SQLite 파일(PVC에 영속 저장)이며, `postgresql`로 전환하면 차트가 직접 띄우는 PostgreSQL StatefulSet 또는 직접 운영하는 외부 PostgreSQL 인스턴스를 사용할 수 있습니다.
 
 ---
 
@@ -81,11 +81,12 @@ helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kuber
 | `ui.service.type` | 서비스 타입 (`ClusterIP`, `NodePort`, `LoadBalancer`) | `ClusterIP` |
 | `ui.service.frontendPort` | 프론트엔드 (Next.js) 포트 | `3000` |
 | `ui.service.backendPort` | 백엔드 (FastAPI) 포트 | `8000` |
-| `ui.database.type` | 데이터베이스 백엔드: `sqlite`(내장, 기본값) 또는 `postgresql`(외부) | `sqlite` |
+| `ui.database.type` | 데이터베이스 백엔드: `sqlite`(내장, 기본값) 또는 `postgresql` | `sqlite` |
 | `ui.database.sqlite.persistence.enabled` | SQLite 데이터베이스 파일을 PVC에 영속 저장 | `true` |
 | `ui.database.sqlite.persistence.size` | SQLite PVC 스토리지 크기 | `1Gi` |
 | `ui.database.sqlite.persistence.storageClassName` | SQLite PVC 스토리지 클래스 | `null` |
-| `ui.database.postgresql.databaseUrl` | 외부 PostgreSQL 연결 URL (`type=postgresql` 일 때) | `""` |
+| `ui.database.postgresql.deploy` | 차트 관리형 PostgreSQL StatefulSet 프로비저닝 (`type=postgresql` 일 때) | `false` |
+| `ui.database.postgresql.databaseUrl` | 외부 PostgreSQL 연결 URL (`type=postgresql`, `deploy=false` 일 때) | `""` |
 | `ui.database.postgresql.existingSecret` | `DATABASE_URL` 키를 포함하는 기존 Secret (`databaseUrl` 대안) | `""` |
 | `ui.k8s.enabled` | K8s 클러스터 관리 기능 활성화 | `true` |
 | `ui.ingress.enabled` | 외부 접근용 Ingress 생성 | `false` |
@@ -407,9 +408,30 @@ Aerospike 클러스터에 등록된 사용자 정의 함수(Lua 모듈)를 업�
 api는 클러스터 연결 메타데이터를 데이터베이스에 저장하며, `ui.database.type`으로 백엔드를 선택합니다.
 
 - **`sqlite`** (기본값) — api 컨테이너에 내장된 SQLite 파일을 PVC에 영속 저장합니다. 추가 인프라가 필요 없습니다. SQLite는 단일 라이터(single-writer)이므로 `ui.replicaCount`는 `1`이어야 합니다(그렇지 않으면 차트가 설치를 실패시킵니다).
-- **`postgresql`** — 직접 운영하는 **외부** PostgreSQL 인스턴스(RDS, Cloud SQL, AlloyDB, 클러스터 내 PostgreSQL 오퍼레이터 등)에 연결합니다. HA·다중 레플리카에 필요합니다. 차트는 PostgreSQL을 직접 배포하지 않습니다.
+- **`postgresql`** — PostgreSQL 데이터베이스로, 두 가지 하위 모드가 있습니다:
+  - **차트 관리형** (`ui.database.postgresql.deploy=true`) — 차트가 단일 레플리카 PostgreSQL StatefulSet(데이터는 PVC)을 프로비저닝하고 api를 자동 연결합니다. 간편하지만 고가용성은 아닙니다.
+  - **외부** (`deploy=false`, 기본값) — 직접 운영하는 PostgreSQL 인스턴스(RDS, Cloud SQL, AlloyDB, 클러스터 내 오퍼레이터 등)에 연결합니다. HA·다중 레플리카에 적합합니다.
 
-외부 PostgreSQL을 사용하려면 연결 URL을 지정합니다:
+### 차트 관리형 PostgreSQL
+
+외부 데이터베이스 없이 차트가 PostgreSQL을 직접 띄우게 합니다:
+
+```bash
+helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kubernetes-operator \
+  --namespace aerospike-operator --create-namespace \
+  --set ui.database.type=postgresql \
+  --set ui.database.postgresql.deploy=true
+```
+
+이렇게 하면 `<릴리스명>-...-ui-postgres` StatefulSet(공식 `postgres` 이미지, 데이터는 8Gi PVC), Service, 자동 생성된 비밀번호를 담은 Secret이 렌더링됩니다. api의 `DATABASE_URL`은 자동으로 연결됩니다. `ui.database.postgresql.image` / `.auth` / `.persistence` / `.resources`로 데이터베이스를 조정할 수 있습니다.
+
+:::warning
+차트 관리형 StatefulSet은 **단일 레플리카**입니다 — 간편하지만 고가용성은 아닙니다. 프로덕션 HA에는 아래의 외부 PostgreSQL을 사용하세요.
+:::
+
+### 외부 PostgreSQL
+
+직접 운영하는 PostgreSQL 인스턴스에 연결하려면 연결 URL을 지정합니다:
 
 ```bash
 helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kubernetes-operator \

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/reference/helm-values.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/reference/helm-values.md
@@ -197,7 +197,7 @@ Aerospike Cluster Manager는 오퍼레이터와 함께 배포되는 풀스택 �
 
 ### 데이터베이스
 
-api는 클러스터 연결 메타데이터를 데이터베이스에 저장합니다. 백엔드는 `ui.database.type`으로 선택하며, `sqlite`(내장, 기본값) 또는 `postgresql`(외부) 중 하나입니다. 차트는 PostgreSQL을 직접 배포하지 않습니다 — 이전 차트 버전의 임베디드 PostgreSQL 사이드카는 제거되었습니다.
+api는 클러스터 연결 메타데이터를 데이터베이스에 저장합니다. 백엔드는 `ui.database.type`으로 선택하며, `sqlite`(내장, 기본값) 또는 `postgresql` 중 하나입니다. `postgresql`은 외부 인스턴스에 연결하거나, `ui.database.postgresql.deploy=true`로 차트가 단일 레플리카 PostgreSQL StatefulSet을 직접 프로비저닝하도록 할 수 있습니다. 이전 차트 버전의 임베디드 PostgreSQL *사이드카*는 제거되었습니다.
 
 | 키 | 타입 | 기본값 | 설명 |
 |-----|------|---------|-------------|
@@ -213,9 +213,31 @@ api는 클러스터 연결 메타데이터를 데이터베이스에 저장합니
 | `ui.database.postgresql.poolMaxSize` | int | `10` | 커넥션 풀 최대 크기 (`DB_POOL_MAX_SIZE`). |
 | `ui.database.postgresql.commandTimeout` | int | `30` | SQL 명령 실행 타임아웃 (초, `DB_COMMAND_TIMEOUT`). |
 
+아래 키들은 **차트 관리형** PostgreSQL을 프로비저닝하며 `ui.database.postgresql.deploy=true`일 때만 적용됩니다.
+
+| 키 | 타입 | 기본값 | 설명 |
+|-----|------|---------|-------------|
+| `ui.database.postgresql.deploy` | bool | `false` | `true`이면 차트가 단일 레플리카 PostgreSQL StatefulSet + Service + Secret을 프로비저닝하고 api의 `DATABASE_URL`을 자동 연결(`databaseUrl` / `existingSecret`은 무시·거부됨). `false`이면 외부 인스턴스에 연결. |
+| `ui.database.postgresql.image.repository` | string | `postgres` | 차트 관리형 PostgreSQL 이미지 리포지토리. |
+| `ui.database.postgresql.image.tag` | string | `"17"` | PostgreSQL 이미지 태그. |
+| `ui.database.postgresql.image.pullPolicy` | string | `IfNotPresent` | PostgreSQL 이미지 풀 정책. |
+| `ui.database.postgresql.auth.database` | string | `aerospike_manager` | 첫 시작 시 생성되는 데이터베이스 이름. |
+| `ui.database.postgresql.auth.username` | string | `aerospike` | 데이터베이스 사용자. |
+| `ui.database.postgresql.auth.password` | string | `""` | 데이터베이스 비밀번호. 비우면 첫 설치 시 24자 무작위 비밀번호를 생성하고 `helm upgrade` 시에도 유지. |
+| `ui.database.postgresql.persistence.enabled` | bool | `true` | PostgreSQL 데이터 디렉터리를 PVC(volumeClaimTemplate)에 영속 저장. `false`이면 `emptyDir`을 사용하며 Pod 재시작 시 데이터가 모두 사라짐. |
+| `ui.database.postgresql.persistence.storageClassName` | string | `null` | PostgreSQL PVC 스토리지 클래스. `null` = 클러스터 기본값, `""` = 사전 프로비저닝 PV, `"name"` = 지정 StorageClass. |
+| `ui.database.postgresql.persistence.accessMode` | string | `ReadWriteOnce` | PostgreSQL PVC 접근 모드. |
+| `ui.database.postgresql.persistence.size` | string | `8Gi` | PostgreSQL PVC 볼륨 크기. |
+| `ui.database.postgresql.resources` | object | `100m`/`256Mi` → `500m`/`512Mi` | PostgreSQL 컨테이너 리소스 requests / limits. |
+| `ui.database.postgresql.podSecurityContext` | object | `runAsUser/runAsGroup/fsGroup: 999` | PostgreSQL 파드 레벨 securityContext. |
+| `ui.database.postgresql.securityContext` | object | 모든 capability 제거 | PostgreSQL 컨테이너 레벨 securityContext. |
+| `ui.database.postgresql.nodeSelector` | object | `{}` | PostgreSQL 파드 노드 셀렉터. |
+| `ui.database.postgresql.tolerations` | list | `[]` | PostgreSQL 파드 toleration. |
+| `ui.database.postgresql.affinity` | object | `{}` | PostgreSQL 파드 어피니티. |
+
 **SQLite (기본값)** 는 api 컨테이너 내부의 단일 파일에 데이터를 저장하며 PersistentVolumeClaim으로 백업됩니다. 단일 라이터이므로 `ui.replicaCount`는 `1`이어야 합니다 — 그렇지 않으면 차트가 설치를 실패시킵니다.
 
-**PostgreSQL** 모드는 직접 운영하는 외부 데이터베이스(RDS / Cloud SQL / AlloyDB 같은 관리형 서비스, 또는 클러스터 내 PostgreSQL 오퍼레이터)에 연결합니다. HA·다중 레플리카 배포에 필요합니다.
+**PostgreSQL** 모드는 두 가지 하위 모드를 가집니다. `deploy=false`(기본값)이면 직접 운영하는 **외부** 데이터베이스(RDS / Cloud SQL / AlloyDB 같은 관리형 서비스, 또는 클러스터 내 PostgreSQL 오퍼레이터)에 연결하며 HA·다중 레플리카에 적합합니다. `deploy=true`이면 차트가 **단일 레플리카** PostgreSQL StatefulSet(데이터는 PVC)을 프로비저닝하고 api를 자동 연결합니다 — 간편하지만 고가용성은 아닙니다.
 
 > **마이그레이션:** 임베디드 사이드카 시절의 구버전 `ui.postgresql.*` / `ui.persistence.*` 키는 설치 시 마이그레이션 안내 메시지와 함께 실패합니다. `ui.postgresql.enabled: true` → `ui.database.type: postgresql` + `ui.database.postgresql.databaseUrl`, `ui.postgresql.enabled: false` → `ui.database.type: sqlite`, `ui.persistence.*` → `ui.database.sqlite.persistence.*`, `ui.env.databaseUrl` → `ui.database.postgresql.databaseUrl`로 매핑하세요. 임베디드 PostgreSQL에서 자동 데이터 마이그레이션은 제공되지 않으며, 임베디드 사이드카 릴리스에서의 업그레이드는 `ui.database.acknowledgeEmbeddedPostgresRemoval=true`를 설정할 때까지 차단됩니다. `pg_dump` → 복원 → 업그레이드 런북은 차트 README의 "Migrating off the embedded PostgreSQL sidecar" 절을 참고하세요.
 


### PR DESCRIPTION
## Summary

`ui.database.type=postgresql` was **external-only** since #274. This adds an opt-in **chart-managed PostgreSQL** mode: with `ui.database.postgresql.deploy=true` the chart provisions a single-replica PostgreSQL `StatefulSet` + `Service` + `Secret` and wires the api's `DATABASE_URL` to it automatically — a turnkey backend that needs no external database and no SQLite single-writer constraint.

This does **not** revert #274: SQLite stays the default, `deploy=false` (external PostgreSQL) stays the production-HA recommendation. The new mode is purely additive and opt-in.

## Design

| Mode | `ui.database.type` | `...postgresql.deploy` | Result |
|------|--------------------|------------------------|--------|
| SQLite (default) | `sqlite` | — | embedded SQLite file on a PVC |
| Chart-managed PG | `postgresql` | `true` | chart deploys a PostgreSQL StatefulSet |
| External PG | `postgresql` | `false` | connect to a PostgreSQL you operate |

## Changes

**New templates** (all gated on `type=postgresql` AND `deploy=true`):
- `templates/ui/postgres-statefulset.yaml` — single-replica `postgres:17`, `PGDATA` on a per-pod PVC (`volumeClaimTemplate`), `pg_isready` liveness/readiness, non-root (uid/gid 999) securityContext.
- `templates/ui/postgres-service.yaml` — ClusterIP Service (also the StatefulSet `serviceName`).
- `templates/ui/postgres-secret.yaml` — generates a 24-char password (preserved across `helm upgrade` via `lookup`) and assembles `DATABASE_URL`.

**Wiring:**
- New `ui.database.secretName` helper — the api Deployment resolves its DB Secret through it (`-postgres` Secret when `deploy=true`, else the existing `-db` / `existingSecret`).
- `secret.yaml` (external `-db` Secret) is skipped when `deploy=true`.
- The api gets a `wait-for-postgres` init container so it does not crash-loop while PostgreSQL initialises. `pg_isready` is passed `-U` explicitly — the init container inherits the UI `runAsUser` (1001), which has no `/etc/passwd` entry in the postgres image, and libpq tools report "no attempt" if they must look the uid up.
- `networkpolicy.yaml` — allow api→postgres `:5432` ingress when `deploy=true` (the UI NetworkPolicy's podSelector also matches the postgres pod).
- The chart-managed Secret uses a distinct name (`-postgres`, not `-db`) so it never trips #274's embedded-sidecar upgrade-block check.

**Validation** (`validate.databaseConfig`): `deploy=true` rejects `databaseUrl`/`existingSecret`; external mode still requires one of them; `deploy=true` with `type=sqlite` fails with a clear message.

**Docs:** `reference/helm-values.md` + `getting-started/cluster-manager-ui.md` (en + ko) document the option and all `ui.database.postgresql.*` keys.

## Testing — verified on a Kind cluster

```
helm install acko . --set ui.database.type=postgresql --set ui.database.postgresql.deploy=true ...
```

- ✅ PostgreSQL StatefulSet + Service + Secret render and deploy; PVC binds (8Gi).
- ✅ api connects, initialises its schema (4 tables created in `aerospike_manager`).
- ✅ Fresh install: api `wait-for-postgres` init container gates startup → **0 restarts** on both pods.
- ✅ `helm upgrade` preserves the generated password (the `lookup` logic).
- ✅ `helm lint` clean; `helm template` renders correctly for all three modes.
- ✅ Validation failures fire as expected (deploy + databaseUrl, sqlite + deploy, postgresql + no URL).

## Limitations

The StatefulSet is **single-replica** — convenient, not highly available. For production HA, run an external managed PostgreSQL (`deploy=false`). This is stated in the values comments, NOTES.txt, and docs.