### PR TITLE
fix(helm): chart-managed PostgreSQL as Deployment + GitOps-safe Secret

### DIFF
--- a/charts/aerospike-ce-kubernetes-operator/README.md
+++ b/charts/aerospike-ce-kubernetes-operator/README.md
@@ -234,13 +234,14 @@ sidecar configuration.
 
 #### Database backend
 
-The api persists cluster connection metadata in a database. Two backends are
-supported via `ui.database.type`:
+The api persists cluster connection metadata in a database. The backend is
+selected by `ui.database.type`:
 
-| `ui.database.type` | Where the data lives | Use when |
-|--------------------|----------------------|----------|
+| Backend | Where the data lives | Use when |
+|---------|----------------------|----------|
 | `sqlite` (default) | Embedded SQLite file inside the api container, on a PVC (`ui.database.sqlite.persistence`) | Single-instance installs. Zero extra infrastructure. SQLite is single-writer, so `ui.replicaCount` must stay `1`. |
-| `postgresql`       | An **external** PostgreSQL instance you operate (RDS / Cloud SQL / AlloyDB / an in-cluster PostgreSQL operator) | HA / multi-replica. The chart never deploys PostgreSQL itself. |
+| `postgresql`, external (`deploy=false`) | An **external** PostgreSQL instance you operate (RDS / Cloud SQL / AlloyDB / an in-cluster PostgreSQL operator) | HA / multi-replica. The chart provisions no database. |
+| `postgresql`, chart-managed (`deploy=true`) | A single-replica PostgreSQL **Deployment** the chart provisions (Service + data PVC + Secret) | A turnkey PostgreSQL with no external dependency. Convenient, **not** highly available. |
 
 SQLite (default) — nothing to configure:
 
@@ -259,6 +260,37 @@ helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/acko \
   --set ui.database.type=postgresql \
   --set ui.database.postgresql.databaseUrl='postgresql://user:pass@db-host:5432/aerospike_manager'
 ```
+
+Chart-managed PostgreSQL — let the chart run a single-replica PostgreSQL
+`Deployment` and wire the api to it:
+
+```bash
+helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/acko \
+  --version 0.4.0 --namespace aerospike-operator --create-namespace \
+  --set ui.database.type=postgresql \
+  --set ui.database.postgresql.deploy=true
+```
+
+The data PVC carries `helm.sh/resource-policy: keep`, so it survives `helm
+uninstall` — delete it by hand to discard the database. This backend is
+single-replica (`Recreate` update strategy on a `ReadWriteOnce` volume); run an
+external PostgreSQL for HA.
+
+> **GitOps (ArgoCD / Flux / kustomize `helmCharts`) — keep the password stable.**
+> With `deploy=true` and an empty `auth.password`, the chart generates a random
+> `POSTGRES_PASSWORD` and preserves it by re-reading the live Secret. That
+> `lookup` only works for a server-side `helm install` / `helm upgrade` — a
+> **client-side `helm template`** (what GitOps tools run) cannot read the
+> cluster, so it regenerates the password on **every** render and breaks the
+> running database. Pick one of:
+>
+> - **`ui.database.postgresql.auth.password`** — set an explicit password
+>   (`[A-Za-z0-9._~-]` characters only). Simple, but the password sits in values.
+> - **`ui.database.postgresql.existingSecret`** — point at a Secret you manage
+>   (sealed-secret / vault) carrying both `POSTGRES_PASSWORD` and a `DATABASE_URL`
+>   (`postgresql://<user>:<pass>@<release>-…-ui-postgres:5432/<db>`). The chart
+>   then renders no Secret of its own. This keeps credentials out of Git and is
+>   the recommended GitOps path.
 
 #### Migrating off the embedded PostgreSQL sidecar
 

--- a/charts/aerospike-ce-kubernetes-operator/README.md
+++ b/charts/aerospike-ce-kubernetes-operator/README.md
@@ -332,6 +332,41 @@ UI.
 
 **Value mapping:** `ui.postgresql.enabled: true` → `ui.database.type: postgresql` + `ui.database.postgresql.databaseUrl`; `ui.postgresql.enabled: false` → `ui.database.type: sqlite`; `ui.persistence.*` → `ui.database.sqlite.persistence.*`; `ui.env.databaseUrl` → `ui.database.postgresql.databaseUrl`. Stale `ui.postgresql.*` / `ui.persistence.*` keys fail the install with a migration message.
 
+#### Upgrading the chart-managed PostgreSQL (StatefulSet → Deployment)
+
+Chart **v1.6.0** ran the chart-managed PostgreSQL (`deploy=true`) as a
+`StatefulSet` whose data lived on a `volumeClaimTemplate` PVC named
+`data-<release>-…-ui-postgres-0`. Newer chart versions run it as a
+`Deployment` with a standalone PVC named `<release>-…-ui-postgres-data`.
+
+A plain `helm upgrade` would delete the StatefulSet (its PVC is **retained**
+but orphaned) and start the Deployment on a **new, empty** PVC — the database
+is silently lost. To protect against that, the chart **blocks the upgrade**
+when it detects the leftover StatefulSet, until you set
+`ui.database.postgresql.acknowledgeStatefulSetMigration=true`.
+
+**Migration runbook (preserve your data):**
+
+```bash
+# 1. Back up the database from the running StatefulSet pod
+kubectl exec -n <ns> <release>-aerospike-ce-kubernetes-operator-ui-postgres-0 \
+  -- pg_dump -U aerospike -d aerospike_manager --no-owner --no-privileges \
+  > acm-pg-backup.sql
+
+# 2. Upgrade — the chart replaces the StatefulSet with a Deployment + new PVC
+helm upgrade <release> oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kubernetes-operator \
+  -n <ns> --reuse-values \
+  --set ui.database.postgresql.acknowledgeStatefulSetMigration=true
+
+# 3. Restore into the new Deployment's database
+kubectl exec -i -n <ns> deploy/<release>-aerospike-ce-kubernetes-operator-ui-postgres \
+  -- psql -U aerospike -d aerospike_manager -v ON_ERROR_STOP=1 < acm-pg-backup.sql
+```
+
+The old `data-<release>-…-ui-postgres-0` PVC is left untouched — delete it by
+hand once the restore is verified. On a fresh install there is no StatefulSet,
+so the gate never fires.
+
 #### Customizing the UI deployment
 
 You can customize the UI with service annotations, resource defaults, and extra environment variables:

--- a/charts/aerospike-ce-kubernetes-operator/templates/NOTES.txt
+++ b/charts/aerospike-ce-kubernetes-operator/templates/NOTES.txt
@@ -100,13 +100,13 @@ Ensure acko-crds is installed separately before creating AerospikeCluster resour
 
 NOTE: The embedded PostgreSQL *sidecar* has been REMOVED. The api now runs on
 SQLite (embedded file on a PVC, the default), an EXTERNAL PostgreSQL that you
-operate, or a chart-managed PostgreSQL StatefulSet
+operate, or a chart-managed PostgreSQL Deployment
 (ui.database.postgresql.deploy=true).
   Migration of values:
     ui.postgresql.enabled: true   -> ui.database.type: postgresql, then either
                                      ui.database.postgresql.databaseUrl (external)
                                      or ui.database.postgresql.deploy=true
-                                     (chart-managed PostgreSQL StatefulSet)
+                                     (chart-managed PostgreSQL Deployment)
     ui.postgresql.enabled: false  -> ui.database.type: sqlite   (default)
     ui.persistence.*              -> ui.database.sqlite.persistence.*
     ui.env.databaseUrl            -> ui.database.postgresql.databaseUrl
@@ -341,9 +341,19 @@ View UI logs:
 {{- if .Values.ui.database.postgresql.deploy }}
 
 Database backend: PostgreSQL (chart-managed).
-The chart deployed a single-replica PostgreSQL StatefulSet "{{ include "aerospike-ce-kubernetes-operator.ui.postgres.fullname" . }}"
+The chart deployed a single-replica PostgreSQL Deployment "{{ include "aerospike-ce-kubernetes-operator.ui.postgres.fullname" . }}"
 (data on a {{ .Values.ui.database.postgresql.persistence.size }} PVC). Convenient, but NOT highly
 available — use an external database (deploy=false) for production HA.
