### PR TITLE
feat(helm): make operator OpenTelemetry export work behind NetworkPolicy

### DIFF
--- a/charts/aerospike-ce-kubernetes-operator/README.md
+++ b/charts/aerospike-ce-kubernetes-operator/README.md
@@ -102,14 +102,21 @@ observability:
   otel:
     enabled: true
     endpoint: otel-collector.observability.svc.cluster.local:4317  # OTLP/gRPC
+    serviceName: ""                                                # override service.name
     headers: ""                                                    # collector auth
     resourceAttributes: "deployment.environment=prod,team=platform"
     sampler: parentbased_traceidratio
     samplerArg: "1.0"
+    collectorPort: 4317                                            # NetworkPolicy egress port
 ```
 
 `endpoint` is required when `enabled: true` (rendering fails fast otherwise).
-All settings map to the OTel SDK standard environment variables. See
+All settings map to the OTel SDK standard environment variables.
+
+When `networkPolicy.enabled` or `cilium.enabled` is set, enabling OTel
+automatically opens an egress rule to the collector on `collectorPort`
+(default `4317`) — the locked-down operator egress would otherwise drop all
+exported telemetry. See
 [Monitoring — OpenTelemetry export](https://aerospike-ce-ecosystem.github.io/aerospike-ce-kubernetes-operator/operations/monitoring)
 for the full reference.
 

--- a/charts/aerospike-ce-kubernetes-operator/templates/_helpers.tpl
+++ b/charts/aerospike-ce-kubernetes-operator/templates/_helpers.tpl
@@ -541,3 +541,25 @@ all gates uniformly.
 {{- include "aerospike-ce-kubernetes-operator.validate.webhookTlsSource" . -}}
 {{- include "aerospike-ce-kubernetes-operator.validate.databaseConfig" . -}}
 {{- end }}
+
+{{/*
+Normalize an OTLP exporter endpoint so it carries a URL scheme.
+
+The OpenTelemetry SDK requires OTEL_EXPORTER_OTLP_ENDPOINT to carry a URL
+scheme: a bare "host:port" is parsed as scheme://opaque, leaving the
+exporter with an empty address ("missing address") and silently dropping
+all telemetry. A scheme-less value is normalized to insecure http://
+(plaintext) — the common case for an in-cluster collector. Pass an explicit
+https:// endpoint for a TLS-terminated collector. Used for both the operator
+and the cluster-manager API.
+
+Usage: include "aerospike-ce-kubernetes-operator.otel.normalizeEndpoint" <endpoint-string>
+*/}}
+{{- define "aerospike-ce-kubernetes-operator.otel.normalizeEndpoint" -}}
+{{- $ep := . -}}
+{{- if regexMatch "^[A-Za-z][A-Za-z0-9+.-]*://" $ep -}}
+{{- $ep -}}
+{{- else -}}
+{{- printf "http://%s" $ep -}}
+{{- end -}}
+{{- end }}

--- a/charts/aerospike-ce-kubernetes-operator/templates/ciliumnetworkpolicy.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ciliumnetworkpolicy.yaml
@@ -56,5 +56,20 @@ spec:
     # Allow communication with kube-apiserver
     - toEntities:
         - kube-apiserver
+    {{- if .Values.observability.otel.enabled }}
+    # Allow OTLP export to the OpenTelemetry collector (traces/metrics/logs).
+    # Without this the collector is unreachable when cilium.enabled is set and
+    # exported telemetry is silently dropped. Scoped to the collector port for
+    # any destination (in-cluster or external) — mirroring the port-scoped
+    # rule in the standard NetworkPolicy, since the collector endpoint is
+    # user-configured and cannot be matched by a fixed label selector here.
+    - toEntities:
+        - cluster
+        - world
+      toPorts:
+        - ports:
+            - port: {{ .Values.observability.otel.collectorPort | quote }}
+              protocol: TCP
+    {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/aerospike-ce-kubernetes-operator/templates/deployment.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/deployment.yaml
@@ -57,9 +57,13 @@ spec:
             - name: OTEL_SDK_DISABLED
               value: "false"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              value: {{ .Values.observability.otel.endpoint | quote }}
+              value: {{ include "aerospike-ce-kubernetes-operator.otel.normalizeEndpoint" .Values.observability.otel.endpoint | quote }}
             - name: OTEL_EXPORTER_OTLP_PROTOCOL
               value: "grpc"
+            {{- with .Values.observability.otel.serviceName }}
+            - name: OTEL_SERVICE_NAME
+              value: {{ . | quote }}
+            {{- end }}
             {{- with .Values.observability.otel.headers }}
             - name: OTEL_EXPORTER_OTLP_HEADERS
               value: {{ . | quote }}

--- a/charts/aerospike-ce-kubernetes-operator/templates/networkpolicy.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/networkpolicy.yaml
@@ -51,5 +51,15 @@ spec:
           protocol: TCP
         - port: 6443
           protocol: TCP
+    {{- if .Values.observability.otel.enabled }}
+    # OpenTelemetry collector — OTLP export of traces/metrics/logs.
+    # Without this egress rule the collector is unreachable when
+    # networkPolicy.enabled is set and exported telemetry is silently dropped.
+    # Port-scoped (no `to:` peer) to match the kube-apiserver rule above;
+    # standard NetworkPolicy cannot select the collector by Service DNS name.
+    - ports:
+        - port: {{ .Values.observability.otel.collectorPort }}
+          protocol: TCP
+    {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/deployment-api.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/deployment-api.yaml
@@ -200,7 +200,7 @@ spec:
             - name: AEROSPIKE_PY_TRACING
               value: {{ .Values.ui.api.otel.aerospikePyTracing | quote }}
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              value: {{ required "ui.api.otel.endpoint is required when ui.api.otel.enabled is true" .Values.ui.api.otel.endpoint | quote }}
+              value: {{ include "aerospike-ce-kubernetes-operator.otel.normalizeEndpoint" (required "ui.api.otel.endpoint is required when ui.api.otel.enabled is true" .Values.ui.api.otel.endpoint) | quote }}
             - name: OTEL_EXPORTER_OTLP_PROTOCOL
               value: {{ .Values.ui.api.otel.protocol | quote }}
             - name: OTEL_TRACES_SAMPLER

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/networkpolicy.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/networkpolicy.yaml
@@ -59,6 +59,17 @@ spec:
           protocol: TCP
         - port: {{ .Values.ui.aerospikePorts.heartbeat }}
           protocol: TCP
+    {{- if .Values.ui.api.otel.enabled }}
+    # OpenTelemetry collector — OTLP export. Without this egress rule the
+    # collector is unreachable when ui.networkPolicy.enabled is set. Both OTLP
+    # ports are allowed (4317 gRPC, 4318 HTTP) so the rule holds regardless of
+    # ui.api.otel.protocol.
+    - ports:
+        - port: 4317
+          protocol: TCP
+        - port: 4318
+          protocol: TCP
+    {{- end }}
     {{- if eq .Values.ui.database.type "postgresql" }}
     # PostgreSQL (external instance or chart-managed pod)
     - ports:

--- a/charts/aerospike-ce-kubernetes-operator/values.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/values.yaml
@@ -240,8 +240,13 @@ observability:
     # -- OTLP/gRPC collector endpoint, e.g.
     # "otel-collector.observability.svc.cluster.local:4317". The operator
     # exports over OTLP/gRPC only. Required when enabled=true (rendering
-    # fails otherwise).
+    # fails otherwise). A scheme-less host:port is normalized to insecure
+    # http:// (plaintext gRPC) — the OTel SDK rejects an endpoint with no
+    # scheme. Use an explicit https:// URL for a TLS-terminated collector.
     endpoint: ""
+    # -- Override the service.name resource attribute. Empty keeps the
+    # operator's built-in default ("aerospike-ce-kubernetes-operator").
+    serviceName: ""
     # -- OTLP headers for collector auth, e.g. "api-key=xxxxxxxx".
     headers: ""
     # -- Comma-separated extra resource attributes, e.g.
@@ -253,6 +258,12 @@ observability:
     sampler: parentbased_traceidratio
     # -- Sampler argument (sampling ratio for the traceidratio variants).
     samplerArg: "1.0"
+    # -- TCP port the OTLP collector listens on. Used only to open an egress
+    # rule to the collector in the operator's NetworkPolicy / CiliumNetworkPolicy
+    # when networkPolicy.enabled or cilium.enabled is set — without it the
+    # collector is unreachable and exported telemetry is silently dropped. The
+    # operator exports over OTLP/gRPC, whose conventional port is 4317.
+    collectorPort: 4317
     # -- Extra raw environment variables appended to the operator container,
     # for any OTel SDK standard variable not surfaced above.
     # Example: [{ name: OTEL_BSP_SCHEDULE_DELAY, value: "5000" }]

--- a/docs/content/operations/monitoring.md
+++ b/docs/content/operations/monitoring.md
@@ -376,6 +376,8 @@ observability:
     enabled: true
     # OTLP/gRPC collector endpoint (required when enabled).
     endpoint: otel-collector.observability.svc.cluster.local:4317
+    # Optional: override the service.name resource attribute.
+    serviceName: ""
     # Optional collector auth headers.
     headers: "api-key=xxxxxxxx"
     # Optional extra resource attributes.
@@ -383,11 +385,25 @@ observability:
     # OTel SDK standard trace sampler.
     sampler: parentbased_traceidratio
     samplerArg: "1.0"
+    # Collector TCP port — opens the NetworkPolicy egress rule (see below).
+    collectorPort: 4317
 ```
 
 The operator exports over **OTLP/gRPC only** — point `endpoint` at the
 collector's gRPC receiver (port `4317`). Chart rendering fails fast if
