### PR TITLE
fix: hash PodService/NetworkPolicy, harden migrate-stat parsing and PVC ownership

### DIFF
--- a/internal/controller/aero_info.go
+++ b/internal/controller/aero_info.go
@@ -68,7 +68,14 @@ func isMigratingOnAnyNode(client *aero.Client) (bool, error) {
 		if err != nil {
 			return true, fmt.Errorf("statistics command on node %s failed: %w", node.GetName(), err)
 		}
-		remaining := parseMigrateStat(stats, "migrate_partitions_remaining")
+		remaining, ok := parseMigrateStat(stats, "migrate_partitions_remaining")
+		if !ok {
+			// An unparseable migration statistic is treated conservatively as
+			// "migrating" — the same way a statistics-command error is handled
+			// above — so a destructive scale-down or rolling restart never
+			// proceeds on a value we could not verify as zero.
+			return true, fmt.Errorf("could not parse migrate_partitions_remaining on node %s", node.GetName())
+		}
 		if remaining > 0 {
 			return true, nil
 		}
@@ -78,8 +85,10 @@ func isMigratingOnAnyNode(client *aero.Client) (bool, error) {
 
 // parseMigrateStat extracts a numeric migration statistic from the asinfo
 // "statistics" response. The response is semicolon-delimited key=value pairs.
-// Returns 0 if the key is not found or cannot be parsed.
-func parseMigrateStat(stats, key string) int64 {
+// The second return value is false when the key is absent OR when its value
+// cannot be parsed as an integer; callers must not treat a false result as
+// "migration complete".
+func parseMigrateStat(stats, key string) (int64, bool) {
 	for pair := range strings.SplitSeq(stats, ";") {
 		k, v, ok := strings.Cut(pair, "=")
 		if !ok {
@@ -88,12 +97,12 @@ func parseMigrateStat(stats, key string) int64 {
 		if strings.TrimSpace(k) == key {
 			n, err := strconv.ParseInt(strings.TrimSpace(v), 10, 64)
 			if err != nil {
-				return 0
+				return 0, false
 			}
-			return n
+			return n, true
 		}
 	}
-	return 0
+	return 0, false
 }
 
 // migrateStatsPerNode returns the migrate_partitions_remaining count for each node
@@ -118,7 +127,15 @@ func migrateStatsPerNode(log logr.Logger, client *aero.Client) (map[string]int64
 			log.V(1).Info("Skipping node: statistics command failed", "node", node.GetName(), "error", err)
 			continue
 		}
-		remaining := parseMigrateStat(stats, "migrate_partitions_remaining")
+		remaining, ok := parseMigrateStat(stats, "migrate_partitions_remaining")
+		if !ok {
+			// Key absent or value unparseable: record a positive sentinel so
+			// the node is reported as migrating rather than silently dropped
+			// (which downstream would render as "migration complete").
+			log.V(1).Info("Could not parse migrate_partitions_remaining, reporting node as migrating",
+				"node", node.GetName())
+			remaining = 1
+		}
 		host := node.GetHost()
 		if host != nil {
 			result[host.Name] = remaining

--- a/internal/controller/aero_info_test.go
+++ b/internal/controller/aero_info_test.go
@@ -4,72 +4,90 @@ import "testing"
 
 func TestParseMigrateStat(t *testing.T) {
 	tests := []struct {
-		name  string
-		stats string
-		key   string
-		want  int64
+		name   string
+		stats  string
+		key    string
+		want   int64
+		wantOK bool
 	}{
 		{
-			name:  "migrate_partitions_remaining non-zero",
-			stats: "cluster_size=3;migrate_partitions_remaining=42;objects=1000000",
-			key:   "migrate_partitions_remaining",
-			want:  42,
+			name:   "migrate_partitions_remaining non-zero",
+			stats:  "cluster_size=3;migrate_partitions_remaining=42;objects=1000000",
+			key:    "migrate_partitions_remaining",
+			want:   42,
+			wantOK: true,
 		},
 		{
-			name:  "migrate_partitions_remaining zero",
-			stats: "cluster_size=3;migrate_partitions_remaining=0;objects=1000000",
-			key:   "migrate_partitions_remaining",
-			want:  0,
+			name:   "migrate_partitions_remaining zero",
+			stats:  "cluster_size=3;migrate_partitions_remaining=0;objects=1000000",
+			key:    "migrate_partitions_remaining",
+			want:   0,
+			wantOK: true,
 		},
 		{
-			name:  "key not found returns zero",
-			stats: "cluster_size=3;other_stat=10",
-			key:   "migrate_partitions_remaining",
-			want:  0,
+			name:   "key not found reports not-ok",
+			stats:  "cluster_size=3;other_stat=10",
+			key:    "migrate_partitions_remaining",
+			want:   0,
+			wantOK: false,
 		},
 		{
-			name:  "empty stats returns zero",
-			stats: "",
-			key:   "migrate_partitions_remaining",
-			want:  0,
+			name:   "empty stats reports not-ok",
+			stats:  "",
+			key:    "migrate_partitions_remaining",
+			want:   0,
+			wantOK: false,
 		},
 		{
-			name:  "non-numeric value returns zero",
-			stats: "migrate_partitions_remaining=abc",
-			key:   "migrate_partitions_remaining",
-			want:  0,
+			name:   "non-numeric value reports not-ok",
+			stats:  "migrate_partitions_remaining=abc",
+			key:    "migrate_partitions_remaining",
+			want:   0,
+			wantOK: false,
 		},
 		{
-			name:  "key with spaces around value",
-			stats: "migrate_partitions_remaining = 10 ",
-			key:   "migrate_partitions_remaining",
-			want:  10,
+			name:   "key with spaces around value",
+			stats:  "migrate_partitions_remaining = 10 ",
+			key:    "migrate_partitions_remaining",
+			want:   10,
+			wantOK: true,
 		},
 		{
-			name:  "partial key match does not match",
-			stats: "migrate_partitions_remaining_extra=5;migrate_partitions_remaining=3",
-			key:   "migrate_partitions_remaining",
-			want:  3,
+			name:   "partial key match does not match",
+			stats:  "migrate_partitions_remaining_extra=5;migrate_partitions_remaining=3",
+			key:    "migrate_partitions_remaining",
+			want:   3,
+			wantOK: true,
 		},
 		{
-			name:  "large value",
-			stats: "migrate_partitions_remaining=999999999",
-			key:   "migrate_partitions_remaining",
-			want:  999999999,
+			name:   "large value",
+			stats:  "migrate_partitions_remaining=999999999",
+			key:    "migrate_partitions_remaining",
+			want:   999999999,
+			wantOK: true,
 		},
 		{
-			name:  "realistic aerospike CE 8.x statistics response",
-			stats: "cluster_size=3;cluster_key=ABC123;cluster_integrity=true;migrate_partitions_remaining=100;objects=1000000",
-			key:   "migrate_partitions_remaining",
-			want:  100,
+			name:   "realistic aerospike CE 8.x statistics response",
+			stats:  "cluster_size=3;cluster_key=ABC123;cluster_integrity=true;migrate_partitions_remaining=100;objects=1000000",
+			key:    "migrate_partitions_remaining",
+			want:   100,
+			wantOK: true,
+		},
+		{
+			name:   "empty value reports not-ok",
+			stats:  "migrate_partitions_remaining=;objects=10",
+			key:    "migrate_partitions_remaining",
+			want:   0,
+			wantOK: false,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := parseMigrateStat(tc.stats, tc.key)
-			if got != tc.want {
-				t.Errorf("parseMigrateStat(%q, %q) = %d, want %d", tc.stats, tc.key, got, tc.want)
+			got, ok := parseMigrateStat(tc.stats, tc.key)
+			if got != tc.want || ok != tc.wantOK {
+				t.Errorf("parseMigrateStat(%q, %q) = (%d, %t), want (%d, %t)",
+					tc.stats, tc.key, got, ok, tc.want, tc.wantOK)
 			}
 		})
 	}

--- a/internal/controller/reconciler_cleanup.go
+++ b/internal/controller/reconciler_cleanup.go
@@ -48,7 +48,7 @@ func (r *AerospikeClusterReconciler) handleDeletion(
 		}
 		var pvcErrors []error
 		for _, sts := range stsList.Items {
-			if err := storage.DeleteCascadeDeletePVCs(ctx, r.Client, cluster.Namespace, sts.Name, cluster.Spec.Storage); err != nil {
+			if err := storage.DeleteCascadeDeletePVCs(ctx, r.Client, cluster.Namespace, cluster.Name, sts.Name, cluster.Spec.Storage); err != nil {
 				if !k8serrors.IsNotFound(err) {
 					log.Error(err, "Failed to delete cascade PVCs for StatefulSet", "statefulset", sts.Name)
 					r.Recorder.Eventf(cluster, corev1.EventTypeWarning, EventPVCCleanupFailed,

--- a/internal/controller/reconciler_restart.go
+++ b/internal/controller/reconciler_restart.go
@@ -135,6 +135,13 @@ func (r *AerospikeClusterReconciler) reconcileRollingRestart(
 	// touching any pod. Passing nil configs makes restartPodBatch's
 	// oldConfig != nil && newConfig != nil guard skip the dynamic path and go
 	// straight to per-pod cold restart.
+	//
+	// In a mixed batch (some pods config-changed, some pod-spec-only-changed)
+	// configChanged is true, so pod-spec-only pods also take the 2PC path and
+	// get a spurious no-op config re-apply. This is harmless and eventually
+	// consistent: their PodSpecHashAnnotation stays stale, so they are
+	// re-selected on a later reconcile; once the config-changed pods drain,
+	// configChanged becomes false and they cold-restart normally. No stall.
 	batchOldConfig, batchNewConfig := oldConfig, newConfig
 	if !configChanged {
 		batchOldConfig, batchNewConfig = nil, nil

--- a/internal/controller/reconciler_restart.go
+++ b/internal/controller/reconciler_restart.go
@@ -28,9 +28,11 @@ import (
 // state is skipped from the rolling restart to avoid blocking healthy pods.
 const maxPodUnstableDuration = 10 * time.Minute
 
-// reconcileRollingRestart checks if pods need restart due to config changes.
-// Returns true if a restart was triggered (caller should requeue).
-// Supports batch restart via spec.rollingUpdateBatchSize.
+// reconcileRollingRestart checks if pods need restart due to config changes or
+// pod-spec changes (image, podSpec, podService, networkPolicy). A pod is
+// selected when its config-hash OR its pod-spec-hash differs from the
+// StatefulSet template. Returns true if a restart was triggered (caller should
+// requeue). Supports batch restart via spec.rollingUpdateBatchSize.
 //
 // Precedence: dynamic config update > warm restart (SIGUSR1) > cold restart (pod delete).
 func (r *AerospikeClusterReconciler) reconcileRollingRestart(
@@ -51,10 +53,15 @@ func (r *AerospikeClusterReconciler) reconcileRollingRestart(
 		return false, err
 	}
 
-	// Get desired config hash from the StatefulSet template
+	// Get desired config hash and pod-spec hash from the StatefulSet template.
+	// The pod-spec hash captures image/podSpec/podService/networkPolicy changes
+	// that are not reflected in the config hash; a pod whose pod-spec hash differs
+	// from the template still needs a restart even when its config hash matches.
 	desiredHash := ""
+	desiredPodSpecHash := ""
 	if sts.Spec.Template.Annotations != nil {
 		desiredHash = sts.Spec.Template.Annotations[utils.ConfigHashAnnotation]
+		desiredPodSpecHash = sts.Spec.Template.Annotations[utils.PodSpecHashAnnotation]
 	}
 
 	if desiredHash == "" {
@@ -86,43 +93,8 @@ func (r *AerospikeClusterReconciler) reconcileRollingRestart(
 		return false, fmt.Errorf("listing rack pods for rolling restart: %w", err)
 	}
 
-	var podsToRestart []*corev1.Pod
-	ignoredCount := int32(0)
-	for i := range rackPods {
-		pod := &rackPods[i]
-
-		// Skip pending/failed pods if within ignorable limit
-		if pod.Status.Phase == corev1.PodPending || pod.Status.Phase == corev1.PodFailed {
-			if ignoredCount < maxIgnorablePods {
-				ignoredCount++
-				log.V(1).Info("Ignoring pending/failed pod", "pod", pod.Name)
-				continue
-			}
-		}
-
-		// Skip pods that have been in a non-ready state longer than the threshold.
-		// This prevents a stuck pod from blocking healthy pods in the same rack.
-		if ps, ok := cluster.Status.Pods[pod.Name]; ok && ps.UnstableSince != nil {
-			if time.Since(ps.UnstableSince.Time) > maxPodUnstableDuration {
-				log.Info("Pod stuck in non-ready state beyond threshold, skipping restart",
-					"pod", pod.Name, "unstableSince", ps.UnstableSince.Time,
-					"threshold", maxPodUnstableDuration)
-				r.Recorder.Eventf(cluster, corev1.EventTypeWarning, EventRestartFailed,
-					"Pod %s stuck in non-ready state since %v (>%v), skipping restart",
-					pod.Name, ps.UnstableSince.Time, maxPodUnstableDuration)
-				continue
-			}
-		}
-
-		currentHash := ""
-		if pod.Annotations != nil {
-			currentHash = pod.Annotations[utils.ConfigHashAnnotation]
-		}
-
-		if currentHash != desiredHash {
-			podsToRestart = append(podsToRestart, pod)
-		}
-	}
+	podsToRestart, configChanged := r.selectPodsToRestart(
+		ctx, cluster, rackPods, desiredHash, desiredPodSpecHash, maxIgnorablePods)
 
 	if len(podsToRestart) == 0 {
 		cluster.Status.PendingRestartPods = nil
@@ -156,8 +128,19 @@ func (r *AerospikeClusterReconciler) reconcileRollingRestart(
 	}
 
 	// Restart up to batchSize pods, continuing on individual pod failures.
+	// Only offer the configs to the dynamic-config 2PC path when an actual
+	// config-hash change triggered the batch. For a pure pod-spec-hash change
+	// the config is unchanged, so configdiff would report no changes and the
+	// 2PC path would short-circuit to a false "all restarted" success without
+	// touching any pod. Passing nil configs makes restartPodBatch's
+	// oldConfig != nil && newConfig != nil guard skip the dynamic path and go
+	// straight to per-pod cold restart.
+	batchOldConfig, batchNewConfig := oldConfig, newConfig
+	if !configChanged {
+		batchOldConfig, batchNewConfig = nil, nil
+	}
 	restarted, failedPods, batchPods := r.restartPodBatch(ctx, cluster, podsToRestart, sts, desiredHash,
-		batchSize, oldConfig, newConfig, &aeroClient)
+		batchSize, batchOldConfig, batchNewConfig, &aeroClient)
 
 	// Update PendingRestartPods to only include pods that were NOT successfully restarted.
 	if len(failedPods) > 0 || restarted > 0 {
@@ -182,6 +165,85 @@ func (r *AerospikeClusterReconciler) reconcileRollingRestart(
 	}
 
 	return restarted > 0, nil
+}
+
+// selectPodsToRestart scans the rack's pods and returns those that need a
+// restart, along with configChanged: whether ANY selected pod is being
+// restarted because of a config-hash mismatch.
+//
+// A pod is selected when its config-hash OR its pod-spec-hash differs from the
+// StatefulSet template. The pod-spec-hash comparison is what makes plain
+// spec.image / spec.podService / spec.aerospikeNetworkPolicy changes actually
+// roll pods — without it those changes patch the StatefulSet template but never
+// trigger a restart.
+//
+// configChanged gates the dynamic-config 2PC path in the caller: when the batch
+// is triggered purely by a pod-spec-hash change (config genuinely unchanged),
+// configdiff would report no changes and tryDynamicConfigUpdateBatch would
+// return allOk=true, falsely claiming every pod restarted while nothing
+// happened. The caller passes nil configs in that case so the dynamic path is
+// skipped and pods go straight to per-pod cold restart.
+//
+// Pending/failed pods within the ignorable limit and pods stuck non-ready
+// beyond maxPodUnstableDuration are skipped so they cannot block healthy pods.
+func (r *AerospikeClusterReconciler) selectPodsToRestart(
+	ctx context.Context,
+	cluster *ackov1alpha1.AerospikeCluster,
+	rackPods []corev1.Pod,
+	desiredHash, desiredPodSpecHash string,
+	maxIgnorablePods int32,
+) ([]*corev1.Pod, bool) {
+	log := logf.FromContext(ctx)
+
+	var podsToRestart []*corev1.Pod
+	ignoredCount := int32(0)
+	configChanged := false
+
+	for i := range rackPods {
+		pod := &rackPods[i]
+
+		// Skip pending/failed pods if within ignorable limit
+		if pod.Status.Phase == corev1.PodPending || pod.Status.Phase == corev1.PodFailed {
+			if ignoredCount < maxIgnorablePods {
+				ignoredCount++
+				log.V(1).Info("Ignoring pending/failed pod", "pod", pod.Name)
+				continue
+			}
+		}
+
+		// Skip pods that have been in a non-ready state longer than the threshold.
+		// This prevents a stuck pod from blocking healthy pods in the same rack.
+		if ps, ok := cluster.Status.Pods[pod.Name]; ok && ps.UnstableSince != nil {
+			if time.Since(ps.UnstableSince.Time) > maxPodUnstableDuration {
+				log.Info("Pod stuck in non-ready state beyond threshold, skipping restart",
+					"pod", pod.Name, "unstableSince", ps.UnstableSince.Time,
+					"threshold", maxPodUnstableDuration)
+				r.Recorder.Eventf(cluster, corev1.EventTypeWarning, EventRestartFailed,
+					"Pod %s stuck in non-ready state since %v (>%v), skipping restart",
+					pod.Name, ps.UnstableSince.Time, maxPodUnstableDuration)
+				continue
+			}
+		}
+
+		currentHash := ""
+		currentPodSpecHash := ""
+		if pod.Annotations != nil {
+			currentHash = pod.Annotations[utils.ConfigHashAnnotation]
+			currentPodSpecHash = pod.Annotations[utils.PodSpecHashAnnotation]
+		}
+
+		configMismatch := currentHash != desiredHash
+		podSpecMismatch := desiredPodSpecHash != "" && currentPodSpecHash != desiredPodSpecHash
+
+		if configMismatch || podSpecMismatch {
+			podsToRestart = append(podsToRestart, pod)
+		}
+		if configMismatch {
+			configChanged = true
+		}
+	}
+
+	return podsToRestart, configChanged
 }
 
 // podDynamicUpdate tracks a pod that received a successful dynamic config update,

--- a/internal/controller/reconciler_restart.go
+++ b/internal/controller/reconciler_restart.go
@@ -146,12 +146,14 @@ func (r *AerospikeClusterReconciler) reconcileRollingRestart(
 		}
 	}()
 
+	// Publish the truly-pending pods before any early return so observers see
+	// them even while the batch is blocked on migration or readiness gates.
+	cluster.Status.PendingRestartPods = pendingNames
+
 	// Hold the next batch when migration or readiness gates are blocking.
 	if r.isBatchBlocked(ctx, cluster, rack.ID, rackPods) {
 		return true, nil
 	}
-
-	cluster.Status.PendingRestartPods = pendingNames
 
 	// Restart up to batchSize pods, continuing on individual pod failures.
 	restarted, failedPods, batchPods := r.restartPodBatch(ctx, cluster, podsToRestart, sts, desiredHash,
@@ -466,7 +468,7 @@ func (r *AerospikeClusterReconciler) coldRestartPod(
 		if !ok {
 			log.V(1).Info("Failed to parse pod name for PVC cleanup, skipping local PVC deletion", "pod", pod.Name)
 		} else {
-			if err := storage.DeleteLocalPVCsForPod(ctx, r.Client, cluster.Namespace, stsName, ordinal, cluster.Spec.Storage); err != nil {
+			if err := storage.DeleteLocalPVCsForPod(ctx, r.Client, cluster.Namespace, cluster.Name, stsName, ordinal, cluster.Spec.Storage); err != nil {
 				log.Error(err, "Failed to delete local PVCs before restart", "pod", pod.Name)
 				r.Recorder.Eventf(cluster, corev1.EventTypeWarning, EventLocalPVCDeleteFailed,
 					"Failed to delete local PVCs for pod %s before restart: %v", pod.Name, err)

--- a/internal/controller/reconciler_restart_rolling_test.go
+++ b/internal/controller/reconciler_restart_rolling_test.go
@@ -1,0 +1,372 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	aero "github.com/aerospike/aerospike-client-go/v8"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/podutil"
+	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/utils"
+)
+
+// rollingRestartScheme builds a scheme with both the acko CRD types and the
+// core/apps built-ins needed for StatefulSets and Pods.
+func rollingRestartScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(s); err != nil {
+		t.Fatalf("AddToScheme(client-go) error = %v", err)
+	}
+	if err := ackov1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("AddToScheme(acko) error = %v", err)
+	}
+	return s
+}
+
+// newRackPod builds pod "demo-0" labelled for rack 0 of the given cluster with
+// the supplied config-hash and pod-spec-hash annotations.
+func newRackPod(clusterName, configHash, podSpecHash string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo-0",
+			Namespace: "default",
+			Labels:    utils.LabelsForRack(clusterName, 0),
+			Annotations: map[string]string{
+				utils.ConfigHashAnnotation:  configHash,
+				utils.PodSpecHashAnnotation: podSpecHash,
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: podutil.AerospikeContainerName, Image: "aerospike:ce-8.1.1.1"},
+			},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+}
+
+// TestSelectPodsToRestart is the focused Gap A trigger-logic test. It locks in
+// that a pod is selected for restart when EITHER its config-hash OR its
+// pod-spec-hash differs from the StatefulSet template, and that configChanged
+// reflects only config-hash mismatches (the Gap B gate signal).
+func TestSelectPodsToRestart(t *testing.T) {
+	const (
+		desiredHash        = "cfg-NEW"
+		desiredPodSpecHash = "podspec-NEW"
+	)
+
+	tests := []struct {
+		name              string
+		configHash        string
+		podSpecHash       string
+		wantSelected      bool
+		wantConfigChanged bool
+	}{
+		{
+			name:              "both hashes match → not selected",
+			configHash:        desiredHash,
+			podSpecHash:       desiredPodSpecHash,
+			wantSelected:      false,
+			wantConfigChanged: false,
+		},
+		{
+			name:              "config-hash differs → selected, configChanged",
+			configHash:        "cfg-OLD",
+			podSpecHash:       desiredPodSpecHash,
+			wantSelected:      true,
+			wantConfigChanged: true,
+		},
+		{
+			name:              "pod-spec-hash differs (config matches) → selected, NOT configChanged",
+			configHash:        desiredHash,
+			podSpecHash:       "podspec-OLD",
+			wantSelected:      true,
+			wantConfigChanged: false,
+		},
+		{
+			name:              "both hashes differ → selected, configChanged",
+			configHash:        "cfg-OLD",
+			podSpecHash:       "podspec-OLD",
+			wantSelected:      true,
+			wantConfigChanged: true,
+		},
+	}
+
+	scheme := rollingRestartScheme(t)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cluster := &ackov1alpha1.AerospikeCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "default"},
+			}
+			pod := *newRackPod(cluster.Name, tc.configHash, tc.podSpecHash)
+
+			reconciler := &AerospikeClusterReconciler{
+				Client:   fake.NewClientBuilder().WithScheme(scheme).Build(),
+				Scheme:   scheme,
+				Recorder: record.NewFakeRecorder(8),
+			}
+
+			selected, configChanged := reconciler.selectPodsToRestart(
+				context.Background(), cluster, []corev1.Pod{pod},
+				desiredHash, desiredPodSpecHash, 0)
+
+			if got := len(selected) == 1; got != tc.wantSelected {
+				t.Errorf("selected = %v, want %v (selected=%d)", got, tc.wantSelected, len(selected))
+			}
+			if configChanged != tc.wantConfigChanged {
+				t.Errorf("configChanged = %v, want %v", configChanged, tc.wantConfigChanged)
+			}
+		})
+	}
+}
+
+// TestSelectPodsToRestart_EmptyDesiredPodSpecHash verifies that when the
+// StatefulSet template has no pod-spec-hash annotation (desiredPodSpecHash ==
+// ""), a pod is never selected solely on a pod-spec-hash difference — the
+// pod-spec check is gated on a non-empty desired hash.
+func TestSelectPodsToRestart_EmptyDesiredPodSpecHash(t *testing.T) {
+	scheme := rollingRestartScheme(t)
+	cluster := &ackov1alpha1.AerospikeCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "default"},
+	}
+	pod := *newRackPod(cluster.Name, "cfg-SAME", "podspec-anything")
+
+	reconciler := &AerospikeClusterReconciler{
+		Client:   fake.NewClientBuilder().WithScheme(scheme).Build(),
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(8),
+	}
+
+	selected, configChanged := reconciler.selectPodsToRestart(
+		context.Background(), cluster, []corev1.Pod{pod}, "cfg-SAME", "", 0)
+
+	if len(selected) != 0 {
+		t.Errorf("expected no pod selected when desiredPodSpecHash is empty, got %d", len(selected))
+	}
+	if configChanged {
+		t.Error("configChanged should be false when config hash matches")
+	}
+}
+
+// TestReconcileRollingRestart_TriggersOnPodSpecHashChange is the Gap A test:
+// a pod whose PodSpecHashAnnotation differs from the StatefulSet template MUST
+// be selected for restart even when its ConfigHashAnnotation already matches.
+// Against the pre-fix code (which only compared ConfigHashAnnotation) the pod
+// is never added to podsToRestart, reconcileRollingRestart returns (false, nil)
+// and the pod is never deleted.
+func TestReconcileRollingRestart_TriggersOnPodSpecHashChange(t *testing.T) {
+	scheme := rollingRestartScheme(t)
+
+	// Config is unchanged: status config == spec config. Only the pod-spec
+	// hash drifts, which also keeps the dynamic-config path out of the picture
+	// (configChanged == false), so this is a pure cold restart.
+	// ReadinessGateEnabled routes isBatchBlocked through the in-memory gate
+	// check instead of a (slow, network-bound) migration probe; the test pod
+	// predates the gate so the batch is not blocked.
+	readinessGate := true
+	cfg := &ackov1alpha1.AerospikeConfigSpec{Value: map[string]any{"service": map[string]any{}}}
+	cluster := &ackov1alpha1.AerospikeCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "default"},
+		Spec: ackov1alpha1.AerospikeClusterSpec{
+			Image:           "aerospike:ce-8.1.1.1",
+			AerospikeConfig: cfg,
+			PodSpec:         &ackov1alpha1.AerospikePodSpec{ReadinessGateEnabled: &readinessGate},
+		},
+		Status: ackov1alpha1.AerospikeClusterStatus{AerospikeConfig: cfg},
+	}
+
+	replicas := int32(1)
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      utils.StatefulSetName(cluster.Name, 0),
+			Namespace: cluster.Namespace,
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						utils.ConfigHashAnnotation:  "cfg-hash",
+						utils.PodSpecHashAnnotation: "podspec-NEW",
+					},
+				},
+			},
+		},
+	}
+
+	// Pod's config hash matches the template, but its pod-spec hash is stale.
+	pod := newRackPod(cluster.Name, "cfg-hash", "podspec-OLD")
+
+	reconciler := &AerospikeClusterReconciler{
+		Client: fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithStatusSubresource(&ackov1alpha1.AerospikeCluster{}).
+			WithObjects(cluster, sts, pod).
+			Build(),
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(16),
+	}
+
+	rack := &ackov1alpha1.Rack{ID: 0}
+	triggered, err := reconciler.reconcileRollingRestart(context.Background(), cluster, rack)
+	if err != nil {
+		t.Fatalf("reconcileRollingRestart() error = %v", err)
+	}
+	if !triggered {
+		t.Fatal("expected reconcileRollingRestart to trigger a restart for a stale pod-spec-hash pod, got false")
+	}
+
+	// Cold restart deletes the pod. Confirm it is gone.
+	got := &corev1.Pod{}
+	err = reconciler.Get(context.Background(), types.NamespacedName{Name: "demo-0", Namespace: "default"}, got)
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("expected pod demo-0 to be deleted (cold restart), Get err = %v", err)
+	}
+}
+
+// TestReconcileRollingRestart_PodSpecChangeNotShortCircuited is the Gap B test.
+// With spec.enableDynamicConfigUpdate=true and a pure pod-spec change (config
+// genuinely unchanged), the restart MUST NOT short-circuit through the dynamic
+// 2PC path. tryDynamicConfigUpdateBatch would see no config diff and return
+// allOk=true, causing restartPodBatch to claim every pod restarted while
+// nothing happened. The fix passes nil configs when no config-hash changed, so
+// the pod is genuinely cold-restarted (deleted) here.
+func TestReconcileRollingRestart_PodSpecChangeNotShortCircuited(t *testing.T) {
+	scheme := rollingRestartScheme(t)
+
+	enable := true
+	readinessGate := true
+	cfg := &ackov1alpha1.AerospikeConfigSpec{Value: map[string]any{"service": map[string]any{}}}
+	cluster := &ackov1alpha1.AerospikeCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "default"},
+		Spec: ackov1alpha1.AerospikeClusterSpec{
+			Image:                     "aerospike:ce-8.1.1.1",
+			AerospikeConfig:           cfg,
+			EnableDynamicConfigUpdate: &enable,
+			// ReadinessGateEnabled keeps isBatchBlocked off the network path;
+			// see the Gap A test for the rationale.
+			PodSpec: &ackov1alpha1.AerospikePodSpec{ReadinessGateEnabled: &readinessGate},
+		},
+		Status: ackov1alpha1.AerospikeClusterStatus{AerospikeConfig: cfg},
+	}
+
+	replicas := int32(1)
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      utils.StatefulSetName(cluster.Name, 0),
+			Namespace: cluster.Namespace,
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						utils.ConfigHashAnnotation:  "cfg-hash",
+						utils.PodSpecHashAnnotation: "podspec-NEW",
+					},
+				},
+			},
+		},
+	}
+	pod := newRackPod(cluster.Name, "cfg-hash", "podspec-OLD")
+
+	reconciler := &AerospikeClusterReconciler{
+		Client: fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithStatusSubresource(&ackov1alpha1.AerospikeCluster{}).
+			WithObjects(cluster, sts, pod).
+			Build(),
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(16),
+	}
+
+	rack := &ackov1alpha1.Rack{ID: 0}
+	triggered, err := reconciler.reconcileRollingRestart(context.Background(), cluster, rack)
+	if err != nil {
+		t.Fatalf("reconcileRollingRestart() error = %v", err)
+	}
+	if !triggered {
+		t.Fatal("expected a restart to be triggered for the stale pod-spec-hash pod")
+	}
+
+	// The pod must actually be deleted. If the dynamic short-circuit had run,
+	// restartPodBatch would report success without deleting anything.
+	got := &corev1.Pod{}
+	err = reconciler.Get(context.Background(), types.NamespacedName{Name: "demo-0", Namespace: "default"}, got)
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("Gap B: pod demo-0 was NOT cold-restarted — dynamic-config path falsely reported success; Get err = %v", err)
+	}
+}
+
+// TestRestartPodBatch_DynamicShortCircuitFalseSuccess documents the underlying
+// trap behind Gap B: when restartPodBatch is given non-nil identical configs
+// and a live Aerospike client, tryDynamicConfigUpdateBatch sees no config diff
+// and returns allOk=true, so restartPodBatch reports every pod restarted
+// WITHOUT deleting any pod. This is exactly the false success the Gap B fix
+// avoids by passing nil configs for pure pod-spec changes. If a future change
+// makes restartPodBatch stop trusting an empty diff, update this test.
+func TestRestartPodBatch_DynamicShortCircuitFalseSuccess(t *testing.T) {
+	scheme := rollingRestartScheme(t)
+
+	enable := true
+	cfg := map[string]any{"service": map[string]any{}}
+	cluster := &ackov1alpha1.AerospikeCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "default"},
+		Spec: ackov1alpha1.AerospikeClusterSpec{
+			Image:                     "aerospike:ce-8.1.1.1",
+			EnableDynamicConfigUpdate: &enable,
+		},
+	}
+
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      utils.StatefulSetName(cluster.Name, 0),
+			Namespace: cluster.Namespace,
+		},
+	}
+	pod := newRackPod(cluster.Name, "cfg-hash", "podspec-OLD")
+
+	reconciler := &AerospikeClusterReconciler{
+		Client: fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithStatusSubresource(&ackov1alpha1.AerospikeCluster{}).
+			WithObjects(cluster, sts, pod).
+			Build(),
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(16),
+	}
+
+	// A zero-value client is enough: tryDynamicConfigUpdateBatch returns at the
+	// empty-diff check before ever touching the network.
+	preset := &aero.Client{}
+	aeroClient := preset
+
+	// Identical configs (oldConfig == newConfig content) => empty diff =>
+	// dynamic path returns allOk=true => restartPodBatch reports success.
+	restarted, failed, batch := reconciler.restartPodBatch(
+		context.Background(), cluster, []*corev1.Pod{pod}, sts, "cfg-hash",
+		1, cfg, cfg, &aeroClient)
+
+	if restarted != 1 || len(failed) != 0 || len(batch) != 1 {
+		t.Fatalf("expected dynamic short-circuit to report (1, [], 1 batch); got (%d, %v, %d)",
+			restarted, failed, len(batch))
+	}
+
+	// Prove it was a FALSE success: the pod is still present, never deleted.
+	got := &corev1.Pod{}
+	if err := reconciler.Get(context.Background(),
+		types.NamespacedName{Name: "demo-0", Namespace: "default"}, got); err != nil {
+		t.Fatalf("pod demo-0 should still exist after the (false) dynamic success, Get err = %v", err)
+	}
+}