+{{- if not .Values.ui.database.postgresql.existingSecret }}
+{{- if not .Values.ui.database.postgresql.auth.password }}
+
+  GitOps note: the POSTGRES_PASSWORD in Secret "{{ include "aerospike-ce-kubernetes-operator.ui.postgres.fullname" . }}"
+  was auto-generated. A client-side `helm template` (ArgoCD / Flux / kustomize)
+  regenerates it on every render — set ui.database.postgresql.auth.password
+  explicitly, or point ui.database.postgresql.existingSecret at a pre-baked
+  Secret, to keep it stable.
+{{- end }}
+{{- end }}
 {{- else }}
 
 Database backend: PostgreSQL (external).

--- a/charts/aerospike-ce-kubernetes-operator/templates/_helpers.tpl
+++ b/charts/aerospike-ce-kubernetes-operator/templates/_helpers.tpl
@@ -468,6 +468,19 @@ stale sidecar-era value keys and on invalid backend combinations.
 {{- fail (printf "Upgrade blocked: Secret %q carries a POSTGRES_PASSWORD key, so this release previously ran the embedded PostgreSQL sidecar (removed in this chart version). Upgrading does NOT migrate that data -- with ui.database.type=sqlite the old database is stranded on the PVC, with type=postgresql the PVC is deleted. Back it up first (pg_dump the embedded database), restore it into your chosen backend, then re-run with ui.database.acknowledgeEmbeddedPostgresRemoval=true. See the chart README 'Database' migration section." $dbSecretName) -}}
 {{- end -}}
 {{- end -}}
+{{- /* Upgrade safety: the chart-managed PostgreSQL shipped as a StatefulSet
+       through chart v1.6.0; it now runs as a Deployment whose data PVC has a
+       different name. A `helm upgrade` would strand the StatefulSet's volume
+       and start the Deployment on a fresh, EMPTY database. Detect the leftover
+       StatefulSet and refuse the upgrade until the operator acknowledges it
+       (after backing the data up). `lookup` is empty on fresh installs and on
+       `helm template`, so this fires only on a real in-cluster upgrade. */ -}}
+{{- if and .Values.ui.database.postgresql.deploy (not .Values.ui.database.postgresql.acknowledgeStatefulSetMigration) -}}
+{{- $pgName := include "aerospike-ce-kubernetes-operator.ui.postgres.fullname" . -}}
+{{- if lookup "apps/v1" "StatefulSet" .Release.Namespace $pgName -}}
+{{- fail (printf "Upgrade blocked: StatefulSet %q is the chart-managed PostgreSQL from chart v1.6.0 or earlier. This chart version runs it as a Deployment whose data PVC is named %q, while the StatefulSet's volume is %q -- upgrading would start an EMPTY database and strand that old volume. Back the data up (pg_dump), then set ui.database.postgresql.acknowledgeStatefulSetMigration=true to proceed and restore afterwards. See the chart README 'Database' migration section." $pgName (include "aerospike-ce-kubernetes-operator.ui.postgres.pvcName" .) (printf "data-%s-0" $pgName)) -}}
+{{- end -}}
+{{- end -}}
 {{- /* The remaining checks only matter when the api Deployment is rendered. */ -}}
 {{- if eq (include "aerospike-ce-kubernetes-operator.ui.api.enabled" .) "true" -}}
 {{- if eq $type "postgresql" -}}

--- a/charts/aerospike-ce-kubernetes-operator/templates/_helpers.tpl
+++ b/charts/aerospike-ce-kubernetes-operator/templates/_helpers.tpl
@@ -219,16 +219,29 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
 {{/*
+Name of the data PVC for the chart-managed PostgreSQL Deployment
+(ui.database.postgresql.deploy=true with persistence.enabled=true).
+*/}}
+{{- define "aerospike-ce-kubernetes-operator.ui.postgres.pvcName" -}}
+{{- include "aerospike-ce-kubernetes-operator.ui.postgres.fullname" . }}-data
+{{- end }}
+
+{{/*
 Name of the Secret carrying the api's DATABASE_URL.
-- deploy=true  -> the chart's own "<ui.fullname>-postgres" Secret.
-- deploy=false -> the user's existingSecret, else the chart's "<ui.fullname>-db"
-  Secret built from databaseUrl.
+- existingSecret set -> the operator-supplied Secret (works for an external
+  database AND, with deploy=true, as a GitOps-safe alternative to the chart's
+  randomly-generated Secret — it then also carries POSTGRES_PASSWORD).
+- deploy=true        -> the chart's own "<ui.fullname>-postgres" Secret.
+- deploy=false       -> the chart's "<ui.fullname>-db" Secret built from
+  databaseUrl.
 */}}
 {{- define "aerospike-ce-kubernetes-operator.ui.database.secretName" -}}
-{{- if .Values.ui.database.postgresql.deploy -}}
+{{- if .Values.ui.database.postgresql.existingSecret -}}
+{{- .Values.ui.database.postgresql.existingSecret -}}
+{{- else if .Values.ui.database.postgresql.deploy -}}
 {{- include "aerospike-ce-kubernetes-operator.ui.postgres.fullname" . -}}
 {{- else -}}
-{{- .Values.ui.database.postgresql.existingSecret | default (printf "%s-db" (include "aerospike-ce-kubernetes-operator.ui.fullname" .)) -}}
+{{- printf "%s-db" (include "aerospike-ce-kubernetes-operator.ui.fullname" .) -}}
 {{- end -}}
 {{- end }}
 
@@ -459,19 +472,31 @@ stale sidecar-era value keys and on invalid backend combinations.
 {{- if eq (include "aerospike-ce-kubernetes-operator.ui.api.enabled" .) "true" -}}
 {{- if eq $type "postgresql" -}}
 {{- if .Values.ui.database.postgresql.deploy -}}
-{{- /* Chart-managed PostgreSQL: the chart provisions the database and builds
-       DATABASE_URL itself, so the external-connection keys must be unset. */ -}}
-{{- if .Values.ui.database.postgresql.existingSecret -}}
-{{- fail "ui.database.postgresql.deploy=true provisions a chart-managed PostgreSQL and builds its own Secret — unset ui.database.postgresql.existingSecret (it applies only to an external database)." -}}
-{{- end -}}
+{{- /* Chart-managed PostgreSQL: the chart provisions the database (Deployment
+       + Service + data PVC). databaseUrl is an INLINE external connection URL
+       and never applies here. existingSecret IS allowed — it lets an operator
+       supply a pre-baked Secret (sealed-secret / vault) carrying
+       POSTGRES_PASSWORD + DATABASE_URL instead of the chart's
+       randomly-generated one. That is the GitOps-safe path: a client-side
+       `helm template` (ArgoCD / Flux / kustomize) cannot preserve a random
+       password across renders, so it would otherwise regenerate it every
+       reconcile. */ -}}
 {{- if .Values.ui.database.postgresql.databaseUrl -}}
-{{- fail "ui.database.postgresql.deploy=true provisions a chart-managed PostgreSQL and builds DATABASE_URL itself — unset ui.database.postgresql.databaseUrl (it applies only to an external database)." -}}
+{{- fail "ui.database.postgresql.deploy=true provisions a chart-managed PostgreSQL and builds DATABASE_URL itself — unset ui.database.postgresql.databaseUrl (it applies only to an external database). To supply credentials yourself, use ui.database.postgresql.existingSecret instead." -}}
 {{- end -}}
