### PR TITLE
docs: fix Helm chart reference drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Deploy, scale, and perform rolling updates of Aerospike CE clusters via a custom
 | **Namespace** | Dual meaning: Aerospike data partition OR K8s namespace |
 | **AerospikeCluster** | The CRD Kind for a cluster CR (`kubectl get asc`) |
 
-→ Full glossary: [docs/content/guide/glossary.md](docs/content/guide/glossary.md)
+→ Full glossary: [docs/content/reference/glossary.md](docs/content/reference/glossary.md)
 
 ## Quick Start
 
@@ -352,7 +352,7 @@ claude plugin install aerospike-ce-ecosystem
 
 ## TODO
 
-- [ ] Register OCI repository on [Artifact Hub](https://artifacthub.io/) — Add repository with Kind: **OCI**, URL: `oci://ghcr.io/aerospike-ce-ecosystem/aerospike-operator`
+- [ ] Register OCI repository on [Artifact Hub](https://artifacthub.io/) — Add repository with Kind: **OCI**, URL: `oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kubernetes-operator`
 
 ## License
 

--- a/charts/aerospike-ce-kubernetes-operator/README.md
+++ b/charts/aerospike-ce-kubernetes-operator/README.md
@@ -25,7 +25,7 @@ kubectl -n cert-manager get pods
 
 > **Alternative**: If you don't want cert-manager, disable it and provide a TLS secret manually:
 > ```bash
-> helm install acko ./charts/acko \
+> helm install acko ./charts/aerospike-ce-kubernetes-operator \
 >   --set certManager.enabled=false \
 >   --set webhookTlsSecret=my-webhook-tls
 > ```
@@ -50,24 +50,24 @@ helm install kube-prometheus-stack prometheus-community/kube-prometheus-stack \
 CRDs and the operator are installed together. `crds.install=true` is the default.
 
 ```bash
-helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/acko \
-  --version 0.1.0 \
+helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kubernetes-operator \
+  --version 1.3.1 \
   --namespace aerospike-operator --create-namespace
 ```
 
 ### Method 2: Separate CRD chart (GitOps / ArgoCD / Flux)
 
-Install `acko-crds` once, then the operator separately. This is the recommended
+Install `aerospike-ce-kubernetes-operator-crds` once, then the operator separately. This is the recommended
 approach for GitOps workflows to control CRD lifecycle independently.
 
 ```bash
 # Step 1: Install CRDs (once per cluster)
-helm install acko-crds oci://ghcr.io/aerospike-ce-ecosystem/charts/acko-crds \
-  --version 0.1.0
+helm install acko-crds oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kubernetes-operator-crds \
+  --version 1.3.1
 
 # Step 2: Install operator (skip CRD installation)
-helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/acko \
-  --version 0.1.0 \
+helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kubernetes-operator \
+  --version 1.3.1 \
   --set crds.install=false \
   --namespace aerospike-operator --create-namespace
 ```
@@ -75,15 +75,15 @@ helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/acko \
 ### From Local Chart
 
 ```bash
-helm install acko ./charts/acko \
+helm install acko ./charts/aerospike-ce-kubernetes-operator \
   --namespace aerospike-operator --create-namespace
 ```
 
 ### With monitoring enabled
 
 ```bash
-helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/acko \
-  --version 0.1.0 \
+helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kubernetes-operator \
+  --version 1.3.1 \
   --namespace aerospike-operator --create-namespace \
   --set serviceMonitor.enabled=true \
   --set prometheusRule.enabled=true \
@@ -93,8 +93,8 @@ helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/acko \
 ### With Cilium network policy
 
 ```bash
-helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/acko \
-  --version 0.1.0 \
+helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kubernetes-operator \
+  --version 1.3.1 \
   --namespace aerospike-operator --create-namespace \
   --set cilium.enabled=true
 ```
@@ -105,8 +105,8 @@ The Cluster Manager UI (api + web) is deployed by default. A plain
 `helm install` of the chart already brings both Deployments up:
 
 ```bash
-helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/acko \
-  --version 0.4.0 \
+helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kubernetes-operator \
+  --version 1.3.1 \
   --namespace aerospike-operator --create-namespace
 ```
 
@@ -114,16 +114,16 @@ To skip the UI entirely (operator-only install), set both toggles
 to `false`:
 
 ```bash
-helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/acko \
-  --version 0.4.0 \
+helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kubernetes-operator \
+  --version 1.3.1 \
   --namespace aerospike-operator --create-namespace \
   --set ui.api.enabled=false --set ui.web.enabled=false
 ```
 
 Access the UI:
 ```bash
-kubectl port-forward svc/<release-name>-acko-ui 3000:3000 -n aerospike-operator
-# Open http://localhost:3000
+kubectl port-forward svc/<release-name>-aerospike-ce-kubernetes-operator-ui-web 3100:3100 -n aerospike-operator
+# Open http://localhost:3100
 ```
 
 #### Independent api / web toggles (chart 0.3.0+)
@@ -246,8 +246,8 @@ selected by `ui.database.type`:
 SQLite (default) — nothing to configure:
 
 ```bash
-helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/acko \
-  --version 0.4.0 --namespace aerospike-operator --create-namespace \
+helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kubernetes-operator \
+  --version 1.3.1 --namespace aerospike-operator --create-namespace \
   --set ui.database.sqlite.persistence.size=2Gi
 ```
 
@@ -255,8 +255,8 @@ External PostgreSQL — supply the connection URL (or an existing Secret with a
 `DATABASE_URL` key via `ui.database.postgresql.existingSecret`):
 
 ```bash
-helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/acko \
-  --version 0.4.0 --namespace aerospike-operator --create-namespace \
+helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kubernetes-operator \
+  --version 1.3.1 --namespace aerospike-operator --create-namespace \
   --set ui.database.type=postgresql \
   --set ui.database.postgresql.databaseUrl='postgresql://user:pass@db-host:5432/aerospike_manager'
 ```
@@ -265,8 +265,8 @@ Chart-managed PostgreSQL — let the chart run a single-replica PostgreSQL
 `Deployment` and wire the api to it:
 
 ```bash
-helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/acko \
-  --version 0.4.0 --namespace aerospike-operator --create-namespace \
+helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kubernetes-operator \
+  --version 1.3.1 --namespace aerospike-operator --create-namespace \
   --set ui.database.type=postgresql \
   --set ui.database.postgresql.deploy=true
 ```
@@ -369,21 +369,25 @@ so the gate never fires.
 
 #### Customizing the UI deployment
 
-You can customize the UI with service annotations, resource defaults, and extra environment variables:
+You can customize the UI with per-component image, service, resource, and environment values:
 
 ```bash
-helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/acko \
-  --version 0.4.0 \
+helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kubernetes-operator \
+  --version 1.3.1 \
   --namespace aerospike-operator --create-namespace \
-  --set ui.service.type=LoadBalancer \
-  --set ui.service.annotations."service\.beta\.kubernetes\.io/aws-load-balancer-type"=nlb \
-  --set ui.resources.requests.cpu=200m \
-  --set ui.resources.requests.memory=512Mi \
-  --set ui.resources.limits.cpu=500m \
-  --set ui.resources.limits.memory=1Gi
+  --set ui.imageTag=0.24.0 \
+  --set ui.api.image.repository=ghcr.io/aerospike-ce-ecosystem/aerospike-cluster-manager-api \
+  --set ui.web.image.repository=ghcr.io/aerospike-ce-ecosystem/aerospike-cluster-manager-web \
+  --set ui.web.service.type=LoadBalancer \
+  --set ui.web.service.annotations."service\.beta\.kubernetes\.io/aws-load-balancer-type"=nlb \
+  --set ui.api.resources.requests.cpu=200m \
+  --set ui.api.resources.requests.memory=512Mi \
+  --set ui.api.resources.limits.cpu=500m \
+  --set ui.api.resources.limits.memory=1Gi
 ```
 
-Extra environment variables can be passed via `ui.extraEnv`:
+Shared extra environment variables can be passed to both UI containers via
+`ui.extraEnv`; API-only environment can be passed via `ui.api.extraEnv`:
 
 ```yaml
 ui:
@@ -395,13 +399,17 @@ ui:
         secretKeyRef:
           name: my-secret
           key: value
+  api:
+    extraEnv:
+      - name: API_ONLY_SETTING
+        value: enabled
 ```
 
 ### Full example
 
 ```bash
-helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/acko \
-  --version 0.4.0 \
+helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kubernetes-operator \
+  --version 1.3.1 \
   --namespace aerospike-operator --create-namespace \
   --set serviceMonitor.enabled=true \
   --set prometheusRule.enabled=true \
@@ -423,8 +431,8 @@ metadata:
 spec:
   source:
     repoURL: ghcr.io/aerospike-ce-ecosystem/charts
-    chart: acko-crds
-    targetRevision: "0.1.0"
+    chart: aerospike-ce-kubernetes-operator-crds
+    targetRevision: "1.3.1"
   syncPolicy:
     automated:
       prune: false   # Never auto-delete CRDs
@@ -438,8 +446,8 @@ metadata:
 spec:
   source:
     repoURL: ghcr.io/aerospike-ce-ecosystem/charts
-    chart: acko
-    targetRevision: "0.1.0"
+    chart: aerospike-ce-kubernetes-operator
+    targetRevision: "1.3.1"
     helm:
       values: |
         crds:
@@ -475,8 +483,8 @@ metadata:
 spec:
   chart:
     spec:
-      chart: acko-crds
-      version: "0.1.0"
+      chart: aerospike-ce-kubernetes-operator-crds
+      version: "1.3.1"
       sourceRef:
         kind: HelmRepository
         name: acko
@@ -496,8 +504,8 @@ spec:
   targetNamespace: aerospike-operator
   chart:
     spec:
-      chart: acko
-      version: "0.1.0"
+      chart: aerospike-ce-kubernetes-operator
+      version: "1.3.1"
       sourceRef:
         kind: HelmRepository
         name: acko

--- a/docs/content/reference/helm-values.md
+++ b/docs/content/reference/helm-values.md
@@ -207,6 +207,7 @@ Each UI component has its own Service.
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `ui.ingress.enabled` | bool | `false` | Enable ingress for external access. |
+| `ui.ingress.target` | string | `web` | UI Service the Ingress routes to: `web` or `api`. |
 | `ui.ingress.className` | string | `""` | Ingress class name. |
 | `ui.ingress.annotations` | object | `{}` | Ingress annotations. |
 | `ui.ingress.hosts` | list | See values.yaml | Ingress host rules. |
@@ -299,6 +300,7 @@ The UI container includes a **preStop lifecycle hook** (`sleep 5`) to allow in-f
 |-----|------|---------|-------------|
 | `ui.k8s.enabled` | bool | `true` | Enable Kubernetes cluster management features (Create Cluster). |
 | `ui.k8s.verifySsl` | bool | `true` | Verify TLS certificates when connecting to the Kubernetes API server. Set to `false` for clusters with self-signed or non-standard CA certificates. |
+| `ui.k8s.caFile` | string | `""` | Path inside the api container to a custom Kubernetes API CA bundle mounted with `ui.api.extraVolumes` / `ui.api.extraVolumeMounts`. |
 
 ### UI Resources
 
@@ -436,7 +438,9 @@ The UI ServiceMonitor scrapes the backend metrics endpoint at `/api/metrics`. Th
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `ui.extraEnv` | list | `[]` | Extra environment variables for the UI container. Supports standard Kubernetes env var syntax including `valueFrom` references. |
+| `ui.extraEnv` | list | `[]` | Extra environment variables injected into both UI containers (api and web). Supports standard Kubernetes env var syntax including `valueFrom` references. |
+| `ui.api.extraEnv` | list | `[]` | Extra environment variables for the api container only. |
+| `ui.api.extraEnvFrom` | list | `[]` | `envFrom` entries (`configMapRef` / `secretRef`) for bulk api environment injection. |
 
 ### UI Helm Tests
 

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/getting-started/install.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/getting-started/install.md
@@ -74,7 +74,7 @@ GitOps 환경에서는 오퍼레이터 라이프사이클과 독립적으로 관
 
 ```bash
 helm install aerospike-ce-kubernetes-operator-crds oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kubernetes-operator-crds \
-  --version 0.1.0
+  --version 1.3.1
 ```
 
 CRD는 `helm.sh/resource-policy: keep` 어노테이션이 있어 `helm uninstall` 시에도 **삭제되지 않아** 클러스터 데이터를 보호합니다.
@@ -83,7 +83,7 @@ CRD는 `helm.sh/resource-policy: keep` 어노테이션이 있어 `helm uninstall
 
 ```bash
 helm install aerospike-ce-kubernetes-operator oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kubernetes-operator \
-  --version 0.1.0 \
+  --version 1.3.1 \
   --set crds.install=false \
   -n aerospike-operator --create-namespace
 ```
@@ -102,7 +102,7 @@ spec:
   source:
     repoURL: ghcr.io/aerospike-ce-ecosystem/charts
     chart: aerospike-ce-kubernetes-operator-crds
-    targetRevision: "0.1.0"
+    targetRevision: "1.3.1"
   syncPolicy:
     automated:
       prune: false
@@ -117,7 +117,7 @@ spec:
   source:
     repoURL: ghcr.io/aerospike-ce-ecosystem/charts
     chart: aerospike-ce-kubernetes-operator
-    targetRevision: "0.1.0"
+    targetRevision: "1.3.1"
     helm:
       values: |
         crds:
@@ -154,7 +154,7 @@ spec:
   chart:
     spec:
       chart: aerospike-ce-kubernetes-operator-crds
-      version: "0.1.0"
+      version: "1.3.1"
       sourceRef:
         kind: HelmRepository
         name: aerospike-ce-kubernetes-operator
@@ -175,7 +175,7 @@ spec:
   chart:
     spec:
       chart: aerospike-ce-kubernetes-operator
-      version: "0.1.0"
+      version: "1.3.1"
       sourceRef:
         kind: HelmRepository
         name: aerospike-ce-kubernetes-operator

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/reference/helm-values.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/reference/helm-values.md
@@ -200,6 +200,7 @@ UI 컴포넌트별로 각각의 서비스가 생성됩니다.
 | 키 | 타입 | 기본값 | 설명 |
 |-----|------|---------|-------------|
 | `ui.ingress.enabled` | bool | `false` | 외부 접근용 Ingress 활성화. |
+| `ui.ingress.target` | string | `web` | Ingress가 라우팅할 UI 서비스: `web` 또는 `api`. |
 | `ui.ingress.className` | string | `""` | Ingress 클래스 이름. |
 | `ui.ingress.annotations` | object | `{}` | Ingress 어노테이션. |
 | `ui.ingress.hosts` | list | values.yaml 참조 | Ingress 호스트 규칙. |
@@ -266,6 +267,8 @@ UI 컨테이너에는 **preStop 라이프사이클 훅** (`sleep 5`)이 포함�
 | 키 | 타입 | 기본값 | 설명 |
 |-----|------|---------|-------------|
 | `ui.k8s.enabled` | bool | `true` | Kubernetes 클러스터 관리 기능 활성화 (클러스터 생성). |
+| `ui.k8s.verifySsl` | bool | `true` | Kubernetes API 서버 연결 시 TLS 인증서 검증. 자체 서명 또는 비표준 CA 인증서를 쓰는 클러스터에서는 `false`로 설정 가능. |
+| `ui.k8s.caFile` | string | `""` | `ui.api.extraVolumes` / `ui.api.extraVolumeMounts`로 마운트한 Kubernetes API 커스텀 CA 번들의 api 컨테이너 내부 경로. |
 
 ### UI 리소스
 
@@ -395,7 +398,9 @@ UI ServiceMonitor는 `/api/metrics` 경로에서 백엔드 메트릭을 스크�
 
 | 키 | 타입 | 기본값 | 설명 |
 |-----|------|---------|-------------|
-| `ui.extraEnv` | list | `[]` | UI 컨테이너의 추가 환경 변수. `valueFrom` 참조를 포함한 표준 Kubernetes 환경 변수 문법 지원. |
+| `ui.extraEnv` | list | `[]` | 두 UI 컨테이너(api와 web)에 모두 주입되는 추가 환경 변수. `valueFrom` 참조를 포함한 표준 Kubernetes 환경 변수 문법 지원. |
+| `ui.api.extraEnv` | list | `[]` | api 컨테이너에만 주입되는 추가 환경 변수. |
+| `ui.api.extraEnvFrom` | list | `[]` | api 환경 변수를 일괄 주입하기 위한 `envFrom` 항목(`configMapRef` / `secretRef`). |
 
 ### UI Helm 테스트
 


### PR DESCRIPTION
## Summary
- Replace stale Helm chart names, OCI paths, versions, and UI service examples with the current chart layout.
- Sync Helm values references for `ui.imageTag`, `ui.api.image.*`, and `ui.web.image.*` in English and Korean docs.
- Fix stale README glossary and Artifact Hub OCI references.

## Testing
- `helm lint ./charts/aerospike-ce-kubernetes-operator ./charts/aerospike-ce-kubernetes-operator-crds`
- targeted `rg` checks for stale chart/value/link references
- `git diff --check`