### PR TITLE
fix: stop access-address placeholders leaking into shared cluster spec; skip pointless retries on permanent errors

### DIFF
--- a/internal/controller/aero_client.go
+++ b/internal/controller/aero_client.go
@@ -84,6 +84,11 @@ func (r *AerospikeClusterReconciler) getAerospikeClient(
 // getAerospikeClientWithRetry wraps getAerospikeClient with retry logic using
 // exponential backoff (2s, 4s, 8s). This is useful during initial deployment
 // when DNS may not yet be resolving for the headless service.
+//
+// Permanent validation errors (e.g. a missing admin Secret or a Secret without
+// a "password" key) are returned immediately: they will never self-heal, so
+// retrying just burns ~14s of backoff sleep on every reconcile and delays the
+// circuit breaker from surfacing the permanent error to the user.
 func (r *AerospikeClusterReconciler) getAerospikeClientWithRetry(
 	ctx context.Context,
 	cluster *ackov1alpha1.AerospikeCluster,
@@ -113,6 +118,10 @@ func (r *AerospikeClusterReconciler) getAerospikeClientWithRetry(
 			return client, nil
 		}
 		lastErr = err
+		// Don't burn backoff cycles on errors that cannot self-heal.
+		if ackoerrors.IsValidation(err) {
+			return nil, err
+		}
 	}
 
 	return nil, fmt.Errorf("failed after %d retries: %w", maxRetries, lastErr)

--- a/internal/controller/aero_client_test.go
+++ b/internal/controller/aero_client_test.go
@@ -1,9 +1,16 @@
 package controller
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	ackoerrors "github.com/ksr/aerospike-ce-kubernetes-operator/internal/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestGetServicePort(t *testing.T) {
@@ -105,6 +112,62 @@ func TestGetAerospikeClientWithRetry_MethodSignature(t *testing.T) {
 	fn := r.getAerospikeClientWithRetry
 	// Use fn to satisfy the compiler.
 	_ = fn
+}
+
+// TestGetAerospikeClientWithRetry_NoRetryOnValidationError verifies that the
+// retry wrapper returns immediately on a permanent ValidationError instead of
+// burning ~14s of exponential backoff (2s+4s+8s). A missing admin Secret on an
+// ACL-enabled cluster surfaces such a validation error via getPasswordFromSecret.
+func TestGetAerospikeClientWithRetry_NoRetryOnValidationError(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme(client-go) error = %v", err)
+	}
+	if err := ackov1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme(acko) error = %v", err)
+	}
+
+	cluster := &ackov1alpha1.AerospikeCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "default",
+		},
+		Spec: ackov1alpha1.AerospikeClusterSpec{
+			AerospikeAccessControl: &ackov1alpha1.AerospikeAccessControlSpec{
+				Users: []ackov1alpha1.AerospikeUserSpec{
+					{
+						Name:       "admin",
+						SecretName: "missing-admin-secret", // not created in the fake client
+						Roles:      []string{"sys-admin", "user-admin"},
+					},
+				},
+			},
+		},
+	}
+
+	r := &AerospikeClusterReconciler{
+		Client: fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(cluster).
+			Build(),
+		Scheme: scheme,
+	}
+
+	start := time.Now()
+	_, err := r.getAerospikeClientWithRetry(context.Background(), cluster)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("getAerospikeClientWithRetry() error = nil, want validation error")
+	}
+	if !ackoerrors.IsValidation(err) {
+		t.Errorf("getAerospikeClientWithRetry() error is not a ValidationError: %v", err)
+	}
+	// With retries the wrapper would sleep at least 2s before the first retry.
+	// A correct short-circuit returns near-instantly.
+	if elapsed >= 2*time.Second {
+		t.Errorf("getAerospikeClientWithRetry() took %v; expected immediate return on validation error", elapsed)
+	}
 }
 
 func TestBuildQuiesceCommand(t *testing.T) {

--- a/internal/controller/reconciler_config.go
+++ b/internal/controller/reconciler_config.go
@@ -52,9 +52,21 @@ func (r *AerospikeClusterReconciler) reconcileConfigMap(
 				},
 			},
 		}