-{{- /* The password is embedded verbatim in DATABASE_URL; reject characters
-       that would corrupt the connection string (the auto-generated default
-       is always safe). */ -}}
+{{- if .Values.ui.database.postgresql.existingSecret -}}
+{{- /* The operator-supplied Secret carries the password, so auth.password
+       would be silently ignored — reject the ambiguous combination. */ -}}
+{{- if .Values.ui.database.postgresql.auth.password -}}
+{{- fail "ui.database.postgresql.deploy=true with existingSecret reads the password from that Secret — unset ui.database.postgresql.auth.password (it would be ignored). The existingSecret must carry both POSTGRES_PASSWORD and a DATABASE_URL pointing at the chart's in-cluster PostgreSQL Service." -}}
+{{- end -}}
+{{- else -}}
+{{- /* Chart-generated Secret: the password is embedded verbatim in
+       DATABASE_URL; reject characters that would corrupt the connection
+       string (the auto-generated default is always safe). */ -}}
 {{- if and .Values.ui.database.postgresql.auth.password (not (regexMatch "^[A-Za-z0-9._~-]+$" .Values.ui.database.postgresql.auth.password)) -}}
 {{- fail "ui.database.postgresql.auth.password contains a character outside [A-Za-z0-9._~-]. The chart embeds it verbatim in DATABASE_URL, so URL-special characters (@ : / ? # ...) would corrupt the connection string. Use a password from that set, or leave it empty to auto-generate one." -}}
+{{- end -}}
 {{- end -}}
 {{- else -}}
 {{- /* External PostgreSQL: a connection URL is mandatory. */ -}}

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/postgres-deployment.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/postgres-deployment.yaml
@@ -1,17 +1,25 @@
 {{- /*
-Chart-managed PostgreSQL StatefulSet (ui.database.postgresql.deploy=true).
+Chart-managed PostgreSQL Deployment (ui.database.postgresql.deploy=true).
 
 A single-replica PostgreSQL running the official postgres image with its data
-directory (PGDATA) on a per-pod PersistentVolumeClaim. The api consumes
-DATABASE_URL from the "<ui.fullname>-postgres" Secret (postgres-secret.yaml).
+directory (PGDATA) on a PersistentVolumeClaim (postgres-pvc.yaml). The api
+consumes DATABASE_URL from the database Secret — the chart-built
+"<ui.fullname>-postgres" Secret (postgres-secret.yaml) or, when
+ui.database.postgresql.existingSecret is set, that operator-supplied Secret.
 
 This is a convenience backend — single-replica, NOT highly available. For
 production HA use an external managed PostgreSQL (deploy=false).
+
+A Deployment (not a StatefulSet): the database is single-replica, so the
+ordinal identity / per-replica volume that a StatefulSet provides buys
+nothing. The strategy is Recreate — the data PVC is ReadWriteOnce, so the old
+pod must release the volume before the new one can mount it; a rolling update
+would deadlock on the volume.
 */}}
 {{- if and (eq (include "aerospike-ce-kubernetes-operator.ui.api.enabled" .) "true") (eq .Values.ui.database.type "postgresql") .Values.ui.database.postgresql.deploy }}
 {{- $pg := .Values.ui.database.postgresql -}}
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: {{ include "aerospike-ce-kubernetes-operator.ui.postgres.fullname" . }}
   namespace: {{ .Release.Namespace }}
@@ -19,7 +27,9 @@ metadata:
     {{- include "aerospike-ce-kubernetes-operator.ui.postgres.labels" . | nindent 4 }}
 spec:
   replicas: 1