-`enabled: true` is set without an `endpoint`.
+`enabled: true` is set without an `endpoint`. A scheme-less `host:port` is
+normalized to insecure `http://` (plaintext gRPC); pass an explicit
+`https://` URL for a TLS-terminated collector.
+
+### NetworkPolicy
+
+When `networkPolicy.enabled` or `cilium.enabled` is set, the operator's egress
+is locked down to DNS and the Kubernetes API server. Enabling OTel
+**automatically adds an egress rule** for the collector on
+`observability.otel.collectorPort` (default `4317`) — without it the collector
+would be unreachable and exported telemetry silently dropped. Set
+`collectorPort` to match your collector if it does not use the conventional
+OTLP/gRPC port.
 
 ### Configuration
 
@@ -399,14 +415,13 @@ the Helm values are thin wrappers over them.
 |------------|----------------------|---------|
 | `observability.otel.enabled` | `OTEL_SDK_DISABLED` | Master switch (`enabled: false` → `OTEL_SDK_DISABLED=true`). |
 | `observability.otel.endpoint` | `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP/gRPC collector endpoint. |
+| `observability.otel.serviceName` | `OTEL_SERVICE_NAME` | Override `service.name`. Empty keeps the default `aerospike-ce-kubernetes-operator`. |
 | `observability.otel.headers` | `OTEL_EXPORTER_OTLP_HEADERS` | Collector auth headers. |
 | `observability.otel.resourceAttributes` | `OTEL_RESOURCE_ATTRIBUTES` | Extra resource attributes. |
 | `observability.otel.sampler` | `OTEL_TRACES_SAMPLER` | Trace sampler. |
 | `observability.otel.samplerArg` | `OTEL_TRACES_SAMPLER_ARG` | Sampler argument. |
+| `observability.otel.collectorPort` | *(NetworkPolicy)* | Collector TCP port allowed by the egress rule — see [NetworkPolicy](#networkpolicy). |
 | `observability.otel.extraEnv` | *(raw)* | Any other `OTEL_*` SDK variable not surfaced above. |
-
-The service name reported to the collector is `aerospike-ce-kubernetes-operator`
-(override with `OTEL_SERVICE_NAME` via `extraEnv`).
 
 :::note
 Pointing the operator and the [Cluster Manager API](../getting-started/cluster-manager-ui.md)


### PR DESCRIPTION
## Summary

PR #279 added `observability.otel.*` values to enable the operator's OpenTelemetry export — but **enabling it did not actually work** in two common situations. Both were found by an end-to-end test on a real kind + Calico cluster.

1. **NetworkPolicy blocked the collector.** When `networkPolicy.enabled` (or `cilium.enabled`) is set, the operator's egress is locked down to DNS + the Kubernetes API server. The OTLP export to the collector was silently dropped — the chart created no egress rule for it.
2. **Scheme-less endpoint silently dropped all telemetry.** The OTel SDK requires `OTEL_EXPORTER_OTLP_ENDPOINT` to carry a URL scheme. A bare `host:port` is parsed as `scheme://opaque`, leaving the gRPC exporter with an empty address (`"missing address"`).

