### PR TITLE
fix: terminate failed on-demand operations and harden webhook/rack validation

### DIFF
--- a/api/v1alpha1/aerospikecluster_webhook.go
+++ b/api/v1alpha1/aerospikecluster_webhook.go
@@ -778,16 +778,31 @@ func (v *AerospikeClusterValidator) validateNamespaceConfig(nsMap map[string]any
 		}
 	}
 
-	// Validate replication-factor: single-node clusters should use 1
+	// Validate replication-factor: single-node clusters should use 1.
+	// Accept every integer type a decoder can plausibly produce (int, int32,
+	// int64, float64, json.Number); an unhandled type would otherwise silently
+	// skip the range check.
 	if rf, ok := nsMap["replication-factor"]; ok {
 		switch v := rf.(type) {
 		case int:
 			if v < 1 || v > 4 {
 				errors = append(errors, fmt.Sprintf("namespace[%d] %q: replication-factor must be between 1 and 4 (got %d)", index, nsName, v))
 			}
+		case int32:
+			if v < 1 || v > 4 {
+				errors = append(errors, fmt.Sprintf("namespace[%d] %q: replication-factor must be between 1 and 4 (got %d)", index, nsName, v))
+			}
+		case int64:
+			if v < 1 || v > 4 {
+				errors = append(errors, fmt.Sprintf("namespace[%d] %q: replication-factor must be between 1 and 4 (got %d)", index, nsName, v))
+			}
 		case float64:
 			if v < 1 || v > 4 {
 				errors = append(errors, fmt.Sprintf("namespace[%d] %q: replication-factor must be between 1 and 4 (got %v)", index, nsName, v))
+			}
+		case json.Number:
+			if n, err := v.Int64(); err == nil && (n < 1 || n > 4) {
+				errors = append(errors, fmt.Sprintf("namespace[%d] %q: replication-factor must be between 1 and 4 (got %s)", index, nsName, v.String()))
 			}
 		}
 	}
@@ -1027,9 +1042,14 @@ func (v *AerospikeClusterValidator) validateReplicationFactor(cluster *Aerospike
 			continue
 		}
 		rfInt := 0