-  serviceName: {{ include "aerospike-ce-kubernetes-operator.ui.postgres.fullname" . }}
+  {{- /* ReadWriteOnce data PVC — never run two postgres pods at once. */}}
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       {{- include "aerospike-ce-kubernetes-operator.ui.postgres.selectorLabels" . | nindent 6 }}
@@ -61,7 +71,7 @@ spec:
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "aerospike-ce-kubernetes-operator.ui.postgres.fullname" . }}
+                  name: {{ include "aerospike-ce-kubernetes-operator.ui.database.secretName" . }}
                   key: POSTGRES_PASSWORD
             {{- /* PGDATA is a sub-directory of the mounted volume so the
                    volume root (which may carry a lost+found) is never the
@@ -104,25 +114,12 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if not $pg.persistence.enabled }}
       volumes:
         - name: data
+          {{- if $pg.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "aerospike-ce-kubernetes-operator.ui.postgres.pvcName" . }}
+          {{- else }}
           emptyDir: {}
-      {{- end }}
-  {{- if $pg.persistence.enabled }}
-  volumeClaimTemplates:
-    - metadata:
-        name: data
-        labels:
-          {{- include "aerospike-ce-kubernetes-operator.ui.postgres.labels" . | nindent 10 }}
-      spec:
-        accessModes:
-          - {{ $pg.persistence.accessMode }}
-        {{- if not (kindIs "invalid" $pg.persistence.storageClassName) }}
-        storageClassName: {{ $pg.persistence.storageClassName | quote }}
-        {{- end }}
-        resources:
-          requests:
-            storage: {{ $pg.persistence.size }}
-  {{- end }}
+          {{- end }}
 {{- end }}

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/postgres-pvc.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/postgres-pvc.yaml
@@ -1,0 +1,33 @@
+{{- /*
+PersistentVolumeClaim for the chart-managed PostgreSQL Deployment
+(ui.database.postgresql.deploy=true with persistence.enabled=true).
+
+The Deployment (postgres-deployment.yaml) mounts this at
+/var/lib/postgresql/data. The "helm.sh/resource-policy: keep" annotation
+makes `helm uninstall` leave the volume in place so the database survives an
+uninstall/reinstall — delete the PVC by hand to discard the data.
+
+Not rendered when persistence.enabled=false (the Deployment falls back to an
+emptyDir and all data is lost on pod restart).
+*/}}
+{{- if and (eq (include "aerospike-ce-kubernetes-operator.ui.api.enabled" .) "true") (eq .Values.ui.database.type "postgresql") .Values.ui.database.postgresql.deploy .Values.ui.database.postgresql.persistence.enabled }}
+{{- $pg := .Values.ui.database.postgresql -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "aerospike-ce-kubernetes-operator.ui.postgres.pvcName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "aerospike-ce-kubernetes-operator.ui.postgres.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/resource-policy: keep
+spec:
+  accessModes:
+    - {{ $pg.persistence.accessMode }}
+  {{- if not (kindIs "invalid" $pg.persistence.storageClassName) }}
+  storageClassName: {{ $pg.persistence.storageClassName | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ $pg.persistence.size }}
+{{- end }}

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/postgres-secret.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/postgres-secret.yaml
@@ -1,16 +1,24 @@
 {{- /*
-Secret for the chart-managed PostgreSQL StatefulSet
+Secret for the chart-managed PostgreSQL Deployment
 (ui.database.postgresql.deploy=true).
 
 Carries POSTGRES_PASSWORD (consumed by the postgres container) and the
-assembled DATABASE_URL (consumed by the api container via envFrom). When
+assembled DATABASE_URL (consumed by the api container). When
 ui.database.postgresql.auth.password is empty the password is generated once
-and preserved across `helm upgrade` by re-reading the existing Secret
-(`lookup` is empty on fresh installs and on `helm template`).
+and preserved across `helm upgrade` by re-reading the existing Secret.
 
-Not rendered for an external PostgreSQL (deploy=false) — see secret.yaml.
+GitOps caveat: `lookup` is empty on fresh installs AND on every client-side
+`helm template` (ArgoCD / Flux / kustomize). With an empty auth.password such
+a renderer regenerates the password on every reconcile. For a GitOps-safe,
+deterministic password either set ui.database.postgresql.auth.password
+explicitly, or set ui.database.postgresql.existingSecret to a pre-baked Secret
+(sealed-secret / vault) carrying POSTGRES_PASSWORD + DATABASE_URL — in which
+case this template renders nothing and that Secret is used instead.
+
+Not rendered for an external PostgreSQL (deploy=false) — see secret.yaml —
+nor when existingSecret is set.
 */}}
-{{- if and (eq (include "aerospike-ce-kubernetes-operator.ui.api.enabled" .) "true") (eq .Values.ui.database.type "postgresql") .Values.ui.database.postgresql.deploy }}
+{{- if and (eq (include "aerospike-ce-kubernetes-operator.ui.api.enabled" .) "true") (eq .Values.ui.database.type "postgresql") .Values.ui.database.postgresql.deploy (not .Values.ui.database.postgresql.existingSecret) }}
 {{- $pg := .Values.ui.database.postgresql -}}
 {{- $name := include "aerospike-ce-kubernetes-operator.ui.postgres.fullname" . -}}
 {{- $password := $pg.auth.password -}}

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/postgres-service.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/postgres-service.yaml
@@ -1,7 +1,7 @@
 {{- /*
-ClusterIP Service for the chart-managed PostgreSQL StatefulSet
-(ui.database.postgresql.deploy=true). Doubles as the StatefulSet's
-serviceName. The api reaches PostgreSQL at "<name>:5432" via this stable VIP.
+ClusterIP Service for the chart-managed PostgreSQL Deployment
+(ui.database.postgresql.deploy=true). The api reaches PostgreSQL at
+"<name>:5432" via this stable VIP.
 
 Not rendered for an external PostgreSQL (deploy=false).
 */}}

--- a/charts/aerospike-ce-kubernetes-operator/values.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/values.yaml
@@ -785,7 +785,7 @@ ui:
   #     operate (managed services such as RDS / Cloud SQL / AlloyDB, an
   #     in-cluster PostgreSQL operator, etc.), or — when
   #     database.postgresql.deploy=true — a single-replica PostgreSQL
-  #     StatefulSet that this chart provisions and wires up for you.
+  #     Deployment that this chart provisions and wires up for you.
   #     Required for HA / multi-replica. There is no embedded sidecar.
   # =============================================================================
   database:
@@ -820,14 +820,15 @@ ui:
 
     # -- PostgreSQL backend settings. Used only when database.type=postgresql.
     postgresql:
-      # -- Deploy a chart-managed PostgreSQL StatefulSet instead of connecting
+      # -- Deploy a chart-managed PostgreSQL Deployment instead of connecting
       # to an external instance.
       #   false (default) — connect to an EXTERNAL PostgreSQL via databaseUrl /
       #     existingSecret; the chart provisions no database.
       #   true            — the chart renders a single-replica PostgreSQL
-      #     StatefulSet + Service + Secret and wires the api's DATABASE_URL to
-      #     it automatically (databaseUrl / existingSecret are then ignored).
-      # NOTE: the StatefulSet is single-replica — convenient, not
+      #     Deployment + Service + data PVC + Secret and wires the api's
+      #     DATABASE_URL to it automatically. databaseUrl is ignored; set
+      #     existingSecret to supply your own credentials Secret (see below).
+      # NOTE: the Deployment is single-replica — convenient, not
       # highly-available. For production HA run an external managed database
       # and leave deploy=false.
       deploy: false
@@ -837,8 +838,15 @@ ui:
       #   "postgresql://user:pass@db-host:5432/aerospike_manager"
       # Leave empty and set existingSecret to keep credentials out of values.
       databaseUrl: ""
-      # -- Use an existing Secret (with a DATABASE_URL key) instead of
-      # databaseUrl. Used only when deploy=false.
+      # -- Name of an existing Secret holding the database credentials.
+      #   deploy=false — the Secret needs a DATABASE_URL key (external instance).
+      #   deploy=true  — the Secret needs BOTH a POSTGRES_PASSWORD key and a
+      #     DATABASE_URL key. The chart then skips its own randomly-generated
+      #     Secret and reads credentials from yours — the GitOps-safe way to
+      #     keep the password stable across client-side `helm template` renders
+      #     (ArgoCD / Flux / kustomize). The DATABASE_URL must point at the
+      #     chart's in-cluster PostgreSQL Service and use the auth.username /
+      #     auth.database below; auth.password must stay empty.
       existingSecret: ""
 
       # -- Connection pool minimum size (DB_POOL_MIN_SIZE)
@@ -850,7 +858,7 @@ ui:
 
       # -----------------------------------------------------------------------
       # Chart-managed PostgreSQL — every setting below applies only when
-      # deploy=true. The chart renders a StatefulSet running the official
+      # deploy=true. The chart renders a Deployment running the official
       # postgres image with its data directory on a PersistentVolumeClaim.
       # -----------------------------------------------------------------------
       # -- PostgreSQL container image (used only when deploy=true).
@@ -866,14 +874,21 @@ ui:
         username: aerospike
         # -- Password. When empty the chart generates a 24-character random
         # password on first install and preserves it across `helm upgrade` by
-        # re-reading the existing Secret. `helm uninstall` deletes the Secret;
-        # set an explicit password if credentials must survive a full
-        # uninstall/reinstall against a retained data volume.
+        # re-reading the existing Secret.
+        # GitOps caveat: a client-side `helm template` (ArgoCD / Flux /
+        # kustomize) cannot re-read the Secret, so an empty password is
+        # regenerated on every render. For GitOps set this explicitly, or use
+        # existingSecret above. `helm uninstall` deletes the chart's Secret but
+        # KEEPS the data PVC (helm.sh/resource-policy: keep); set an explicit
+        # password (or existingSecret) so credentials survive a full
+        # uninstall/reinstall against that retained volume.
         password: ""
-      # -- Data directory persistence for the PostgreSQL StatefulSet.
+      # -- Data directory persistence for the chart-managed PostgreSQL.
       persistence:
-        # -- Persist the data directory on a PVC (volumeClaimTemplate). When
-        # false an emptyDir is used and all data is lost on pod restart.
+        # -- Persist the data directory on a PersistentVolumeClaim. The PVC
+        # carries helm.sh/resource-policy: keep, so it survives `helm
+        # uninstall`. When false an emptyDir is used and all data is lost on
+        # pod restart.
         enabled: true
         # -- Storage class. null = cluster default StorageClass,
         # "" = pre-provisioned PV, "name" = a specific StorageClass.

--- a/charts/aerospike-ce-kubernetes-operator/values.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/values.yaml
@@ -833,6 +833,14 @@ ui:
       # and leave deploy=false.
       deploy: false
 
+      # -- Upgrade-safety gate for deploy=true. The chart-managed PostgreSQL
+      # shipped as a StatefulSet through chart v1.6.0; it now runs as a
+      # Deployment whose data PVC has a different name. When the chart detects
+      # the leftover StatefulSet it BLOCKS the upgrade until this is true — set
+      # it only AFTER backing the data up (see the chart README "Database"
+      # migration section). No effect on fresh installs.
+      acknowledgeStatefulSetMigration: false
+
       # -- Full connection URL of the external PostgreSQL instance.
       # Used only when deploy=false. Example:
       #   "postgresql://user:pass@db-host:5432/aerospike_manager"
@@ -847,6 +855,9 @@ ui:
       #     (ArgoCD / Flux / kustomize). The DATABASE_URL must point at the
       #     chart's in-cluster PostgreSQL Service and use the auth.username /
       #     auth.database below; auth.password must stay empty.
+      # NOTE: an externally-managed Secret is not tracked by the chart's
+      # pod-restart checksum — after rotating it, run `kubectl rollout restart`
+      # on the postgres and api Deployments to pick up the new credentials.
       existingSecret: ""
 
       # -- Connection pool minimum size (DB_POOL_MIN_SIZE)

--- a/docs/content/getting-started/cluster-manager-ui.md
+++ b/docs/content/getting-started/cluster-manager-ui.md
@@ -533,7 +533,7 @@ database. The backend is selected with `ui.database.type`:
   install otherwise).
 - **`postgresql`** — a PostgreSQL database, in one of two sub-modes:
   - **chart-managed** (`ui.database.postgresql.deploy=true`) — the chart
-    provisions a single-replica PostgreSQL StatefulSet (data on a PVC) and
+    provisions a single-replica PostgreSQL Deployment (data on a PVC) and
     wires the api to it automatically. Turnkey, but not highly available.
   - **external** (`deploy=false`, default) — connects to a PostgreSQL
     instance you operate (RDS, Cloud SQL, AlloyDB, an in-cluster operator, …).
@@ -550,14 +550,27 @@ helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kuber
   --set ui.database.postgresql.deploy=true
 ```
 
-This renders a `<release>-...-ui-postgres` StatefulSet (official `postgres`
+This renders a `<release>-...-ui-postgres` Deployment (official `postgres`
 image, data on an 8Gi PVC), a Service, and a Secret holding an auto-generated
 password. The api's `DATABASE_URL` is wired automatically. Tune the database
 via `ui.database.postgresql.image` / `.auth` / `.persistence` / `.resources`.
 
 :::warning
-The chart-managed StatefulSet is **single-replica** — convenient, not highly
-available. For production HA, use an external PostgreSQL instead (below).
+The chart-managed Deployment is **single-replica** (`Recreate` update strategy
+on a `ReadWriteOnce` volume) — convenient, not highly available. For production
+HA, use an external PostgreSQL instead (below).
+:::
+
+:::warning GitOps — keep the password stable
+With `deploy=true` and an empty `auth.password`, the chart generates a random
+`POSTGRES_PASSWORD` and preserves it by re-reading the live Secret. That only
+works for a server-side `helm install` / `helm upgrade`. A **client-side `helm
+template`** (ArgoCD, Flux, kustomize `helmCharts`) cannot read the cluster, so
+it regenerates the password on every render and breaks the running database.
+For GitOps, either set `ui.database.postgresql.auth.password` explicitly, or
+point `ui.database.postgresql.existingSecret` at a Secret you manage
+(sealed-secret / vault) carrying both `POSTGRES_PASSWORD` and a `DATABASE_URL`.
+The chart then renders no Secret of its own.
 :::
 
 ### External PostgreSQL
@@ -573,7 +586,9 @@ helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kuber
 
 :::tip
 To keep credentials out of values, set `ui.database.postgresql.existingSecret`
-to an existing Kubernetes Secret name. The Secret must contain a `DATABASE_URL` key.
+to an existing Kubernetes Secret name. For an external database the Secret must
+contain a `DATABASE_URL` key; with `deploy=true` it must contain both
+`POSTGRES_PASSWORD` and `DATABASE_URL`.
 :::
 
 :::warning
@@ -613,9 +628,9 @@ restore → upgrade runbook.
 | `ui.database.type` | Database backend: `sqlite` (embedded, default) or `postgresql` | `sqlite` |
 | `ui.database.sqlite.persistence.enabled` | Persist the SQLite database file on a PVC | `true` |
 | `ui.database.sqlite.persistence.size` | SQLite PVC storage size | `1Gi` |
-| `ui.database.postgresql.deploy` | Provision a chart-managed PostgreSQL StatefulSet (when `type=postgresql`) | `false` |
+| `ui.database.postgresql.deploy` | Provision a chart-managed PostgreSQL Deployment (when `type=postgresql`) | `false` |
 | `ui.database.postgresql.databaseUrl` | External PostgreSQL connection URL (when `type=postgresql`, `deploy=false`) | `""` |
-| `ui.database.postgresql.existingSecret` | Existing Secret with a `DATABASE_URL` key (alternative to `databaseUrl`) | `""` |
+| `ui.database.postgresql.existingSecret` | Existing credentials Secret. `deploy=false`: needs `DATABASE_URL`. `deploy=true`: needs `POSTGRES_PASSWORD` + `DATABASE_URL` | `""` |
 | `ui.env.corsOrigins` | Backend CORS origins (empty string = disable CORS; frontend proxies via Next.js rewrites) | `""` |
 | `ui.env.logLevel` | Log level (`DEBUG`, `INFO`, `WARNING`, `ERROR`) | `"INFO"` |
 | `ui.env.logFormat` | Log format: `"text"` (human-readable), `"json"` (structured logging) | `"text"` |

--- a/docs/content/reference/helm-values.md
+++ b/docs/content/reference/helm-values.md
@@ -218,7 +218,7 @@ The api persists cluster connection metadata in a database. The backend is
 selected by `ui.database.type` — `sqlite` (embedded, default) or `postgresql`.
 For `postgresql` you can either connect to an external instance, or set
 `ui.database.postgresql.deploy=true` to have the chart provision a
-single-replica PostgreSQL StatefulSet for you. The embedded PostgreSQL
+single-replica PostgreSQL Deployment for you. The embedded PostgreSQL
 *sidecar* of earlier chart versions has been removed.
 
 | Key | Type | Default | Description |
@@ -230,7 +230,7 @@ single-replica PostgreSQL StatefulSet for you. The embedded PostgreSQL
 | `ui.database.sqlite.persistence.accessMode` | string | `ReadWriteOnce` | PVC access mode. SQLite is single-writer; keep `ReadWriteOnce`. |
 | `ui.database.sqlite.persistence.size` | string | `1Gi` | SQLite PVC volume size. |
 | `ui.database.postgresql.databaseUrl` | string | `""` | Connection URL of the external PostgreSQL instance. Required (or `existingSecret`) when `type=postgresql`. |
-| `ui.database.postgresql.existingSecret` | string | `""` | Existing Secret name containing a `DATABASE_URL` key. Use instead of `databaseUrl` to keep credentials out of values. |
+| `ui.database.postgresql.existingSecret` | string | `""` | Existing Secret holding the database credentials. With `deploy=false` it needs a `DATABASE_URL` key. With `deploy=true` it needs both `POSTGRES_PASSWORD` and `DATABASE_URL` — the chart then renders no Secret of its own (the GitOps-safe way to keep the password stable across `helm template` renders). |
 | `ui.database.postgresql.poolMinSize` | int | `2` | Connection pool minimum size (`DB_POOL_MIN_SIZE`). |
 | `ui.database.postgresql.poolMaxSize` | int | `10` | Connection pool maximum size (`DB_POOL_MAX_SIZE`). |
 | `ui.database.postgresql.commandTimeout` | int | `30` | SQL command execution timeout in seconds (`DB_COMMAND_TIMEOUT`). |
@@ -239,14 +239,14 @@ The keys below provision a **chart-managed** PostgreSQL and apply only when `ui.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `ui.database.postgresql.deploy` | bool | `false` | When `true`, the chart provisions a single-replica PostgreSQL StatefulSet + Service + Secret and wires the api's `DATABASE_URL` to it automatically (`databaseUrl` / `existingSecret` are then ignored and rejected). When `false`, connect to an external instance. |
+| `ui.database.postgresql.deploy` | bool | `false` | When `true`, the chart provisions a single-replica PostgreSQL Deployment + Service + data PVC + Secret and wires the api's `DATABASE_URL` to it automatically. `databaseUrl` is rejected; set `existingSecret` to supply your own credentials Secret. When `false`, connect to an external instance. |
 | `ui.database.postgresql.image.repository` | string | `postgres` | Chart-managed PostgreSQL image repository. |
 | `ui.database.postgresql.image.tag` | string | `"17"` | PostgreSQL image tag. |
 | `ui.database.postgresql.image.pullPolicy` | string | `IfNotPresent` | PostgreSQL image pull policy. |
 | `ui.database.postgresql.auth.database` | string | `aerospike_manager` | Database name created on first start. |
 | `ui.database.postgresql.auth.username` | string | `aerospike` | Database user. |
 | `ui.database.postgresql.auth.password` | string | `""` | Database password. Empty = a 24-character random password is generated on first install and preserved across `helm upgrade`. |
-| `ui.database.postgresql.persistence.enabled` | bool | `true` | Persist the data directory on a PVC (`volumeClaimTemplate`). When `false`, an `emptyDir` is used and all data is lost on pod restart. |
+| `ui.database.postgresql.persistence.enabled` | bool | `true` | Persist the data directory on a PVC (`helm.sh/resource-policy: keep`, so it survives `helm uninstall`). When `false`, an `emptyDir` is used and all data is lost on pod restart. |
 | `ui.database.postgresql.persistence.storageClassName` | string | `null` | Storage class for the PostgreSQL PVC. `null` = cluster default, `""` = pre-provisioned PV, `"name"` = specified StorageClass. |
 | `ui.database.postgresql.persistence.accessMode` | string | `ReadWriteOnce` | PostgreSQL PVC access mode. |
 | `ui.database.postgresql.persistence.size` | string | `8Gi` | PostgreSQL PVC volume size. |
@@ -265,8 +265,11 @@ must stay `1` — the chart fails the install otherwise.
 connects to an **external** database that you operate (managed services such
 as RDS / Cloud SQL / AlloyDB, or an in-cluster PostgreSQL operator) — the
 right choice for HA / multi-replica. With `deploy=true` the chart provisions a
-**single-replica** PostgreSQL StatefulSet (data on a PVC) and wires the api to
-it automatically — turnkey, but not highly available.
+**single-replica** PostgreSQL Deployment (`Recreate` strategy, data on a
+`keep`-policy PVC) and wires the api to it automatically — turnkey, but not
+highly available. For GitOps either set `ui.database.postgresql.auth.password`
+explicitly or point `ui.database.postgresql.existingSecret` at your own Secret,
+so a client-side `helm template` does not regenerate the password each render.
 
 > **Migration:** stale `ui.postgresql.*` and `ui.persistence.*` keys from the
 > embedded-sidecar era fail the install with a migration message. Map

--- a/docs/content/reference/helm-values.md
+++ b/docs/content/reference/helm-values.md
@@ -240,6 +240,7 @@ The keys below provision a **chart-managed** PostgreSQL and apply only when `ui.
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `ui.database.postgresql.deploy` | bool | `false` | When `true`, the chart provisions a single-replica PostgreSQL Deployment + Service + data PVC + Secret and wires the api's `DATABASE_URL` to it automatically. `databaseUrl` is rejected; set `existingSecret` to supply your own credentials Secret. When `false`, connect to an external instance. |
+| `ui.database.postgresql.acknowledgeStatefulSetMigration` | bool | `false` | Upgrade-safety gate for `deploy=true`. Chart v1.6.0 ran the chart-managed PostgreSQL as a StatefulSet; it is now a Deployment with a differently-named data PVC. The chart blocks the upgrade when it detects the leftover StatefulSet until this is `true` (back the database up first — see the migration note below). No effect on fresh installs. |
 | `ui.database.postgresql.image.repository` | string | `postgres` | Chart-managed PostgreSQL image repository. |
 | `ui.database.postgresql.image.tag` | string | `"17"` | PostgreSQL image tag. |
 | `ui.database.postgresql.image.pullPolicy` | string | `IfNotPresent` | PostgreSQL image pull policy. |

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/getting-started/cluster-manager-ui.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/getting-started/cluster-manager-ui.md
@@ -7,7 +7,7 @@ title: 클러스터 매니저 UI
 
 [Aerospike Cluster Manager](https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager)는 Aerospike CE 클러스터를 관리하기 위한 웹 기반 GUI입니다. 오퍼레이터 Helm 차트에 번들로 포함되어 있으며, 오퍼레이터와 함께 선택적 컴포넌트로 배포할 수 있습니다.
 
-UI는 클러스터 연결 프로파일을 데이터베이스에 저장합니다. 기본 백엔드는 api 컨테이너에 내장된 SQLite 파일(PVC에 영속 저장)이며, `postgresql`로 전환하면 차트가 직접 띄우는 PostgreSQL StatefulSet 또는 직접 운영하는 외부 PostgreSQL 인스턴스를 사용할 수 있습니다.
+UI는 클러스터 연결 프로파일을 데이터베이스에 저장합니다. 기본 백엔드는 api 컨테이너에 내장된 SQLite 파일(PVC에 영속 저장)이며, `postgresql`로 전환하면 차트가 직접 띄우는 PostgreSQL Deployment 또는 직접 운영하는 외부 PostgreSQL 인스턴스를 사용할 수 있습니다.
 
 ---
 
@@ -88,9 +88,9 @@ helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kuber
 | `ui.database.sqlite.persistence.enabled` | SQLite 데이터베이스 파일을 PVC에 영속 저장 | `true` |
 | `ui.database.sqlite.persistence.size` | SQLite PVC 스토리지 크기 | `1Gi` |
 | `ui.database.sqlite.persistence.storageClassName` | SQLite PVC 스토리지 클래스 | `null` |
-| `ui.database.postgresql.deploy` | 차트 관리형 PostgreSQL StatefulSet 프로비저닝 (`type=postgresql` 일 때) | `false` |
+| `ui.database.postgresql.deploy` | 차트 관리형 PostgreSQL Deployment 프로비저닝 (`type=postgresql` 일 때) | `false` |
 | `ui.database.postgresql.databaseUrl` | 외부 PostgreSQL 연결 URL (`type=postgresql`, `deploy=false` 일 때) | `""` |
-| `ui.database.postgresql.existingSecret` | `DATABASE_URL` 키를 포함하는 기존 Secret (`databaseUrl` 대안) | `""` |
+| `ui.database.postgresql.existingSecret` | 기존 자격 증명 Secret. `deploy=false`: `DATABASE_URL` 필요. `deploy=true`: `POSTGRES_PASSWORD` + `DATABASE_URL` 필요 | `""` |
 | `ui.k8s.enabled` | K8s 클러스터 관리 기능 활성화 | `true` |
 | `ui.ingress.enabled` | 외부 접근용 Ingress 생성 | `false` |
 | `ui.rbac.create` | K8s API 접근용 ClusterRole 및 ClusterRoleBinding 생성 (AerospikeCluster, Template, HPA 관리 권한 포함) | `true` |
@@ -410,7 +410,7 @@ api는 클러스터 연결 메타데이터를 데이터베이스에 저장하며
 
 - **`sqlite`** (기본값) — api 컨테이너에 내장된 SQLite 파일을 PVC에 영속 저장합니다. 추가 인프라가 필요 없습니다. SQLite는 단일 라이터(single-writer)이므로 `ui.replicaCount`는 `1`이어야 합니다(그렇지 않으면 차트가 설치를 실패시킵니다).
 - **`postgresql`** — PostgreSQL 데이터베이스로, 두 가지 하위 모드가 있습니다:
-  - **차트 관리형** (`ui.database.postgresql.deploy=true`) — 차트가 단일 레플리카 PostgreSQL StatefulSet(데이터는 PVC)을 프로비저닝하고 api를 자동 연결합니다. 간편하지만 고가용성은 아닙니다.
+  - **차트 관리형** (`ui.database.postgresql.deploy=true`) — 차트가 단일 레플리카 PostgreSQL Deployment(데이터는 PVC)을 프로비저닝하고 api를 자동 연결합니다. 간편하지만 고가용성은 아닙니다.
   - **외부** (`deploy=false`, 기본값) — 직접 운영하는 PostgreSQL 인스턴스(RDS, Cloud SQL, AlloyDB, 클러스터 내 오퍼레이터 등)에 연결합니다. HA·다중 레플리카에 적합합니다.
 
 ### 차트 관리형 PostgreSQL
@@ -424,10 +424,22 @@ helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kuber
   --set ui.database.postgresql.deploy=true
 ```
 
-이렇게 하면 `<릴리스명>-...-ui-postgres` StatefulSet(공식 `postgres` 이미지, 데이터는 8Gi PVC), Service, 자동 생성된 비밀번호를 담은 Secret이 렌더링됩니다. api의 `DATABASE_URL`은 자동으로 연결됩니다. `ui.database.postgresql.image` / `.auth` / `.persistence` / `.resources`로 데이터베이스를 조정할 수 있습니다.
+이렇게 하면 `<릴리스명>-...-ui-postgres` Deployment(공식 `postgres` 이미지, 데이터는 8Gi PVC), Service, 자동 생성된 비밀번호를 담은 Secret이 렌더링됩니다. api의 `DATABASE_URL`은 자동으로 연결됩니다. `ui.database.postgresql.image` / `.auth` / `.persistence` / `.resources`로 데이터베이스를 조정할 수 있습니다.
 
 :::warning
-차트 관리형 StatefulSet은 **단일 레플리카**입니다 — 간편하지만 고가용성은 아닙니다. 프로덕션 HA에는 아래의 외부 PostgreSQL을 사용하세요.
+차트 관리형 Deployment는 **단일 레플리카**입니다(`ReadWriteOnce` 볼륨에 `Recreate` 업데이트 전략) — 간편하지만 고가용성은 아닙니다. 프로덕션 HA에는 아래의 외부 PostgreSQL을 사용하세요.
+:::
+
+:::warning GitOps — 비밀번호를 안정적으로 유지하기
+`deploy=true`이고 `auth.password`가 비어 있으면, 차트는 무작위 `POSTGRES_PASSWORD`를
+생성하고 클러스터의 기존 Secret을 다시 읽어 이를 유지합니다. 이 동작은 서버사이드
+`helm install` / `helm upgrade`에서만 작동합니다. **클라이언트사이드 `helm
+template`**(ArgoCD, Flux, kustomize `helmCharts`)은 클러스터를 읽지 못하므로
+매 렌더마다 비밀번호를 재생성하여 실행 중인 데이터베이스를 망가뜨립니다.
+GitOps에서는 `ui.database.postgresql.auth.password`를 명시하거나,
+`ui.database.postgresql.existingSecret`을 직접 관리하는 Secret(sealed-secret /
+vault)에 지정하세요. 그 Secret에는 `POSTGRES_PASSWORD`와 `DATABASE_URL`이 모두
+들어 있어야 하며, 이 경우 차트는 자체 Secret을 렌더링하지 않습니다.
 :::
 
 ### 외부 PostgreSQL
@@ -442,7 +454,7 @@ helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kuber
 ```
 
 :::tip
-자격 증명을 values에 노출하지 않으려면 `ui.database.postgresql.existingSecret`에 기존 Kubernetes Secret 이름을 지정합니다. Secret에는 `DATABASE_URL` 키가 포함되어야 합니다.
+자격 증명을 values에 노출하지 않으려면 `ui.database.postgresql.existingSecret`에 기존 Kubernetes Secret 이름을 지정합니다. 외부 데이터베이스에서는 Secret에 `DATABASE_URL` 키가, `deploy=true`에서는 `POSTGRES_PASSWORD`와 `DATABASE_URL` 키가 모두 포함되어야 합니다.
 :::
 
 :::warning

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/reference/helm-values.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/reference/helm-values.md
@@ -228,6 +228,7 @@ api는 클러스터 연결 메타데이터를 데이터베이스에 저장합니
 | 키 | 타입 | 기본값 | 설명 |
 |-----|------|---------|-------------|
 | `ui.database.postgresql.deploy` | bool | `false` | `true`이면 차트가 단일 레플리카 PostgreSQL Deployment + Service + 데이터 PVC + Secret을 프로비저닝하고 api의 `DATABASE_URL`을 자동 연결. `databaseUrl`은 거부되며, 자체 자격 증명 Secret을 쓰려면 `existingSecret`을 설정. `false`이면 외부 인스턴스에 연결. |
+| `ui.database.postgresql.acknowledgeStatefulSetMigration` | bool | `false` | `deploy=true` 업그레이드 안전 게이트. 차트 v1.6.0은 chart-managed PostgreSQL을 StatefulSet으로 실행했으나 이제 데이터 PVC 이름이 다른 Deployment로 실행됨. 남아 있는 StatefulSet을 감지하면 이 값이 `true`가 될 때까지 업그레이드를 차단(먼저 데이터베이스를 백업 — 아래 마이그레이션 안내 참조). 신규 설치에는 영향 없음. |
 | `ui.database.postgresql.image.repository` | string | `postgres` | 차트 관리형 PostgreSQL 이미지 리포지토리. |
 | `ui.database.postgresql.image.tag` | string | `"17"` | PostgreSQL 이미지 태그. |
 | `ui.database.postgresql.image.pullPolicy` | string | `IfNotPresent` | PostgreSQL 이미지 풀 정책. |

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/reference/helm-values.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/reference/helm-values.md
@@ -207,7 +207,7 @@ UI 컴포넌트별로 각각의 서비스가 생성됩니다.
 
 ### 데이터베이스
 
-api는 클러스터 연결 메타데이터를 데이터베이스에 저장합니다. 백엔드는 `ui.database.type`으로 선택하며, `sqlite`(내장, 기본값) 또는 `postgresql` 중 하나입니다. `postgresql`은 외부 인스턴스에 연결하거나, `ui.database.postgresql.deploy=true`로 차트가 단일 레플리카 PostgreSQL StatefulSet을 직접 프로비저닝하도록 할 수 있습니다. 이전 차트 버전의 임베디드 PostgreSQL *사이드카*는 제거되었습니다.
+api는 클러스터 연결 메타데이터를 데이터베이스에 저장합니다. 백엔드는 `ui.database.type`으로 선택하며, `sqlite`(내장, 기본값) 또는 `postgresql` 중 하나입니다. `postgresql`은 외부 인스턴스에 연결하거나, `ui.database.postgresql.deploy=true`로 차트가 단일 레플리카 PostgreSQL Deployment를 직접 프로비저닝하도록 할 수 있습니다. 이전 차트 버전의 임베디드 PostgreSQL *사이드카*는 제거되었습니다.
 
 | 키 | 타입 | 기본값 | 설명 |
 |-----|------|---------|-------------|
@@ -218,7 +218,7 @@ api는 클러스터 연결 메타데이터를 데이터베이스에 저장합니
 | `ui.database.sqlite.persistence.accessMode` | string | `ReadWriteOnce` | PVC 접근 모드. SQLite는 단일 라이터이므로 `ReadWriteOnce` 유지. |
 | `ui.database.sqlite.persistence.size` | string | `1Gi` | SQLite PVC 볼륨 크기. |
 | `ui.database.postgresql.databaseUrl` | string | `""` | 외부 PostgreSQL 인스턴스의 연결 URL. `type=postgresql`일 때 필수(또는 `existingSecret`). |
-| `ui.database.postgresql.existingSecret` | string | `""` | `DATABASE_URL` 키를 포함하는 기존 Secret 이름. `databaseUrl` 대신 사용해 자격 증명을 values 밖에 둠. |
+| `ui.database.postgresql.existingSecret` | string | `""` | 데이터베이스 자격 증명을 담은 기존 Secret. `deploy=false`이면 `DATABASE_URL` 키가, `deploy=true`이면 `POSTGRES_PASSWORD`와 `DATABASE_URL` 키가 모두 필요. `deploy=true`에서 지정하면 차트가 자체 Secret을 렌더링하지 않음(`helm template` 렌더 간 비밀번호를 안정적으로 유지하는 GitOps 안전 방식). |
 | `ui.database.postgresql.poolMinSize` | int | `2` | 커넥션 풀 최소 크기 (`DB_POOL_MIN_SIZE`). |
 | `ui.database.postgresql.poolMaxSize` | int | `10` | 커넥션 풀 최대 크기 (`DB_POOL_MAX_SIZE`). |
 | `ui.database.postgresql.commandTimeout` | int | `30` | SQL 명령 실행 타임아웃 (초, `DB_COMMAND_TIMEOUT`). |
@@ -227,14 +227,14 @@ api는 클러스터 연결 메타데이터를 데이터베이스에 저장합니
 
 | 키 | 타입 | 기본값 | 설명 |
 |-----|------|---------|-------------|
-| `ui.database.postgresql.deploy` | bool | `false` | `true`이면 차트가 단일 레플리카 PostgreSQL StatefulSet + Service + Secret을 프로비저닝하고 api의 `DATABASE_URL`을 자동 연결(`databaseUrl` / `existingSecret`은 무시·거부됨). `false`이면 외부 인스턴스에 연결. |
+| `ui.database.postgresql.deploy` | bool | `false` | `true`이면 차트가 단일 레플리카 PostgreSQL Deployment + Service + 데이터 PVC + Secret을 프로비저닝하고 api의 `DATABASE_URL`을 자동 연결. `databaseUrl`은 거부되며, 자체 자격 증명 Secret을 쓰려면 `existingSecret`을 설정. `false`이면 외부 인스턴스에 연결. |
 | `ui.database.postgresql.image.repository` | string | `postgres` | 차트 관리형 PostgreSQL 이미지 리포지토리. |
 | `ui.database.postgresql.image.tag` | string | `"17"` | PostgreSQL 이미지 태그. |
 | `ui.database.postgresql.image.pullPolicy` | string | `IfNotPresent` | PostgreSQL 이미지 풀 정책. |
 | `ui.database.postgresql.auth.database` | string | `aerospike_manager` | 첫 시작 시 생성되는 데이터베이스 이름. |
 | `ui.database.postgresql.auth.username` | string | `aerospike` | 데이터베이스 사용자. |
-| `ui.database.postgresql.auth.password` | string | `""` | 데이터베이스 비밀번호. 비우면 첫 설치 시 24자 무작위 비밀번호를 생성하고 `helm upgrade` 시에도 유지. |
-| `ui.database.postgresql.persistence.enabled` | bool | `true` | PostgreSQL 데이터 디렉터리를 PVC(volumeClaimTemplate)에 영속 저장. `false`이면 `emptyDir`을 사용하며 Pod 재시작 시 데이터가 모두 사라짐. |
+| `ui.database.postgresql.auth.password` | string | `""` | 데이터베이스 비밀번호. 비우면 첫 설치 시 24자 무작위 비밀번호를 생성하고 `helm upgrade` 시에도 유지. GitOps 주의: 클라이언트사이드 `helm template`(ArgoCD / Flux / kustomize)은 Secret을 다시 읽지 못해 빈 비밀번호가 매 렌더마다 재생성됨 — GitOps에서는 이 값을 명시하거나 `existingSecret`을 사용. |
+| `ui.database.postgresql.persistence.enabled` | bool | `true` | PostgreSQL 데이터 디렉터리를 PVC에 영속 저장(`helm.sh/resource-policy: keep` — `helm uninstall` 후에도 유지). `false`이면 `emptyDir`을 사용하며 Pod 재시작 시 데이터가 모두 사라짐. |
 | `ui.database.postgresql.persistence.storageClassName` | string | `null` | PostgreSQL PVC 스토리지 클래스. `null` = 클러스터 기본값, `""` = 사전 프로비저닝 PV, `"name"` = 지정 StorageClass. |
 | `ui.database.postgresql.persistence.accessMode` | string | `ReadWriteOnce` | PostgreSQL PVC 접근 모드. |
 | `ui.database.postgresql.persistence.size` | string | `8Gi` | PostgreSQL PVC 볼륨 크기. |
@@ -247,7 +247,7 @@ api는 클러스터 연결 메타데이터를 데이터베이스에 저장합니
 
 **SQLite (기본값)** 는 api 컨테이너 내부의 단일 파일에 데이터를 저장하며 PersistentVolumeClaim으로 백업됩니다. 단일 라이터이므로 `ui.replicaCount`는 `1`이어야 합니다 — 그렇지 않으면 차트가 설치를 실패시킵니다.
 
-**PostgreSQL** 모드는 두 가지 하위 모드를 가집니다. `deploy=false`(기본값)이면 직접 운영하는 **외부** 데이터베이스(RDS / Cloud SQL / AlloyDB 같은 관리형 서비스, 또는 클러스터 내 PostgreSQL 오퍼레이터)에 연결하며 HA·다중 레플리카에 적합합니다. `deploy=true`이면 차트가 **단일 레플리카** PostgreSQL StatefulSet(데이터는 PVC)을 프로비저닝하고 api를 자동 연결합니다 — 간편하지만 고가용성은 아닙니다.
+**PostgreSQL** 모드는 두 가지 하위 모드를 가집니다. `deploy=false`(기본값)이면 직접 운영하는 **외부** 데이터베이스(RDS / Cloud SQL / AlloyDB 같은 관리형 서비스, 또는 클러스터 내 PostgreSQL 오퍼레이터)에 연결하며 HA·다중 레플리카에 적합합니다. `deploy=true`이면 차트가 **단일 레플리카** PostgreSQL Deployment(`Recreate` 전략, 데이터는 `keep` 정책 PVC)를 프로비저닝하고 api를 자동 연결합니다 — 간편하지만 고가용성은 아닙니다. GitOps에서는 `ui.database.postgresql.auth.password`를 명시하거나 `ui.database.postgresql.existingSecret`을 직접 관리하는 Secret에 지정해, 클라이언트사이드 `helm template`이 매 렌더마다 비밀번호를 재생성하지 않도록 하세요.
 
 > **마이그레이션:** 임베디드 사이드카 시절의 구버전 `ui.postgresql.*` / `ui.persistence.*` 키는 설치 시 마이그레이션 안내 메시지와 함께 실패합니다. `ui.postgresql.enabled: true` → `ui.database.type: postgresql` + `ui.database.postgresql.databaseUrl`, `ui.postgresql.enabled: false` → `ui.database.type: sqlite`, `ui.persistence.*` → `ui.database.sqlite.persistence.*`, `ui.env.databaseUrl` → `ui.database.postgresql.databaseUrl`로 매핑하세요. 임베디드 PostgreSQL에서 자동 데이터 마이그레이션은 제공되지 않으며, 임베디드 사이드카 릴리스에서의 업그레이드는 `ui.database.acknowledgeEmbeddedPostgresRemoval=true`를 설정할 때까지 차단됩니다. `pg_dump` → 복원 → 업그레이드 런북은 차트 README의 "Migrating off the embedded PostgreSQL sidecar" 절을 참고하세요.
 


### PR DESCRIPTION
## Summary

Two related fixes to the chart-managed PostgreSQL backend
(`ui.database.postgresql.deploy=true`), introduced in #276 and not yet
released:

1. **Run it as a `Deployment`, not a `StatefulSet`.** The database is
   single-replica, so the ordinal identity / per-replica volume a
   StatefulSet provides buys nothing.
2. **Fix the non-deterministic password under GitOps (#277).**

## StatefulSet → Deployment

- `postgres-statefulset.yaml` → `postgres-deployment.yaml`: `kind: Deployment`
  with a `Recreate` update strategy — the data PVC is `ReadWriteOnce`, so two
  postgres pods must never run at once (a rolling update would deadlock on the
  volume).
- `volumeClaimTemplates` replaced by a standalone `postgres-pvc.yaml` that
  carries `helm.sh/resource-policy: keep`, so the data volume still survives
  `helm uninstall` exactly as the StatefulSet's volumeClaimTemplate PVC did.

## GitOps-safe password — fixes #277

`deploy=true` preserves an auto-generated `POSTGRES_PASSWORD` by re-reading the
live Secret with `lookup`. `lookup` only returns data for a **server-side**
`helm install` / `helm upgrade`. A **client-side `helm template`** (ArgoCD,
Flux, kustomize `helmCharts`) cannot read the cluster, so it regenerated the
password on **every** render — every GitOps reconcile rewrote the Secret,
restarted PostgreSQL, and broke the api connection.

`ui.database.postgresql.existingSecret` is now honored together with
`deploy=true`:

- The chart renders **no Secret of its own** and reads `POSTGRES_PASSWORD` +
  `DATABASE_URL` from the operator-supplied Secret (sealed-secret / vault).
- `_helpers.tpl`: `ui.database.secretName` resolves `existingSecret` first; the
  validation guard allows `deploy=true` + `existingSecret` and rejects the
  ambiguous `deploy=true` + `existingSecret` + `auth.password` combination.

This is the GitOps-safe path requested in #277 (suggestion #2). The README /
docs also document the requirement (suggestion #1).

## Docs

Chart `README.md` (the stale *"chart never deploys PostgreSQL"* table),
`values.yaml`, `NOTES.txt`, and the en/ko `helm-values.md` +
`cluster-manager-ui.md` guides updated.

## Test plan

`helm lint` passes. `helm template` verified across 6 scenarios:

- `deploy=true` → `Deployment` + `PVC` + `Service` + `Secret` render; no `StatefulSet`.
- `deploy=true` + `existingSecret` → chart Secret **not** rendered; `POSTGRES_PASSWORD`
  and the api's `DATABASE_URL` both reference the supplied Secret.
- Two consecutive renders **without** `existingSecret` produce different
  passwords (reproduces #277); **with** `existingSecret` the chart renders
  zero Secrets, so there is nothing to drift.
- `persistence.enabled=false` → `emptyDir`, no PVC.
- `ui.database.type=sqlite` (default) → no postgres resources.
- Negative: `deploy=true` + `databaseUrl`, and `deploy=true` + `existingSecret`
  + `auth.password`, both fail-fast with a clear message.

Closes #277