+	} else {
+		// getEffectiveConfig may return cluster.Spec.AerospikeConfig (or a rack's
+		// AerospikeConfig) directly when there is nothing to merge. Deep-copy it
+		// here so the InjectAccessAddressPlaceholders mutation below stays local
+		// to ConfigMap generation and does not leak placeholders into the shared
+		// spec. Without this copy, when spec.aerospikeNetworkPolicy is set the
+		// placeholders pollute cluster.Spec.AerospikeConfig.Value for the rest of
+		// the reconcile pass — they end up in the dynamic-config diff (a static
+		// access-address key absent from the old config forces every dynamic
+		// change to a cold restart) and in cluster.Status.AerospikeConfig.
+		effectiveConfig = effectiveConfig.DeepCopy()
 	}
 
-	// Inject access-address placeholders based on network policy
+	// Inject access-address placeholders based on network policy. Operates on the
+	// local copy above so the placeholders never reach the shared cluster spec.
 	var podSvcType string
 	if cluster.Spec.PodService != nil {
 		podSvcType = cluster.Spec.PodService.ServiceType

--- a/internal/controller/reconciler_config_test.go
+++ b/internal/controller/reconciler_config_test.go
@@ -1,9 +1,18 @@
 package controller
 
 import (
+	"context"
 	"testing"
 
 	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/utils"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestGetEffectiveConfig(t *testing.T) {
@@ -221,5 +230,92 @@ func TestGetEffectiveConfig_RackConfigOnly(t *testing.T) {
 	got := r.getEffectiveConfig(cluster, rack)
 	if got != rackConfig {
 		t.Errorf("when cluster config is nil, getEffectiveConfig should return rack config pointer directly")
+	}
+}
+
+// TestReconcileConfigMapDoesNotMutateClusterSpec verifies that reconcileConfigMap
+// does not leak access-address placeholders into the shared
+// cluster.Spec.AerospikeConfig when spec.aerospikeNetworkPolicy is set.
+//
+// getEffectiveConfig returns cluster.Spec.AerospikeConfig directly when there is
+// no rack-level config to merge, so InjectAccessAddressPlaceholders must operate
+// on a deep copy. Otherwise the placeholders pollute the dynamic-config diff
+// (forcing a cold restart for every dynamic change) and cluster.Status.AerospikeConfig.
+func TestReconcileConfigMapDoesNotMutateClusterSpec(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme(client-go) error = %v", err)
+	}
+	if err := ackov1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme(acko) error = %v", err)
+	}
+
+	cluster := &ackov1alpha1.AerospikeCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "default",
+		},
+		Spec: ackov1alpha1.AerospikeClusterSpec{
+			Size: 1,
+			// aerospikeNetworkPolicy set => InjectAccessAddressPlaceholders is active.
+			AerospikeNetworkPolicy: &ackov1alpha1.AerospikeNetworkPolicy{
+				AccessType: ackov1alpha1.AerospikeNetworkTypePod,
+			},
+			AerospikeConfig: &ackov1alpha1.AerospikeConfigSpec{
+				Value: map[string]any{
+					"service": map[string]any{
+						"cluster-name": "demo",
+					},
+					"network": map[string]any{
+						"service": map[string]any{
+							"port": 3000,
+						},
+						"heartbeat": map[string]any{
+							"mode": "mesh",
+							"port": 3002,
+						},
+						"fabric": map[string]any{
+							"port": 3001,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	reconciler := &AerospikeClusterReconciler{
+		Client: fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(cluster).
+			Build(),
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(8),
+	}
+
+	rack := &ackov1alpha1.Rack{ID: 0}
+	// getEffectiveConfig returns cluster.Spec.AerospikeConfig directly here
+	// (no rack override), so this is the pointer that must not be mutated.
+	effective := reconciler.getEffectiveConfig(cluster, rack)
+
+	if err := reconciler.reconcileConfigMap(context.Background(), cluster, rack, effective); err != nil {
+		t.Fatalf("reconcileConfigMap() error = %v", err)
+	}
+
+	// The placeholder must NOT have leaked into the shared cluster spec.
+	netSection := cluster.Spec.AerospikeConfig.Value["network"].(map[string]any)
+	svcSection := netSection["service"].(map[string]any)
+	if _, leaked := svcSection["access-address"]; leaked {
+		t.Errorf("access-address placeholder leaked into cluster.Spec.AerospikeConfig: %v", svcSection)
+	}
+
+	// Sanity check: the ConfigMap itself was still generated with the placeholder.
+	cm := &corev1.ConfigMap{}
+	cmName := utils.ConfigMapName(cluster.Name, rack.ID)
+	if err := reconciler.Get(context.Background(),
+		types.NamespacedName{Name: cmName, Namespace: cluster.Namespace}, cm); err != nil {
+		t.Fatalf("Get(ConfigMap) error = %v", err)
+	}
+	if cm.Data["aerospike.conf"] == "" {
+		t.Fatal("generated ConfigMap has no aerospike.conf data")
 	}
 }


### PR DESCRIPTION
Autonomous code-quality run 2026-05-23.

Two genuine bugs found while auditing the reconciliation and Aerospike-client code, both around config/spec handling. New issues — does not overlap with #283.

## Issue 1 — access-address placeholders leak into the shared cluster spec (P1)

**File:** `internal/controller/reconciler_config.go`

`reconcileConfigMap` calls `configgen.InjectAccessAddressPlaceholders(effectiveConfig.Value, ...)`, which mutates the config map **in place**. `getEffectiveConfig` returns `cluster.Spec.AerospikeConfig` *directly* (no copy) whenever there is no rack-level config to merge — the common case. So when `spec.aerospikeNetworkPolicy` is set, the injected placeholders (`access-address`, `alternate-access-address`, ...) get written into `cluster.Spec.AerospikeConfig.Value` for the rest of the reconcile pass.

Consequences within that pass:
- **Dynamic config updates break.** `reconcileRollingRestart` uses `cluster.Spec.AerospikeConfig.Value` as `newConfig` for the configdiff. The injected `network.service.access-address` is not in `dynamicParams`, so it is classified as a *static* change. `tryDynamicConfigUpdateBatch` sees `HasStaticChanges()` and bails — every dynamic config change is forced down the cold-restart path instead of `set-config`, for any cluster with an `aerospikeNetworkPolicy`.
- **Status pollution.** `populateStatus` does `cluster.Status.AerospikeConfig = cluster.Spec.AerospikeConfig.DeepCopy()`; the placeholders leak into the persisted status. (A code comment there already flagged this exact risk.)

**Fix:** deep-copy the effective config in `reconcileConfigMap` before injecting placeholders, so the mutation stays local to ConfigMap generation. `getEffectiveConfig`'s documented "returns the shared pointer" contract is left unchanged.

**Severity:** P1 — silently disables dynamic config updates and corrupts status whenever a network policy is configured.

## Issue 2 — pointless ~14s retry on permanent validation errors (P2)

**File:** `internal/controller/aero_client.go`

`getAerospikeClientWithRetry` (used by ACL sync) retries 3× with exponential backoff (2s + 4s + 8s). A missing admin `Secret`, or a `Secret` without a `password` key, surfaces as a permanent `ValidationError` from `getPasswordFromSecret`. These never self-heal, so the wrapper burned ~14s of backoff sleep on every reconcile and delayed the circuit breaker from surfacing the real error.

**Fix:** return immediately when `ackoerrors.IsValidation(err)` is true.

**Severity:** P2 — wasted reconcile time and delayed error surfacing on misconfigured ACL clusters.

## Tests

- `TestReconcileConfigMapDoesNotMutateClusterSpec` — drives `reconcileConfigMap` with a fake client and `aerospikeNetworkPolicy` set, asserts no `access-address` key leaks into `cluster.Spec.AerospikeConfig`, and that the ConfigMap is still generated. Verified to **fail** without the fix (`access-address:MY_POD_IP` leaked) and pass with it.
- `TestGetAerospikeClientWithRetry_NoRetryOnValidationError` — points an ACL-enabled cluster at a missing Secret, asserts the call returns a `ValidationError` in well under 2s (no backoff sleep).

## Verification

- `go build ./...` — pass
- `go vet ./...` — pass
- `go test ./internal/... ./api/... ./cmd/...` — pass (includes the controller envtest suite, which ran locally)
- `gofmt -l` — clean
- `golangci-lint run` (project custom build with the logcheck plugin) on `internal/controller`, `internal/configgen`, `internal/errors` — 0 issues
- Full e2e/kind suite not run (out of scope for this code-quality pass)