## Changes

- **`networkpolicy.yaml` / `ciliumnetworkpolicy.yaml`** — add an OTLP egress rule on `observability.otel.collectorPort` (default `4317`) whenever OTel is enabled. The Cilium rule uses `toEntities: [cluster, world]` so an external collector also works, mirroring the standard policy's port-scoped posture.
- **`ui/networkpolicy.yaml`** — the same fix for the cluster-manager API, allowing both OTLP ports (4317 gRPC, 4318 HTTP) so the rule holds regardless of `ui.api.otel.protocol`.
- **`_helpers.tpl`** — new `otel.normalizeEndpoint` helper: prepends `http://` (insecure, the in-cluster default) to a scheme-less endpoint. Applied to **both** the operator and the cluster-manager API deployments.
- **`values.yaml`** — new `observability.otel.collectorPort` and `observability.otel.serviceName`.
- **`deployment.yaml`** — wires `OTEL_SERVICE_NAME` from `observability.otel.serviceName`.
- **docs** — a NetworkPolicy section in `operations/monitoring.md` and the chart README.

## End-to-end verification (kind + Calico)

NetworkPolicy enforcement needs a policy-enforcing CNI, so the test ran on a kind cluster with **Calico**:

1. Built the operator image, installed cert-manager, deployed an in-cluster OTel Collector.
2. `helm install` with `observability.otel.enabled=true` **and** `networkPolicy.enabled=true`.
3. ✅ Operator pod healthy; the OTLP egress rule rendered into the NetworkPolicy.
4. ✅ Collector received the operator's **traces** (`Reconcile` → `reconcileCluster` → `reconcileRacks` spans), **metrics** (`controller_runtime_*` via the Prometheus bridge), and **logs** — through the enforced policy.
5. ✅ **Negative control** — removing the OTLP egress rule and restarting the operator produced repeated export failures (egress blocked by Calico); restoring the rule recovered export. This confirms the rule is required and the fix works.

## Notes

`helm lint` passes; `helm template` renders correctly for the operator/UI/Cilium combinations; the Docusaurus docs build has no broken links. Follows up #279.