+		// Accept every integer type a decoder can plausibly produce. Missing
+		// an int32 case here caused an int32-typed value to fall through with
+		// rfInt=0 and trip the misleading "must be >= 1, got 0" branch below.
 		switch val := rf.(type) {
 		case int:
 			rfInt = val
+		case int32:
+			rfInt = int(val)
 		case int64:
 			rfInt = int(val)
 		case float64:
@@ -1039,6 +1059,14 @@ func (v *AerospikeClusterValidator) validateReplicationFactor(cluster *Aerospike
 				continue
 			}
 			rfInt = int(val)
+		case json.Number:
+			n, err := val.Int64()
+			if err != nil {
+				errors = append(errors, fmt.Sprintf(
+					"namespace %q: replication-factor must be a positive integer, got %s", nsName, val.String()))
+				continue
+			}
+			rfInt = int(n)
 		}
 		if rfInt < 1 {
 			errors = append(errors, fmt.Sprintf(

--- a/charts/aerospike-ce-kubernetes-operator/templates/clusterrole-manager.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/clusterrole-manager.yaml
@@ -39,6 +39,18 @@ rules:
   - apiGroups:
       - ""
     resources:
+      - pods/exec
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - pods/status
+    verbs:
+      - patch
+  - apiGroups:
+      - ""
+    resources:
       - secrets
     verbs:
       - get

--- a/internal/controller/reconciler_operations.go
+++ b/internal/controller/reconciler_operations.go
@@ -60,11 +60,19 @@ func (r *AerospikeClusterReconciler) reconcileOperations(
 	// used by the rolling restart path.
 	batchSize := r.getRollingUpdateBatchSize(cluster, int32(len(pods)))
 
-	// Track completed pods from previous status
+	// Track completed and previously-failed pods from prior status.
+	// A pod that has already been attempted (success OR failure) must not be
+	// retried on every reconcile: a failed warm/cold restart would otherwise be
+	// re-run every 5s forever with no backoff, and FailedPods would grow
+	// unbounded with duplicates.
 	completedSet := make(map[string]bool)
+	failedSet := make(map[string]bool)
 	if cluster.Status.OperationStatus != nil && cluster.Status.OperationStatus.ID == op.ID {
 		for _, p := range cluster.Status.OperationStatus.CompletedPods {
 			completedSet[p] = true
+		}
+		for _, p := range cluster.Status.OperationStatus.FailedPods {
+			failedSet[p] = true
 		}
 		opStatus.CompletedPods = cluster.Status.OperationStatus.CompletedPods
 		opStatus.FailedPods = cluster.Status.OperationStatus.FailedPods
@@ -73,7 +81,8 @@ func (r *AerospikeClusterReconciler) reconcileOperations(
 	processed := int32(0)
 
 	for _, pod := range pods {
-		if completedSet[pod.Name] {
+		// Skip pods already resolved (succeeded or failed) in a prior reconcile.
+		if completedSet[pod.Name] || failedSet[pod.Name] {
 			continue
 		}
 
@@ -98,7 +107,11 @@ func (r *AerospikeClusterReconciler) reconcileOperations(
 
 		if opErr != nil {
 			log.Error(opErr, "Operation failed on pod", "pod", pod.Name, "kind", op.Kind)
-			opStatus.FailedPods = append(opStatus.FailedPods, pod.Name)
+			// Dedupe: only record a failed pod once across reconciles.
+			if !failedSet[pod.Name] {
+				opStatus.FailedPods = append(opStatus.FailedPods, pod.Name)
+				failedSet[pod.Name] = true
+			}
 		} else {
 			opStatus.CompletedPods = append(opStatus.CompletedPods, pod.Name)
 			completedSet[pod.Name] = true
@@ -107,11 +120,10 @@ func (r *AerospikeClusterReconciler) reconcileOperations(
 	}
 
 	// Determine completion by directly inspecting how many target pods are still
-	// outstanding. The previous implementation flipped a bool to false on the
-	// first incomplete pod and never restored it, leaving the phase stuck on
-	// InProgress forever once any pod fell out of completedSet — a permanent
-	// regression for any operation that needed more than one reconcile loop.
-	allDone := finalizeOperationPhase(opStatus, pods, completedSet)
+	// outstanding. A pod counts as resolved once attempted — success OR failure —
+	// so an operation with a permanently failing pod still reaches the terminal
+	// Error phase instead of requeueing every 5s forever.
+	allDone := finalizeOperationPhase(opStatus, pods, completedSet, failedSet)
 
 	// Update operation status using Patch to avoid overwriting concurrent status changes.
 	latest, err := r.refetchCluster(ctx, types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace})
@@ -147,10 +159,16 @@ func (r *AerospikeClusterReconciler) getOperationTargetPods(
 	return filterPodsByNames(allPods.Items, podList), nil
 }
 
-// finalizeOperationPhase inspects the target pod list against the completed set
-// and, when no pods remain outstanding, sets opStatus.Phase to Completed (or
-// Error if any pods failed). It returns true when the operation has reached a
-// terminal state, false when more reconciles are needed.
+// finalizeOperationPhase inspects the target pod list against the set of
+// resolved pods (completed OR failed) and, when no pods remain outstanding,
+// sets opStatus.Phase to Completed (or Error if any pods failed). It returns
+// true when the operation has reached a terminal state, false when more
+// reconciles are needed.
+//
+// A failed pod counts as resolved: otherwise a pod whose warm/cold restart
+// permanently fails would keep remainingPods > 0 forever, the operation would
+// never reach the terminal Error phase, and the cluster would requeue every 5s
+// indefinitely while re-restarting the failed pod with no backoff.
 //
 // Splitting this out lets us unit-test the completion logic without exercising
 // the full reconciler — the historical bug (allDone bool flipped to false and
@@ -160,10 +178,11 @@ func finalizeOperationPhase(
 	opStatus *ackov1alpha1.OperationStatus,
 	pods []*corev1.Pod,
 	completedSet map[string]bool,
+	failedSet map[string]bool,
 ) bool {
 	remainingPods := 0
 	for _, pod := range pods {
-		if !completedSet[pod.Name] {
+		if !completedSet[pod.Name] && !failedSet[pod.Name] {
 			remainingPods++
 		}
 	}

--- a/internal/controller/reconciler_operations_test.go
+++ b/internal/controller/reconciler_operations_test.go
@@ -103,7 +103,7 @@ func TestFinalizeOperationPhase_AllCompleted_NoFailures(t *testing.T) {
 	completed := map[string]bool{"pod-0": true, "pod-1": true, "pod-2": true}
 	opStatus := &ackov1alpha1.OperationStatus{Phase: ackov1alpha1.AerospikePhaseInProgress}
 
-	done := finalizeOperationPhase(opStatus, pods, completed)
+	done := finalizeOperationPhase(opStatus, pods, completed, map[string]bool{})
 	if !done {
 		t.Fatal("expected done=true when every pod is in completedSet")
 	}
@@ -117,15 +117,16 @@ func TestFinalizeOperationPhase_AllCompleted_WithFailures_GoesToError(t *testing
 		{ObjectMeta: metav1.ObjectMeta{Name: "pod-0"}},
 		{ObjectMeta: metav1.ObjectMeta{Name: "pod-1"}},
 	}
-	// Both pods are "completed" in the sense that we've stopped retrying them,
-	// but one of them ended up on the FailedPods list.
-	completed := map[string]bool{"pod-0": true, "pod-1": true}
+	// pod-0 succeeded; pod-1 was attempted but failed. A failed pod counts as
+	// resolved, so nothing is outstanding and the operation must terminate.
+	completed := map[string]bool{"pod-0": true}
+	failed := map[string]bool{"pod-1": true}
 	opStatus := &ackov1alpha1.OperationStatus{
 		Phase:      ackov1alpha1.AerospikePhaseInProgress,
 		FailedPods: []string{"pod-1"},
 	}
 
-	done := finalizeOperationPhase(opStatus, pods, completed)
+	done := finalizeOperationPhase(opStatus, pods, completed, failed)
 	if !done {
 		t.Fatal("expected done=true when nothing is outstanding")
 	}
@@ -144,7 +145,7 @@ func TestFinalizeOperationPhase_PartialProgress_StaysInProgress(t *testing.T) {
 	completed := map[string]bool{"pod-0": true} // pod-1, pod-2 still pending
 	opStatus := &ackov1alpha1.OperationStatus{Phase: ackov1alpha1.AerospikePhaseInProgress}
 
-	done := finalizeOperationPhase(opStatus, pods, completed)
+	done := finalizeOperationPhase(opStatus, pods, completed, map[string]bool{})
 	if done {
 		t.Fatal("expected done=false while pods remain outstanding")
 	}
@@ -170,7 +171,7 @@ func TestFinalizeOperationPhase_RecoversFromInterleavedProgress(t *testing.T) {
 	completed := map[string]bool{"pod-0": true, "pod-1": true}
 	opStatus := &ackov1alpha1.OperationStatus{Phase: ackov1alpha1.AerospikePhaseInProgress}
 
-	done := finalizeOperationPhase(opStatus, pods, completed)
+	done := finalizeOperationPhase(opStatus, pods, completed, map[string]bool{})
 	if !done {
 		t.Fatal("regression: phase stuck InProgress after all pods completed")
 	}
@@ -181,11 +182,87 @@ func TestFinalizeOperationPhase_RecoversFromInterleavedProgress(t *testing.T) {
 
 func TestFinalizeOperationPhase_NoPods_IsCompleted(t *testing.T) {
 	opStatus := &ackov1alpha1.OperationStatus{Phase: ackov1alpha1.AerospikePhaseInProgress}
-	done := finalizeOperationPhase(opStatus, nil, map[string]bool{})
+	done := finalizeOperationPhase(opStatus, nil, map[string]bool{}, map[string]bool{})
 	if !done {
 		t.Fatal("expected done=true with no target pods")
 	}
 	if opStatus.Phase != ackov1alpha1.AerospikePhaseCompleted {
 		t.Errorf("phase = %q, want %q", opStatus.Phase, ackov1alpha1.AerospikePhaseCompleted)
+	}
+}
+
+// TestFinalizeOperationPhase_AllFailed_ReachesTerminalError is the direct
+// regression for the infinite-reconcile bug: every target pod failed its
+// warm/cold restart. Before the fix, failed pods were absent from completedSet
+// so remainingPods stayed > 0, the operation never left InProgress, and the
+// cluster requeued every 5s forever. A failed pod must now count as resolved
+// so the operation reaches the terminal Error phase.
+func TestFinalizeOperationPhase_AllFailed_ReachesTerminalError(t *testing.T) {
+	pods := []*corev1.Pod{
+		{ObjectMeta: metav1.ObjectMeta{Name: "pod-0"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "pod-1"}},
+	}
+	completed := map[string]bool{}
+	failed := map[string]bool{"pod-0": true, "pod-1": true}
+	opStatus := &ackov1alpha1.OperationStatus{
+		Phase:      ackov1alpha1.AerospikePhaseInProgress,
+		FailedPods: []string{"pod-0", "pod-1"},
+	}
+
+	done := finalizeOperationPhase(opStatus, pods, completed, failed)
+	if !done {
+		t.Fatal("regression: operation never terminates when every pod fails (infinite reconcile loop)")
+	}
+	if opStatus.Phase != ackov1alpha1.AerospikePhaseError {
+		t.Errorf("phase = %q, want %q (a fully-failed operation must reach terminal Error)",
+			opStatus.Phase, ackov1alpha1.AerospikePhaseError)
+	}
+}
+
+// TestFinalizeOperationPhase_FailedPodNotRetriedKeepsOutstanding verifies that
+// while one pod has failed (resolved) another genuinely pending pod still keeps
+// the operation InProgress — i.e. a failed pod neither blocks completion nor
+// masks remaining work.
+func TestFinalizeOperationPhase_FailedPodNotRetriedKeepsOutstanding(t *testing.T) {
+	pods := []*corev1.Pod{
+		{ObjectMeta: metav1.ObjectMeta{Name: "pod-0"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "pod-1"}},
+	}
+	completed := map[string]bool{}
+	failed := map[string]bool{"pod-0": true} // pod-1 not yet attempted
+	opStatus := &ackov1alpha1.OperationStatus{Phase: ackov1alpha1.AerospikePhaseInProgress}
+
+	done := finalizeOperationPhase(opStatus, pods, completed, failed)
+	if done {
+		t.Fatal("expected done=false: pod-1 is still outstanding")
+	}
+	if opStatus.Phase != ackov1alpha1.AerospikePhaseInProgress {
+		t.Errorf("phase = %q, want %q", opStatus.Phase, ackov1alpha1.AerospikePhaseInProgress)
+	}
+}
+
+// TestOperationFailedPodsDedup simulates the cross-reconcile dedup logic from
+// reconcileOperations: a pod already on FailedPods from a previous reconcile
+// must not be appended again, otherwise FailedPods grows unbounded with
+// duplicates on every 5s requeue.
+func TestOperationFailedPodsDedup(t *testing.T) {
+	// Prior status carried forward into a fresh opStatus, as reconcileOperations does.
+	prev := &ackov1alpha1.OperationStatus{FailedPods: []string{"pod-0"}}
+	opStatus := &ackov1alpha1.OperationStatus{FailedPods: prev.FailedPods}
+
+	failedSet := make(map[string]bool)
+	for _, p := range prev.FailedPods {
+		failedSet[p] = true
+	}
+
+	// Re-observe pod-0 failing on the next reconcile.
+	podName := "pod-0"
+	if !failedSet[podName] {
+		opStatus.FailedPods = append(opStatus.FailedPods, podName)
+		failedSet[podName] = true
+	}
+
+	if len(opStatus.FailedPods) != 1 {
+		t.Fatalf("FailedPods = %v, want exactly one entry (no duplicates across reconciles)", opStatus.FailedPods)
 	}
 }

--- a/internal/controller/reconciler_statefulset.go
+++ b/internal/controller/reconciler_statefulset.go
@@ -375,16 +375,17 @@ func (r *AerospikeClusterReconciler) cleanupRemovedRacks(
 		// fully gone but the orphan PVCs/ConfigMap survive and are handled
 		// by the cleanup path keyed off rackID below).
 		//
-		// If the rackID cannot be parsed from the STS name we refuse to
-		// proceed: a partial cleanup that deletes PVCs without first
-		// confirming pods are gone re-introduces the "PVC deleted while pods
-		// alive" hazard.
+		// If the rackID cannot be parsed from the STS name we skip this
+		// StatefulSet rather than failing: a non-numeric suffix means this is
+		// not an operator-managed rack StatefulSet, so it is not ours to clean
+		// up. Returning a hard error here would abort the entire reconcile for
+		// every other rack over a single unrecognized name.
 		rackIDStr := strings.TrimPrefix(stsName, cluster.Name+"-")
 		rackID, convErr := strconv.Atoi(rackIDStr)
 		if convErr != nil {
-			return fmt.Errorf("cannot derive rackID from StatefulSet name %q (cluster %q): %w; "+
-				"refusing rack cleanup to avoid deleting PVCs while pods may still be running",
-				stsName, cluster.Name, convErr)
+			log.V(1).Info("Skipping StatefulSet with unparseable rackID suffix; not an operator-managed rack",
+				"statefulset", stsName, "err", convErr)
+			continue
 		}
 
 		pods, listErr := r.listRackPods(ctx, cluster, rackID)


### PR DESCRIPTION
Fixes four findings from the 2026-05 code audit. Each fix is a self-contained commit; diffs are kept minimal.

## Fix 1 (P1) — on-demand operation never terminates after a pod failure

**Problem:** When `warmRestartPod`/`coldRestartPod` failed on a pod, the pod was appended to `opStatus.FailedPods` but never added to `completedSet`. `finalizeOperationPhase` computed `remainingPods` from pods absent from `completedSet`, so a failed pod kept `remainingPods > 0` forever. The operation never reached the terminal `Error` phase, the cluster requeued every 5s permanently, the failed pod was re-restarted on every reconcile with no backoff, and `FailedPods` grew unbounded with duplicates (carried forward then re-appended each reconcile).

**Fix:** Treat a pod as resolved once attempted — success OR failure. `finalizeOperationPhase` now counts `remainingPods` against the union of completed and failed pods, and `reconcileOperations` skips already-failed pods and dedupes `FailedPods` across reconciles. A fully-failed operation now reaches the terminal `Error` phase.

**Impact:** On-demand operations (`WarmRestart`, `PodRestart`) with a permanently failing pod now terminate cleanly in `Error` instead of pinning a controller worker in a 5s requeue loop. `FailedPods` no longer accumulates duplicates.

## Fix 2 (P2) — replication-factor validators skip `int32` values

**Problem:** `validateReplicationFactor` and `validateNamespaceConfig` switched only over `int`/`int64`/`float64` (the latter over `int`/`float64`). An `int32`-typed `replication-factor` fell through with `rfInt=0`, tripping the misleading `replication-factor must be >= 1, got 0` error.

**Fix:** Added `int32` and `json.Number` cases to both switches (`encoding/json` is already imported), so every integer type a decoder can produce is validated correctly.

**Impact:** `int32`-typed `replication-factor` values are validated correctly instead of producing a false `got 0` rejection.

## Fix 3 (P2) — `cleanupRemovedRacks` aborts the whole reconcile on an unparseable STS name

**Problem:** `cleanupRemovedRacks` derived the rack ID via `strconv.Atoi` on the StatefulSet name suffix. A non-numeric suffix made `Atoi` fail and returned a hard error that failed the **entire** reconcile, including cleanup of every other rack.

**Fix:** A non-numeric suffix means the StatefulSet is not an operator-managed rack and is not ours to clean up — log it at `V(1)` and `continue` instead of returning an error.

**Impact:** A single unrecognized StatefulSet name no longer aborts reconciliation for the whole cluster.

## Fix 4 (P1) — helm chart manager ClusterRole missing `pods/exec` and `pods/status`

**Problem:** The helm chart's hand-maintained manager ClusterRole (`charts/aerospike-ce-kubernetes-operator/templates/clusterrole-manager.yaml`) had drifted from the kubebuilder-generated RBAC in `config/rbac/role.yaml`. It granted only the `pods` resource (delete/get/list/watch) and was missing both `pods/exec` and `pods/status`. The controller declares these markers (`reconciler.go:113-114`). A kind-cluster test confirmed that, when the operator is installed via the project-mandated `helm install` path, on-demand restart operations (`WarmRestart`/`PodRestart`) always fail with `cannot create resource "pods/exec"`.

**Fix:** Add the two missing rules — `pods/exec` (verbs: create) and `pods/status` (verbs: patch) — to the chart ClusterRole, placed next to the existing `pods` rule, aligning the chart with `config/rbac/role.yaml`.

**Impact:** On-demand operations (`WarmRestart`, `PodRestart`) now work on the `helm install` path. `helm lint` passes and `helm template` renders the manager ClusterRole with both `pods/exec` and `pods/status`.

## Verification

| Command | Result |
|---------|--------|
| `go build ./...` | PASS |
| `go vet ./...` | PASS (clean) |
| `make test-unit` (`fmt` + `vet` + all non-e2e tests, incl. controller envtest suite + `api/v1alpha1`) | PASS |
| Focused `finalizeOperationPhase` / dedup tests (`go test -run 'FinalizeOperationPhase|OperationFailedPodsDedup' -v`) | PASS (14 tests) |
| `helm lint charts/aerospike-ce-kubernetes-operator` | PASS (0 charts failed) |
| `helm template aerospike-ce-kubernetes-operator charts/aerospike-ce-kubernetes-operator` | PASS — manager ClusterRole renders `pods/exec` and `pods/status` |

New regression tests added in `internal/controller/reconciler_operations_test.go`:
- `TestFinalizeOperationPhase_AllFailed_ReachesTerminalError` — a fully-failed operation reaches terminal `Error` (not an infinite loop).
- `TestFinalizeOperationPhase_FailedPodNotRetriedKeepsOutstanding` — a failed pod neither blocks completion nor masks genuinely pending work.
- `TestOperationFailedPodsDedup` — `FailedPods` does not accumulate duplicates across reconciles.

Existing `finalizeOperationPhase` tests were updated for the new `failedSet` parameter.

The slow `make test-integration` (full envtest) target was not run separately; the controller package's envtest suite (`suite_test.go`) does run as part of `make test-unit` and passed.