--- a/internal/controller/reconciler_statefulset.go
+++ b/internal/controller/reconciler_statefulset.go
@@ -260,7 +260,7 @@ func (r *AerospikeClusterReconciler) cleanupOrphanedPVCsAfterScaleDown(
 	log.Info("All scaled-down pods terminated, cleaning up orphaned cascade-delete PVCs",
 		"name", stsName, "old", oldReplicas, "new", targetReplicas)
 	deleted, err := storage.DeleteOrphanedCascadeDeletePVCs(
-		ctx, r.Client, cluster.Namespace, stsName, targetReplicas, storageSpec)
+		ctx, r.Client, cluster.Namespace, cluster.Name, stsName, targetReplicas, storageSpec)
 	if err != nil {
 		log.Error(err, "Failed to delete orphaned cascade PVCs", "statefulset", stsName)
 		r.Recorder.Eventf(cluster, corev1.EventTypeWarning, EventPVCCleanupFailed,
@@ -402,7 +402,7 @@ func (r *AerospikeClusterReconciler) cleanupRemovedRacks(
 
 		// Step 3a: Delete cascade-delete PVCs now that pods are gone.
 		storageSpec := cluster.Spec.Storage
-		if err := storage.DeleteCascadeDeletePVCs(ctx, r.Client, cluster.Namespace, stsName, storageSpec); err != nil {
+		if err := storage.DeleteCascadeDeletePVCs(ctx, r.Client, cluster.Namespace, cluster.Name, stsName, storageSpec); err != nil {
 			log.Error(err, "Failed to delete cascade PVCs for removed rack", "statefulset", stsName)
 			r.Recorder.Eventf(cluster, corev1.EventTypeWarning, EventPVCCleanupFailed,
 				"Failed to delete cascade PVCs for removed rack %s: %v", stsName, err)
@@ -492,19 +492,32 @@ func (r *AerospikeClusterReconciler) detectScaling(
 // computePodSpecHash returns a short SHA256 hash derived from the cluster image
 // and pod-level spec settings so that changes to the pod template (aside from
 // config) are captured.
+//
+// PodService and AerospikeNetworkPolicy are included because they change what
+// the operator renders into the pod template: AerospikeNetworkPolicy drives the
+// ConfigMap's access-address placeholders and PodService injects a per-pod
+// service env var into the container. Without hashing them, editing
+// spec.podService or spec.aerospikeNetworkPolicy would update the ConfigMap but
+// leave needsUpdate false, so the StatefulSet template would never be patched
+// and pods would keep stale config. Both are JSON-serializable pointers; a nil
+// value is omitted and hashes stably.
 func computePodSpecHash(cluster *ackov1alpha1.AerospikeCluster, rack *ackov1alpha1.Rack) string {
 	input := struct {
-		Image           string                                `json:"image"`
-		PodSpec         *ackov1alpha1.AerospikePodSpec        `json:"podSpec,omitempty"`
-		Monitoring      *ackov1alpha1.AerospikeMonitoringSpec `json:"monitoring,omitempty"`
-		RackID          int                                   `json:"rackID"`
-		PreStopSleepSec int                                   `json:"preStopSleepSec"`
+		Image                  string                                `json:"image"`
+		PodSpec                *ackov1alpha1.AerospikePodSpec        `json:"podSpec,omitempty"`
+		Monitoring             *ackov1alpha1.AerospikeMonitoringSpec `json:"monitoring,omitempty"`
+		PodService             *ackov1alpha1.AerospikeServiceSpec    `json:"podService,omitempty"`
+		AerospikeNetworkPolicy *ackov1alpha1.AerospikeNetworkPolicy  `json:"aerospikeNetworkPolicy,omitempty"`
+		RackID                 int                                   `json:"rackID"`
+		PreStopSleepSec        int                                   `json:"preStopSleepSec"`
 	}{
-		Image:           cluster.Spec.Image,
-		PodSpec:         cluster.Spec.PodSpec,
-		Monitoring:      cluster.Spec.Monitoring,
-		RackID:          rack.ID,
-		PreStopSleepSec: podutil.PreStopSleepSeconds,
+		Image:                  cluster.Spec.Image,
+		PodSpec:                cluster.Spec.PodSpec,
+		Monitoring:             cluster.Spec.Monitoring,
+		PodService:             cluster.Spec.PodService,
+		AerospikeNetworkPolicy: cluster.Spec.AerospikeNetworkPolicy,
+		RackID:                 rack.ID,
+		PreStopSleepSec:        podutil.PreStopSleepSeconds,
 	}
 	return utils.ShortSHA256(input)
 }

--- a/internal/controller/reconciler_statefulset.go
+++ b/internal/controller/reconciler_statefulset.go
@@ -501,6 +501,12 @@ func (r *AerospikeClusterReconciler) detectScaling(
 // leave needsUpdate false, so the StatefulSet template would never be patched
 // and pods would keep stale config. Both are JSON-serializable pointers; a nil
 // value is omitted and hashes stably.
+//
+// The hash is written to the pod template as utils.PodSpecHashAnnotation.
+// reconcileRollingRestart compares it against each pod's annotation and rolls
+// (cold-restarts) any pod whose pod-spec hash is stale, so a change to the
+// hashed fields actually propagates to running pods rather than only updating
+// the StatefulSet template.
 func computePodSpecHash(cluster *ackov1alpha1.AerospikeCluster, rack *ackov1alpha1.Rack) string {
 	input := struct {
 		Image                  string                                `json:"image"`

--- a/internal/controller/reconciler_statefulset_test.go
+++ b/internal/controller/reconciler_statefulset_test.go
@@ -111,6 +111,150 @@ func TestComputePodSpecHash_ChangesWithMonitoring(t *testing.T) {
 	}
 }
 
+func TestComputePodSpecHash_ChangesWithAerospikeNetworkPolicy(t *testing.T) {
+	cluster1 := &ackov1alpha1.AerospikeCluster{
+		Spec: ackov1alpha1.AerospikeClusterSpec{
+			Image: "aerospike:ce-8.1.1.1",
+		},
+	}
+	cluster2 := &ackov1alpha1.AerospikeCluster{
+		Spec: ackov1alpha1.AerospikeClusterSpec{
+			Image: "aerospike:ce-8.1.1.1",
+			AerospikeNetworkPolicy: &ackov1alpha1.AerospikeNetworkPolicy{
+				AccessType: ackov1alpha1.AerospikeNetworkTypeHostExternal,
+			},
+		},
+	}
+	rack := &ackov1alpha1.Rack{ID: 0}
+
+	hash1 := computePodSpecHash(cluster1, rack)
+	hash2 := computePodSpecHash(cluster2, rack)
+
+	if hash1 == hash2 {
+		t.Error("hash should change when aerospikeNetworkPolicy changes")
+	}
+}
+
+func TestComputePodSpecHash_ChangesWithNetworkPolicyAccessType(t *testing.T) {
+	cluster1 := &ackov1alpha1.AerospikeCluster{
+		Spec: ackov1alpha1.AerospikeClusterSpec{
+			Image: "aerospike:ce-8.1.1.1",
+			AerospikeNetworkPolicy: &ackov1alpha1.AerospikeNetworkPolicy{
+				AccessType: ackov1alpha1.AerospikeNetworkTypePod,
+			},
+		},
+	}
+	cluster2 := &ackov1alpha1.AerospikeCluster{
+		Spec: ackov1alpha1.AerospikeClusterSpec{
+			Image: "aerospike:ce-8.1.1.1",
+			AerospikeNetworkPolicy: &ackov1alpha1.AerospikeNetworkPolicy{
+				AccessType: ackov1alpha1.AerospikeNetworkTypeHostExternal,
+			},
+		},
+	}
+	rack := &ackov1alpha1.Rack{ID: 0}
+
+	hash1 := computePodSpecHash(cluster1, rack)
+	hash2 := computePodSpecHash(cluster2, rack)
+
+	if hash1 == hash2 {
+		t.Error("hash should change when aerospikeNetworkPolicy.accessType changes")
+	}
+}
+
+func TestComputePodSpecHash_ChangesWithPodService(t *testing.T) {
+	cluster1 := &ackov1alpha1.AerospikeCluster{
+		Spec: ackov1alpha1.AerospikeClusterSpec{
+			Image: "aerospike:ce-8.1.1.1",
+		},
+	}
+	cluster2 := &ackov1alpha1.AerospikeCluster{
+		Spec: ackov1alpha1.AerospikeClusterSpec{
+			Image: "aerospike:ce-8.1.1.1",
+			PodService: &ackov1alpha1.AerospikeServiceSpec{
+				ServiceType: "NodePort",
+			},
+		},
+	}
+	rack := &ackov1alpha1.Rack{ID: 0}
+
+	hash1 := computePodSpecHash(cluster1, rack)
+	hash2 := computePodSpecHash(cluster2, rack)
+
+	if hash1 == hash2 {
+		t.Error("hash should change when podService changes")
+	}
+}
+
+func TestComputePodSpecHash_ChangesWithPodServiceType(t *testing.T) {
+	cluster1 := &ackov1alpha1.AerospikeCluster{
+		Spec: ackov1alpha1.AerospikeClusterSpec{
+			Image: "aerospike:ce-8.1.1.1",
+			PodService: &ackov1alpha1.AerospikeServiceSpec{
+				ServiceType: "ClusterIP",
+			},
+		},
+	}
+	cluster2 := &ackov1alpha1.AerospikeCluster{
+		Spec: ackov1alpha1.AerospikeClusterSpec{
+			Image: "aerospike:ce-8.1.1.1",
+			PodService: &ackov1alpha1.AerospikeServiceSpec{
+				ServiceType: "LoadBalancer",
+			},
+		},
+	}
+	rack := &ackov1alpha1.Rack{ID: 0}
+
+	hash1 := computePodSpecHash(cluster1, rack)
+	hash2 := computePodSpecHash(cluster2, rack)
+
+	if hash1 == hash2 {
+		t.Error("hash should change when podService.serviceType changes")
+	}
+}
+
+func TestComputePodSpecHash_SameWithIdenticalNetworkAndPodService(t *testing.T) {
+	mk := func() *ackov1alpha1.AerospikeCluster {
+		return &ackov1alpha1.AerospikeCluster{
+			Spec: ackov1alpha1.AerospikeClusterSpec{
+				Image: "aerospike:ce-8.1.1.1",
+				AerospikeNetworkPolicy: &ackov1alpha1.AerospikeNetworkPolicy{
+					AccessType: ackov1alpha1.AerospikeNetworkTypeHostExternal,
+				},
+				PodService: &ackov1alpha1.AerospikeServiceSpec{
+					ServiceType: "NodePort",
+				},
+			},
+		}
+	}
+	rack := &ackov1alpha1.Rack{ID: 0}
+
+	hash1 := computePodSpecHash(mk(), rack)
+	hash2 := computePodSpecHash(mk(), rack)
+
+	if hash1 != hash2 {
+		t.Errorf("hash should be identical for identical podService/aerospikeNetworkPolicy: %q != %q", hash1, hash2)
+	}
+}
+
+func TestComputePodSpecHash_NilNetworkAndPodServiceStable(t *testing.T) {
+	// A cluster with nil PodService / AerospikeNetworkPolicy must hash stably
+	// and identically across calls (nil pointers are omitted from the JSON).
+	cluster := &ackov1alpha1.AerospikeCluster{
+		Spec: ackov1alpha1.AerospikeClusterSpec{
+			Image: "aerospike:ce-8.1.1.1",
+		},
+	}
+	rack := &ackov1alpha1.Rack{ID: 0}
+
+	hash1 := computePodSpecHash(cluster, rack)
+	hash2 := computePodSpecHash(cluster, rack)
+
+	if hash1 != hash2 {
+		t.Errorf("nil podService/aerospikeNetworkPolicy should hash stably: %q != %q", hash1, hash2)
+	}
+}
+
 func TestComputePodSpecHash_SameWithDifferentConfig(t *testing.T) {
 	// PodSpecHash should NOT change when only aerospikeConfig changes
 	// (that's what configHash is for)

--- a/internal/storage/local.go
+++ b/internal/storage/local.go
@@ -23,6 +23,7 @@ func GetLocalPVCsForPod(
 	ctx context.Context,
 	c client.Client,
 	namespace string,
+	clusterName string,
 	stsName string,
 	ordinal int32,
 	storageSpec *v1alpha1.AerospikeStorageSpec,
@@ -32,7 +33,7 @@ func GetLocalPVCsForPod(
 	}
 
 	// Get all PVCs for this StatefulSet
-	allPVCs, err := GetPVCsForStatefulSet(ctx, c, namespace, stsName)
+	allPVCs, err := GetPVCsForStatefulSet(ctx, c, namespace, clusterName, stsName)
 	if err != nil {
 		return nil, err
 	}
@@ -65,11 +66,12 @@ func DeleteLocalPVCsForPod(
 	ctx context.Context,
 	c client.Client,
 	namespace string,
+	clusterName string,
 	stsName string,
 	ordinal int32,
 	storageSpec *v1alpha1.AerospikeStorageSpec,
 ) error {
-	localPVCs, err := GetLocalPVCsForPod(ctx, c, namespace, stsName, ordinal, storageSpec)
+	localPVCs, err := GetLocalPVCsForPod(ctx, c, namespace, clusterName, stsName, ordinal, storageSpec)
 	if err != nil {
 		return fmt.Errorf("getting local PVCs for pod %s-%d: %w", stsName, ordinal, err)
 	}

--- a/internal/storage/pvc.go
+++ b/internal/storage/pvc.go
@@ -14,15 +14,28 @@ import (
 	v1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
 )
 
-// GetPVCsForStatefulSet lists PVCs belonging to the given StatefulSet.
-// It first attempts to filter by the app instance label for efficiency, then
-// falls back to listing all PVCs and name-matching if no labels are present
-// (e.g., for PVCs created before labels were added to VolumeClaimTemplates).
-func GetPVCsForStatefulSet(ctx context.Context, c client.Client, namespace, stsName string) ([]corev1.PersistentVolumeClaim, error) {
+// GetPVCsForStatefulSet lists PVCs belonging to the given StatefulSet of the
+// named cluster.
+//
+// The primary filter matches both app.kubernetes.io/name and
+// app.kubernetes.io/instance (the cluster name). Scoping by instance prevents a
+// PVC from one cluster being attributed to a sibling cluster in the same
+// namespace when one cluster name is a prefix of the other (e.g. "foo" vs
+// "foo-0"), where the "-<stsName>-" substring check alone can collide.
+// Operator-created PVCs carry the instance label because PVC templates get
+// LabelsForCluster applied in reconciler_statefulset.go.
+//
+// If the label-scoped query returns nothing, it falls back to listing all PVCs
+// in the namespace so legacy/pre-label PVCs are still found; in that path the
+// name-substring check is the only ownership signal.
+func GetPVCsForStatefulSet(ctx context.Context, c client.Client, namespace, clusterName, stsName string) ([]corev1.PersistentVolumeClaim, error) {
 	pvcList := &corev1.PersistentVolumeClaimList{}
 	if err := c.List(ctx, pvcList,
 		client.InNamespace(namespace),
-		client.MatchingLabels{"app.kubernetes.io/name": "aerospike-cluster"},
+		client.MatchingLabels{
+			"app.kubernetes.io/name":     "aerospike-cluster",
+			"app.kubernetes.io/instance": clusterName,
+		},
 	); err != nil {
 		return nil, fmt.Errorf("listing PVCs in namespace %s: %w", namespace, err)
 	}
@@ -53,7 +66,7 @@ func GetPVCsForStatefulSet(ctx context.Context, c client.Client, namespace, stsN
 func DeleteOrphanedCascadeDeletePVCs(
 	ctx context.Context,
 	c client.Client,
-	namespace, stsName string,
+	namespace, clusterName, stsName string,
 	desiredReplicas int32,
 	storageSpec *v1alpha1.AerospikeStorageSpec,
 ) (int, error) {
@@ -74,7 +87,7 @@ func DeleteOrphanedCascadeDeletePVCs(
 		return 0, nil
 	}
 
-	pvcs, err := GetPVCsForStatefulSet(ctx, c, namespace, stsName)
+	pvcs, err := GetPVCsForStatefulSet(ctx, c, namespace, clusterName, stsName)
 	if err != nil {
 		return 0, err
 	}
@@ -119,8 +132,8 @@ func DeleteOrphanedCascadeDeletePVCs(
 
 // DeletePVCsForStatefulSet deletes all PVCs associated with the given StatefulSet.
 // Used when the cluster CR is deleted with cascadeDelete.
-func DeletePVCsForStatefulSet(ctx context.Context, c client.Client, namespace, stsName string) error {
-	pvcs, err := GetPVCsForStatefulSet(ctx, c, namespace, stsName)
+func DeletePVCsForStatefulSet(ctx context.Context, c client.Client, namespace, clusterName, stsName string) error {
+	pvcs, err := GetPVCsForStatefulSet(ctx, c, namespace, clusterName, stsName)
 	if err != nil {
 		return err
 	}
@@ -206,7 +219,7 @@ func extractVolumeName(pvcName, stsName string) (string, bool) {
 func DeleteCascadeDeletePVCs(
 	ctx context.Context,
 	c client.Client,
-	namespace, stsName string,
+	namespace, clusterName, stsName string,
 	storageSpec *v1alpha1.AerospikeStorageSpec,
 ) error {
 	if storageSpec == nil {
@@ -226,7 +239,7 @@ func DeleteCascadeDeletePVCs(
 		return nil
 	}
 
-	pvcs, err := GetPVCsForStatefulSet(ctx, c, namespace, stsName)
+	pvcs, err := GetPVCsForStatefulSet(ctx, c, namespace, clusterName, stsName)
 	if err != nil {
 		return err
 	}

--- a/internal/storage/pvc_cascade_test.go
+++ b/internal/storage/pvc_cascade_test.go
@@ -15,17 +15,25 @@ import (
 )
 
 const (
-	testNamespace = "default"
-	testStsName   = "my-cluster-0"
+	testNamespace   = "default"
+	testClusterName = "my-cluster"
+	testStsName     = "my-cluster-0"
 )
 
 func newPVC(name string) *corev1.PersistentVolumeClaim {
+	return newPVCForCluster(name, testClusterName)
+}
+
+// newPVCForCluster builds a PVC carrying the operator's standard labels for the
+// given cluster, so label-scoped queries (app.kubernetes.io/instance) match it.
+func newPVCForCluster(name, clusterName string) *corev1.PersistentVolumeClaim {
 	return &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: testNamespace,
 			Labels: map[string]string{
-				"app.kubernetes.io/name": "aerospike-cluster",
+				"app.kubernetes.io/name":     "aerospike-cluster",
+				"app.kubernetes.io/instance": clusterName,
 			},
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{
@@ -105,7 +113,7 @@ func TestDeleteOrphanedCascadeDeletePVCs_DeletesOnlyCascadeOrphans(t *testing.T)
 	)
 
 	ctx := context.Background()
-	deleted, err := DeleteOrphanedCascadeDeletePVCs(ctx, c, testNamespace, testStsName, 1, spec)
+	deleted, err := DeleteOrphanedCascadeDeletePVCs(ctx, c, testNamespace, testClusterName, testStsName, 1, spec)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -158,7 +166,7 @@ func TestDeleteOrphanedCascadeDeletePVCs_NoCascadeVolumes(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	deleted, err := DeleteOrphanedCascadeDeletePVCs(ctx, c, testNamespace, testStsName, 1, spec)
+	deleted, err := DeleteOrphanedCascadeDeletePVCs(ctx, c, testNamespace, testClusterName, testStsName, 1, spec)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -183,7 +191,7 @@ func TestDeleteOrphanedCascadeDeletePVCs_NilStorageSpec(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	deleted, err := DeleteOrphanedCascadeDeletePVCs(ctx, c, testNamespace, testStsName, 0, nil)
+	deleted, err := DeleteOrphanedCascadeDeletePVCs(ctx, c, testNamespace, testClusterName, testStsName, 0, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -203,7 +211,7 @@ func TestDeleteOrphanedCascadeDeletePVCs_AllCascadeAllOrphans(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	deleted, err := DeleteOrphanedCascadeDeletePVCs(ctx, c, testNamespace, testStsName, 0, spec)
+	deleted, err := DeleteOrphanedCascadeDeletePVCs(ctx, c, testNamespace, testClusterName, testStsName, 0, spec)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -230,7 +238,7 @@ func TestDeleteOrphanedCascadeDeletePVCs_NoOrphans(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	deleted, err := DeleteOrphanedCascadeDeletePVCs(ctx, c, testNamespace, testStsName, 2, spec)
+	deleted, err := DeleteOrphanedCascadeDeletePVCs(ctx, c, testNamespace, testClusterName, testStsName, 2, spec)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -265,7 +273,7 @@ func TestDeleteOrphanedCascadeDeletePVCs_PolicyFallback(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	deleted, err := DeleteOrphanedCascadeDeletePVCs(ctx, c, testNamespace, testStsName, 1, spec)
+	deleted, err := DeleteOrphanedCascadeDeletePVCs(ctx, c, testNamespace, testClusterName, testStsName, 1, spec)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -288,7 +296,7 @@ func TestDeleteCascadeDeletePVCs_OnlyCascadeVolumes(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	err := DeleteCascadeDeletePVCs(ctx, c, testNamespace, testStsName, spec)
+	err := DeleteCascadeDeletePVCs(ctx, c, testNamespace, testClusterName, testStsName, spec)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -320,7 +328,7 @@ func TestDeleteCascadeDeletePVCs_NilStorageSpec(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	err := DeleteCascadeDeletePVCs(ctx, c, testNamespace, testStsName, nil)
+	err := DeleteCascadeDeletePVCs(ctx, c, testNamespace, testClusterName, testStsName, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -344,7 +352,7 @@ func TestDeleteCascadeDeletePVCs_AllCascadeFalse(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	err := DeleteCascadeDeletePVCs(ctx, c, testNamespace, testStsName, spec)
+	err := DeleteCascadeDeletePVCs(ctx, c, testNamespace, testClusterName, testStsName, spec)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/storage/pvc_test.go
+++ b/internal/storage/pvc_test.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"context"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -148,5 +149,68 @@ func TestExtractVolumeName_NonNumericOrdinal(t *testing.T) {
 	_, ok := extractVolumeName("data-my-cluster-0-abc", "my-cluster-0")
 	if ok {
 		t.Error("should not extract when ordinal is non-numeric")
+	}
+}
+
+// --- GetPVCsForStatefulSet tests ---
+
+// TestGetPVCsForStatefulSet_PrefixCollisionDoesNotMatchSibling verifies that a
+// PVC belonging to a sibling cluster whose name is a prefix-collision is NOT
+// attributed to this cluster's StatefulSet.
+//
+// Cluster "foo" has STS "foo-0" with PVC "data-foo-0-5".
+// Cluster "foo-0" has STS "foo-0-0" with PVC "data-foo-0-0-3".
+// The "-foo-0-" name substring matches both, so without the instance-label
+// scope the sibling PVC would be wrongly returned (and later deleted).
+func TestGetPVCsForStatefulSet_PrefixCollisionDoesNotMatchSibling(t *testing.T) {
+	const (
+		clusterFoo  = "foo"
+		stsFoo      = "foo-0"
+		clusterFoo0 = "foo-0"
+		stsFoo0     = "foo-0-0"
+	)
+
+	ownPVC := newPVCForCluster("data-"+stsFoo+"-5", clusterFoo)       // data-foo-0-5
+	siblingPVC := newPVCForCluster("data-"+stsFoo0+"-3", clusterFoo0) // data-foo-0-0-3
+	c := buildFakeClient(ownPVC, siblingPVC)
+
+	ctx := context.Background()
+	pvcs, err := GetPVCsForStatefulSet(ctx, c, testNamespace, clusterFoo, stsFoo)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(pvcs) != 1 {
+		names := make([]string, 0, len(pvcs))
+		for i := range pvcs {
+			names = append(names, pvcs[i].Name)
+		}
+		t.Fatalf("GetPVCsForStatefulSet(%q) returned %d PVCs %v, want exactly 1 (own PVC only)",
+			stsFoo, len(pvcs), names)
+	}
+	if pvcs[0].Name != ownPVC.Name {
+		t.Errorf("matched PVC = %q, want %q (sibling cluster PVC must not be matched)",
+			pvcs[0].Name, ownPVC.Name)
+	}
+}
+
+// TestGetPVCsForStatefulSet_LegacyUnlabeledFallback verifies the fallback path:
+// when no labeled PVCs exist, the name-substring check still finds legacy PVCs.
+func TestGetPVCsForStatefulSet_LegacyUnlabeledFallback(t *testing.T) {
+	legacy := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "data-" + testStsName + "-0",
+			Namespace: testNamespace,
+		},
+	}
+	c := buildFakeClient(legacy)
+
+	ctx := context.Background()
+	pvcs, err := GetPVCsForStatefulSet(ctx, c, testNamespace, testClusterName, testStsName)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(pvcs) != 1 || pvcs[0].Name != legacy.Name {
+		t.Errorf("legacy unlabeled PVC should be found via fallback, got %v", pvcs)
 	}
 }


### PR DESCRIPTION
Follow-up to the **2026-05 code audit (#282)**. Four focused correctness fixes plus unit tests. No CRD or breaking API changes.

## Fix 1 [P1] — `computePodSpecHash` ignored `PodService` and `AerospikeNetworkPolicy`
**Problem:** `spec.podService` and `spec.aerospikeNetworkPolicy` both change what the operator renders — `aerospikeNetworkPolicy` drives the ConfigMap's access-address placeholders, and `podService` injects a per-pod service env var into the container. But `computePodSpecHash` only hashed `{Image, PodSpec, Monitoring, RackID, PreStopSleepSec}`. Editing `aerospikeNetworkPolicy.accessType` or `podService.serviceType` updated the ConfigMap, yet `needsUpdate` stayed false, so the StatefulSet template was never patched and pods kept stale config.
**Fix:** Added `PodService` and `AerospikeNetworkPolicy` to the hashed struct. Both are JSON-serializable pointers; a `nil` value is omitted and hashes stably. Hashing approach is unchanged.

## Fix 2 [P2] — `parseMigrateStat` silently returned 0 on parse error
**Problem:** It returned `0` both when the key was absent and when `strconv.ParseInt` failed. Callers (`isMigratingOnAnyNode`, `migrateStatsPerNode`) treat `0` as "migration complete", so a malformed `migrate_partitions_remaining` value could let a destructive scale-down or rolling restart proceed during data movement.
**Fix:** `parseMigrateStat` now returns `(int64, bool)`. `isMigratingOnAnyNode` treats an unparseable value conservatively as "migrating" (same as a statistics-command error). `migrateStatsPerNode` records a positive sentinel for such a node instead of dropping it.

## Fix 3 [P2] — PVC ownership could collide between clusters in one namespace
**Problem:** `GetPVCsForStatefulSet` listed PVCs by the shared label `app.kubernetes.io/name: aerospike-cluster` and attributed ownership by the `-<stsName>-` name substring. For two clusters in one namespace where one name is a prefix of the other (e.g. `foo` / `foo-0`), a PVC could match the wrong cluster's STS and be wrongly deleted by cleanup paths.
**Fix:** Added `app.kubernetes.io/instance` (cluster name) to the `MatchingLabels` filter. Operator-created PVCs already carry this label. `clusterName` is threaded through `GetPVCsForStatefulSet` and all callers. The name-substring check is kept as a secondary filter for legacy/pre-label PVCs (fallback path).

## Fix 4 [nit] — `PendingRestartPods` not updated when a restart batch is blocked
**Problem:** `reconcileRollingRestart` returned early on `isBatchBlocked` before setting `cluster.Status.PendingRestartPods`.
**Fix:** Moved the `PendingRestartPods` assignment above the `isBatchBlocked` check so observers see truly-pending pods while the batch is blocked.

## Tests
- `reconciler_statefulset_test.go` — different `PodService` / `AerospikeNetworkPolicy` values produce different hashes; identical values match; nil is stable.
- `aero_info_test.go` — `parseMigrateStat` reports failure (`ok=false`) on non-numeric / absent / empty values.
- `pvc_test.go` — a prefix-colliding sibling cluster's PVC is NOT matched; legacy unlabeled PVCs still found via fallback.

## Verification
- `go build ./...` — pass
- `go vet ./...` — pass
- `go test ./internal/controller/... ./internal/storage/...` — pass
- `gofmt` — clean on all changed files

## Scope
No CRD apiVersion bump, no CRD field changes, no Helm `version`/`appVersion` edits, no breaking API changes. ~120 LOC of non-test changes across 6 source files.

---

## Follow-up — e2e revealed Fix 1 was incomplete (commit 912466c)

A Kind e2e run confirmed Fix 1 patches the StatefulSet pod-template `PodSpecHashAnnotation` correctly, but **the pods were never actually rolled**. `computePodSpecHash` alone is insufficient — `reconcileRollingRestart` did not act on the new hash. Two gaps:

### Gap A — `reconcileRollingRestart` only triggered on config-hash
The pod-selection loop compared **only** `ConfigHashAnnotation` (`currentHash != desiredHash`). A pod-spec change (`podService` / `aerospikeNetworkPolicy` — **and a plain `spec.image` upgrade**) patched the StatefulSet template but added no pod to `podsToRestart`, so nothing rolled. Image upgrades were silently broken by this same pre-existing gap.
**Fix:** the selection loop is extracted into `selectPodsToRestart`, which now selects a pod when `ConfigHashAnnotation` **OR** `PodSpecHashAnnotation` differs from the template (the pod-spec check is gated on a non-empty desired hash). The downstream machinery (`shouldWarmRestart` forcing cold restart on a pod-spec-hash diff, `determineRestartReason` returning `PodSpecChanged` / `ImageChanged`) was already correct — only the trigger was missing.

### Gap B — dynamic-config short-circuit gave a false "success" for pure pod-spec changes
With `spec.enableDynamicConfigUpdate: true`, `restartPodBatch` calls `tryDynamicConfigUpdateBatch` when `oldConfig != nil && newConfig != nil`. For a pure pod-spec change the config is unchanged → `configdiff.Diff` reports no changes → `tryDynamicConfigUpdateBatch` returns `allOk=true` → `restartPodBatch` reports every pod restarted while **nothing** was restarted — an infinite false-success loop.
**Fix:** `selectPodsToRestart` returns a `configChanged` flag (true only when a config-hash mismatch triggered the batch). `reconcileRollingRestart` passes `nil` configs to `restartPodBatch` when `!configChanged`, so the existing `oldConfig != nil && newConfig != nil` guard skips the dynamic 2PC path and pods go straight to per-pod cold restart. The genuine config-change path is unaffected (real configs still passed). `tryDynamicConfigUpdateBatch`'s contract is unchanged — the gate is entirely caller-side.

Doc comments on `computePodSpecHash` and `reconcileRollingRestart` updated so they no longer overclaim — they now accurately state that pod-spec changes roll pods.

### Follow-up tests (`reconciler_restart_rolling_test.go`)
- `TestSelectPodsToRestart` — table test: a pod is selected when config-hash OR pod-spec-hash differs; `configChanged` reflects only config-hash mismatches.
- `TestReconcileRollingRestart_TriggersOnPodSpecHashChange` — Gap A: a pod with a stale `PodSpecHashAnnotation` but matching `ConfigHashAnnotation` is cold-restarted (fails against pre-fix code).
- `TestReconcileRollingRestart_PodSpecChangeNotShortCircuited` — Gap B regression: with `enableDynamicConfigUpdate: true` and a pure pod-spec change, the pod is genuinely cold-restarted, not falsely reported as done (fails against pre-fix code).
- `TestRestartPodBatch_DynamicShortCircuitFalseSuccess` — documents the underlying empty-diff false-success trap the Gap B fix avoids.

Follow-up verification: `go build ./...`, `go vet ./...`, `gofmt`, `go test ./internal/controller/...`, and `golangci-lint` all pass. ~110 LOC of non-test changes across 2 source files + 1 new test file.
