### PR TITLE
fix: harden status patching, ACL retry, and conflict-retry paths

### DIFF
--- a/internal/controller/reconciler_acl.go
+++ b/internal/controller/reconciler_acl.go
@@ -66,26 +66,40 @@ func (r *AerospikeClusterReconciler) reconcileACL(
 	r.Recorder.Eventf(cluster, corev1.EventTypeNormal, EventACLSyncStarted,
 		"ACL synchronization started")
 
-	aeroClient, err := r.getAerospikeClientWithRetry(ctx, cluster)
-	if err != nil {
-		metrics.ACLSyncTotal.WithLabelValues(cluster.Namespace, cluster.Name, "error").Inc()
-		return false, fmt.Errorf("ACL sync: connecting to cluster: %w", err)
+	// getClient hands out an Aerospike client for both the first attempt and the
+	// transient-error retry. Every client it creates is tracked and closed when
+	// reconcileACL returns, so the retry path never reuses a stale broken
+	// connection and never leaks a connection either.
+	var openClients []*aero.Client
+	defer func() {
+		for _, c := range openClients {
+			closeAerospikeClient(c)
+		}
+	}()
+	getClient := func(forRetry bool) (*aero.Client, error) {
+		c, cErr := r.getAerospikeClientWithRetry(ctx, cluster)
+		if cErr != nil {
+			return nil, cErr
+		}
+		openClients = append(openClients, c)
+		return c, nil
 	}
-	defer closeAerospikeClient(aeroClient)
 
 	// Sync roles first (users may depend on roles).
 	// Retry once on transient connection errors (connection reset, timeout, etc.)
 	// that may occur during rolling restarts when nodes are briefly unavailable.
-	if err := retryOnTransient(func() error {
-		return r.reconcileRoles(ctx, aeroClient, cluster)
+	// The retry uses a freshly-created client so a stale broken connection is
+	// not reused.
+	if err := retryOnTransientWithReconnect(getClient, func(c *aero.Client) error {
+		return r.reconcileRoles(ctx, c, cluster)
 	}); err != nil {
 		metrics.ACLSyncTotal.WithLabelValues(cluster.Namespace, cluster.Name, "error").Inc()
 		return false, fmt.Errorf("ACL sync roles: %w", err)
 	}
 
 	// Sync users with the same single-retry pattern for transient errors.
-	if err := retryOnTransient(func() error {
-		return r.reconcileUsers(ctx, aeroClient, cluster)
+	if err := retryOnTransientWithReconnect(getClient, func(c *aero.Client) error {
+		return r.reconcileUsers(ctx, c, cluster)
 	}); err != nil {
 		metrics.ACLSyncTotal.WithLabelValues(cluster.Namespace, cluster.Name, "error").Inc()
 		return false, fmt.Errorf("ACL sync users: %w", err)
@@ -211,8 +225,15 @@ func (r *AerospikeClusterReconciler) reconcileUsers(
 		// is idempotent — it's a no-op when the password hasn't changed.
 		// This ensures Secret-based password updates are applied even though
 		// Secret changes don't increment the CR's generation.
+		//
+		// A failure here must be returned, not swallowed: if it were only
+		// logged, reconcileACL would still report success and ACLSynced would
+		// be set True even though the password was never rotated. Returning the
+		// error propagates it up through reconcileACL so ACLSynced is set False
+		// with a meaningful reason. Transient errors are retried by the
+		// retryOnTransientWithClient wrapper around reconcileUsers.
 		if err := aeroClient.ChangePassword(adminPolicy, userSpec.Name, password); err != nil {
-			log.Error(err, "Password change failed (non-fatal, continuing)", "user", userSpec.Name)
+			return fmt.Errorf("changing password for user %s: %w", userSpec.Name, err)
 		}
 	}
 

--- a/internal/controller/reconciler_acl.go
+++ b/internal/controller/reconciler_acl.go
@@ -231,7 +231,7 @@ func (r *AerospikeClusterReconciler) reconcileUsers(
 		// be set True even though the password was never rotated. Returning the
 		// error propagates it up through reconcileACL so ACLSynced is set False
 		// with a meaningful reason. Transient errors are retried by the
-		// retryOnTransientWithClient wrapper around reconcileUsers.
+		// retryOnTransientWithReconnect wrapper around reconcileUsers.
 		if err := aeroClient.ChangePassword(adminPolicy, userSpec.Name, password); err != nil {
 			return fmt.Errorf("changing password for user %s: %w", userSpec.Name, err)
 		}

--- a/internal/controller/reconciler_restart.go
+++ b/internal/controller/reconciler_restart.go
@@ -603,6 +603,12 @@ func getDirtyVolumes(storageSpec *ackov1alpha1.AerospikeStorageSpec) []string {
 }
 
 // markDirtyVolumes records dirty volumes in the cluster status for the given pod.
+//
+// It uses a MergeFrom status patch (not a full Status().Update) so that only the
+// DirtyVolumes field of the target pod is written. A full replace would clobber
+// Status.Pods fields written concurrently by updateDynamicConfigStatus /
+// recordPodRestartStatus, which also patch the same map. This mirrors the
+// pattern used in updateDynamicConfigStatus.
 func (r *AerospikeClusterReconciler) markDirtyVolumes(
 	ctx context.Context,
 	cluster *ackov1alpha1.AerospikeCluster,
@@ -618,10 +624,11 @@ func (r *AerospikeClusterReconciler) markDirtyVolumes(
 		latest.Status.Pods = make(map[string]ackov1alpha1.AerospikePodStatus)
 	}
 
+	base := latest.DeepCopy()
 	podStatus := latest.Status.Pods[podName]
 	podStatus.DirtyVolumes = dirtyVols
 	latest.Status.Pods[podName] = podStatus
-	return r.Status().Update(ctx, latest)
+	return r.Status().Patch(ctx, latest, client.MergeFrom(base))
 }
 
 // getRollingUpdateBatchSize returns the effective rolling update batch size.

--- a/internal/controller/reconciler_restart_dirty_volumes_test.go
+++ b/internal/controller/reconciler_restart_dirty_volumes_test.go
@@ -1,0 +1,115 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
+)
+
+// TestMarkDirtyVolumes_PreservesConcurrentPodStatus is the regression test for
+// the markDirtyVolumes fix. markDirtyVolumes must use a MergeFrom status patch,
+// not a full Status().Update — a full replace clobbers Status.Pods fields that
+// other reconcilers (updateDynamicConfigStatus / recordPodRestartStatus) write
+// concurrently with their own MergeFrom patches.
+//
+// The test interposes a concurrent writer between markDirtyVolumes' refetch and
+// its status write: the interceptor stamps DynamicConfigStatus on a *different*
+// pod just before the write is delegated to the real client. With the buggy
+// full Update, markDirtyVolumes' write is built from a status snapshot taken
+// before that concurrent write, so it overwrites the whole status and the
+// concurrent field is lost. With the MergeFrom patch fix, only the target pod's
+// DirtyVolumes field is sent, so the concurrent field survives.
+func TestMarkDirtyVolumes_PreservesConcurrentPodStatus(t *testing.T) {
+	scheme := rollingRestartScheme(t)
+
+	const (
+		clusterName = "demo"
+		namespace   = "default"
+		targetPod   = "demo-0" // markDirtyVolumes writes DirtyVolumes here
+		otherPod    = "demo-1" // a concurrent reconciler writes DynamicConfigStatus here
+	)
+
+	cluster := &ackov1alpha1.AerospikeCluster{}
+	cluster.Name = clusterName
+	cluster.Namespace = namespace
+	cluster.Status.Pods = map[string]ackov1alpha1.AerospikePodStatus{
+		targetPod: {},
+		otherPod:  {},
+	}
+
+	key := types.NamespacedName{Name: clusterName, Namespace: namespace}
+
+	// concurrentWrite simulates another reconciler patching otherPod's
+	// DynamicConfigStatus. It runs exactly once, just before markDirtyVolumes'
+	// own status write is delegated to the underlying fake client.
+	var base client.WithWatch
+	concurrentDone := false
+	concurrentWrite := func(ctx context.Context) {
+		if concurrentDone {
+			return
+		}
+		concurrentDone = true
+		latest := &ackov1alpha1.AerospikeCluster{}
+		if err := base.Get(ctx, key, latest); err != nil {
+			t.Fatalf("concurrent writer: Get error = %v", err)
+		}
+		patch := client.MergeFrom(latest.DeepCopy())
+		ps := latest.Status.Pods[otherPod]
+		ps.DynamicConfigStatus = "Applied"
+		latest.Status.Pods[otherPod] = ps
+		if err := base.Status().Patch(ctx, latest, patch); err != nil {
+			t.Fatalf("concurrent writer: Patch error = %v", err)
+		}
+	}
+
+	base = fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&ackov1alpha1.AerospikeCluster{}).
+		WithObjects(cluster).
+		Build()
+
+	wrapped := interceptor.NewClient(base, interceptor.Funcs{
+		SubResourceUpdate: func(ctx context.Context, c client.Client, sub string, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+			concurrentWrite(ctx)
+			return c.SubResource(sub).Update(ctx, obj, opts...)
+		},
+		SubResourcePatch: func(ctx context.Context, c client.Client, sub string, obj client.Object, p client.Patch, opts ...client.SubResourcePatchOption) error {
+			concurrentWrite(ctx)
+			return c.SubResource(sub).Patch(ctx, obj, p, opts...)
+		},
+	})
+
+	reconciler := &AerospikeClusterReconciler{
+		Client:   wrapped,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(8),
+	}
+
+	if err := reconciler.markDirtyVolumes(context.Background(), cluster, targetPod, []string{"data"}); err != nil {
+		t.Fatalf("markDirtyVolumes() error = %v", err)
+	}
+
+	got := &ackov1alpha1.AerospikeCluster{}
+	if err := base.Get(context.Background(), key, got); err != nil {
+		t.Fatalf("Get final cluster error = %v", err)
+	}
+
+	// markDirtyVolumes must have written DirtyVolumes on the target pod.
+	if dv := got.Status.Pods[targetPod].DirtyVolumes; len(dv) != 1 || dv[0] != "data" {
+		t.Errorf("targetPod DirtyVolumes = %v, want [data]", dv)
+	}
+
+	// The concurrent writer's DynamicConfigStatus on otherPod must survive.
+	// A full Status().Update would clobber it back to "".
+	if got.Status.Pods[otherPod].DynamicConfigStatus != "Applied" {
+		t.Errorf("otherPod DynamicConfigStatus = %q, want %q — markDirtyVolumes clobbered a concurrent status write",
+			got.Status.Pods[otherPod].DynamicConfigStatus, "Applied")
+	}
+}

--- a/internal/controller/reconciler_restart_dirty_volumes_test.go
+++ b/internal/controller/reconciler_restart_dirty_volumes_test.go
@@ -13,6 +13,14 @@ import (
 	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
 )
 
+// Shared fixtures for the code-quality follow-up regression tests. The values
+// are deliberately distinct from production literals so goconst's
+// match-constant check does not flag unrelated code (e.g. "default").
+const (
+	ctrlTestNamespace = "acko-test"
+	ctrlTestDirtyVol  = "data-vol"
+)
+
 // TestMarkDirtyVolumes_PreservesConcurrentPodStatus is the regression test for
 // the markDirtyVolumes fix. markDirtyVolumes must use a MergeFrom status patch,
 // not a full Status().Update — a full replace clobbers Status.Pods fields that
@@ -31,10 +39,10 @@ func TestMarkDirtyVolumes_PreservesConcurrentPodStatus(t *testing.T) {
 
 	const (
 		clusterName = "demo"
-		namespace   = "default"
 		targetPod   = "demo-0" // markDirtyVolumes writes DirtyVolumes here
 		otherPod    = "demo-1" // a concurrent reconciler writes DynamicConfigStatus here
 	)
+	namespace := ctrlTestNamespace
 
 	cluster := &ackov1alpha1.AerospikeCluster{}
 	cluster.Name = clusterName
@@ -92,7 +100,7 @@ func TestMarkDirtyVolumes_PreservesConcurrentPodStatus(t *testing.T) {
 		Recorder: record.NewFakeRecorder(8),
 	}
 
-	if err := reconciler.markDirtyVolumes(context.Background(), cluster, targetPod, []string{"data"}); err != nil {
+	if err := reconciler.markDirtyVolumes(context.Background(), cluster, targetPod, []string{ctrlTestDirtyVol}); err != nil {
 		t.Fatalf("markDirtyVolumes() error = %v", err)
 	}
 
@@ -102,8 +110,8 @@ func TestMarkDirtyVolumes_PreservesConcurrentPodStatus(t *testing.T) {
 	}
 
 	// markDirtyVolumes must have written DirtyVolumes on the target pod.
-	if dv := got.Status.Pods[targetPod].DirtyVolumes; len(dv) != 1 || dv[0] != "data" {
-		t.Errorf("targetPod DirtyVolumes = %v, want [data]", dv)
+	if dv := got.Status.Pods[targetPod].DirtyVolumes; len(dv) != 1 || dv[0] != ctrlTestDirtyVol {
+		t.Errorf("targetPod DirtyVolumes = %v, want [%s]", dv, ctrlTestDirtyVol)
 	}
 
 	// The concurrent writer's DynamicConfigStatus on otherPod must survive.

--- a/internal/controller/reconciler_status.go
+++ b/internal/controller/reconciler_status.go
@@ -125,11 +125,16 @@ func (r *AerospikeClusterReconciler) updateStatusAndPhase(
 	}
 
 	// Use RetryOnConflict for the final status write. On conflict, re-fetch the
-	// object and re-apply the computed status to avoid a full requeue cycle.
+	// object and recompute the status to avoid a full requeue cycle.
 	// Non-conflict errors are returned immediately without refetching, since
 	// RetryOnConflict won't retry them anyway and refetching would clobber
 	// concurrent writes by other reconcilers.
-	computedStatus := latest.Status.DeepCopy()
+	//
+	// computedObservedGeneration is the ObservedGeneration this reconcile
+	// computed (against the spec it actually processed). It is preserved across
+	// the conflict-retry path so a concurrent spec bump does not get falsely
+	// marked as observed (see the IMPORTANT note below).
+	computedObservedGeneration := latest.Status.ObservedGeneration
 	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		if err := r.Status().Update(ctx, latest); err != nil {
 			// Only refetch on conflict — RetryOnConflict will not retry on
@@ -142,15 +147,39 @@ func (r *AerospikeClusterReconciler) updateStatusAndPhase(
 			if fetchErr != nil {
 				return fetchErr
 			}
-			refetched.Status = *computedStatus
-			// IMPORTANT: do NOT overwrite ObservedGeneration with refetched.Generation.
+
+			// Recompute status against the refetched object instead of
+			// stamping a pre-conflict snapshot onto it. The snapshot's
+			// Status.Pods could be stale (a concurrent reconcile may have
+			// just published newer pod-readiness), and blindly re-applying it
+			// would regress that state. populateStatus re-lists pods, so the
+			// retry writes fresh pod-readiness.
+			if _, fetchErr := r.populateStatus(ctx, refetched); fetchErr != nil {
+				return fetchErr
+			}
+			refetched.Status.Phase = phase
+			refetched.Status.PhaseReason = phaseReason
+			setFineGrainedConditions(refetched, opts)
+			if phase == ackov1alpha1.AerospikePhaseCompleted {
+				refetched.Status.AppliedSpec = refetched.Spec.DeepCopy()
+				refetched.Status.OperatorVersion = version.Version
+				now := metav1.Now()
+				refetched.Status.LastReconcileTime = &now
+				refetched.Status.PendingRestartPods = nil
+				r.enrichStatusWithAerospikeInfo(ctx, refetched)
+				r.populateExternalEndpoints(ctx, refetched)
+			}
+
+			// IMPORTANT: do NOT advance ObservedGeneration to refetched.Generation.
 			// The conflict often comes from a concurrent spec update (Generation bump).
-			// If we aligned ObservedGeneration to the new Generation here, we would
-			// falsely advertise that this reconcile has observed the new spec — when
-			// in fact computedStatus was built from the *previous* spec. Keeping the
-			// computed value lets the controller-runtime watch detect the gap
+			// populateStatus above set ObservedGeneration to the refetched (new)
+			// Generation; restore the value this reconcile actually computed so we
+			// do not falsely advertise that the new spec has been observed. Keeping
+			// the computed value lets the controller-runtime watch detect the gap
 			// (Generation > ObservedGeneration) and trigger a fresh reconcile that
 			// actually processes the new spec.
+			refetched.Status.ObservedGeneration = computedObservedGeneration
+
 			latest = refetched
 			return err
 		}

--- a/internal/controller/reconciler_status_conflict_test.go
+++ b/internal/controller/reconciler_status_conflict_test.go
@@ -21,7 +21,7 @@ import (
 func statusConflictPod(clusterName, name string, ready bool) *corev1.Pod {
 	pod := &corev1.Pod{}
 	pod.Name = name
-	pod.Namespace = "default"
+	pod.Namespace = ctrlTestNamespace
 	pod.Labels = utils.SelectorLabelsForCluster(clusterName)
 	pod.Status.Phase = corev1.PodRunning
 	pod.Status.PodIP = "10.0.0.1"
@@ -49,9 +49,9 @@ func TestUpdateStatusAndPhase_ConflictRetryRecomputesPodStatus(t *testing.T) {
 
 	const (
 		clusterName = "demo"
-		namespace   = "default"
 		podName     = "demo-0"
 	)
+	namespace := ctrlTestNamespace
 
 	cluster := &ackov1alpha1.AerospikeCluster{}
 	cluster.Name = clusterName

--- a/internal/controller/reconciler_status_conflict_test.go
+++ b/internal/controller/reconciler_status_conflict_test.go
@@ -1,0 +1,135 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/utils"
+)
+
+// statusConflictPod builds a cluster pod with the given readiness state.
+func statusConflictPod(clusterName, name string, ready bool) *corev1.Pod {
+	pod := &corev1.Pod{}
+	pod.Name = name
+	pod.Namespace = "default"
+	pod.Labels = utils.SelectorLabelsForCluster(clusterName)
+	pod.Status.Phase = corev1.PodRunning
+	pod.Status.PodIP = "10.0.0.1"
+	if ready {
+		pod.Status.Conditions = []corev1.PodCondition{
+			{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+		}
+	}
+	return pod
+}
+
+// TestUpdateStatusAndPhase_ConflictRetryRecomputesPodStatus is the regression
+// test for the updateStatusAndPhase conflict-retry fix. On a 409 conflict the
+// retry path must re-run populateStatus on the refetched object so it publishes
+// *fresh* pod readiness, instead of stamping a pre-conflict computedStatus
+// snapshot (which could carry stale pod-readiness) onto the refetched object.
+//
+// The interceptor returns a conflict on the first Status().Update and, at that
+// same moment, flips the pod from NotReady to Ready on the server. With the
+// buggy snapshot-stamping code the retry would publish the stale snapshot
+// (readyCount captured as 0). With the fix the retry re-lists pods and publishes
+// the fresh state (readyCount = 1).
+func TestUpdateStatusAndPhase_ConflictRetryRecomputesPodStatus(t *testing.T) {
+	scheme := rollingRestartScheme(t)
+
+	const (
+		clusterName = "demo"
+		namespace   = "default"
+		podName     = "demo-0"
+	)
+
+	cluster := &ackov1alpha1.AerospikeCluster{}
+	cluster.Name = clusterName
+	cluster.Namespace = namespace
+	cluster.Spec.Size = 1
+	cluster.Spec.Image = "aerospike:ce-8.1.1.1"
+	cluster.Spec.AerospikeConfig = &ackov1alpha1.AerospikeConfigSpec{
+		Value: map[string]any{"service": map[string]any{}},
+	}
+
+	// Pod starts NotReady.
+	pod := statusConflictPod(clusterName, podName, false)
+
+	key := types.NamespacedName{Name: clusterName, Namespace: namespace}
+
+	var base client.WithWatch
+	conflictReturned := false
+	base = fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&ackov1alpha1.AerospikeCluster{}).
+		WithObjects(cluster, pod).
+		Build()
+
+	wrapped := interceptor.NewClient(base, interceptor.Funcs{
+		SubResourceUpdate: func(ctx context.Context, c client.Client, sub string, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+			if sub == "status" && !conflictReturned {
+				conflictReturned = true
+				// Concurrently flip the pod to Ready, then reject the write
+				// with a conflict so the retry path runs.
+				live := &corev1.Pod{}
+				if err := base.Get(ctx, types.NamespacedName{Name: podName, Namespace: namespace}, live); err != nil {
+					t.Fatalf("interceptor: Get pod error = %v", err)
+				}
+				live.Status.Conditions = []corev1.PodCondition{
+					{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+				}
+				if err := base.Status().Update(ctx, live); err != nil {
+					t.Fatalf("interceptor: pod ready update error = %v", err)
+				}
+				return apierrors.NewConflict(
+					schema.GroupResource{Group: "acko.io", Resource: "aerospikeclusters"},
+					clusterName, errTestConflict)
+			}
+			return c.SubResource(sub).Update(ctx, obj, opts...)
+		},
+	})
+
+	reconciler := &AerospikeClusterReconciler{
+		Client:   wrapped,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(8),
+	}
+
+	err := reconciler.updateStatusAndPhase(context.Background(), key,
+		ackov1alpha1.AerospikePhaseInProgress, "Reconciling", StatusUpdateOpts{})
+	if err != nil {
+		t.Fatalf("updateStatusAndPhase() error = %v", err)
+	}
+
+	got := &ackov1alpha1.AerospikeCluster{}
+	if err := base.Get(context.Background(), key, got); err != nil {
+		t.Fatalf("Get final cluster error = %v", err)
+	}
+
+	// The retry must have re-run populateStatus against the refetched object,
+	// observing the now-Ready pod. A stale snapshot would have published Size=0.
+	if got.Status.Size != 1 {
+		t.Errorf("Status.Size = %d, want 1 — conflict-retry published stale pod readiness", got.Status.Size)
+	}
+	if ps, ok := got.Status.Pods[podName]; !ok || !ps.IsRunningAndReady {
+		t.Errorf("pod %s IsRunningAndReady = %v (present=%v), want true — conflict-retry did not recompute pod status",
+			podName, ps.IsRunningAndReady, ok)
+	}
+}
+
+// errTestConflict is a sentinel cause for the synthetic conflict error.
+var errTestConflict = &testConflictCause{}
+
+type testConflictCause struct{}
+
+func (e *testConflictCause) Error() string { return "object was modified" }

--- a/internal/controller/retry.go
+++ b/internal/controller/retry.go
@@ -1,5 +1,9 @@
 package controller
 
+import (
+	aero "github.com/aerospike/aerospike-client-go/v8"
+)
+
 // retryOnTransient calls fn once. If it returns a transient Aerospike error
 // (connection reset, timeout, etc.), fn is retried exactly once. On the second
 // failure the retry error is returned. Non-transient errors are returned
@@ -13,4 +17,43 @@ func retryOnTransient(fn func() error) error {
 		return err
 	}
 	return fn()
+}
+
+// retryOnTransientWithReconnect calls fn with an Aerospike client obtained from
+// getClient. If fn returns a transient error (connection reset, timeout, etc.),
+// a fresh client is obtained via getClient and fn is retried exactly once with
+// it. Reusing a stale client whose connection is broken is pointless — the retry
+// would fail identically — so the retry always runs against a freshly-acquired
+// connection.
+//
+// getClient(forRetry) returns the client to use: forRetry is false on the first
+// attempt and true when acquiring the client for the retry. The caller owns the
+// lifecycle of every client getClient hands out (closing the first-attempt
+// client and any retry client), which keeps connection cleanup in one place and
+// avoids leaks. If getClient fails when acquiring the retry client, the original
+// transient error is returned so the caller still sees a meaningful failure.
+func retryOnTransientWithReconnect(
+	getClient func(forRetry bool) (*aero.Client, error),
+	fn func(*aero.Client) error,
+) error {
+	initial, err := getClient(false)
+	if err != nil {
+		return err
+	}
+	err = fn(initial)
+	if err == nil {
+		return nil
+	}
+	if !isTransientAeroError(err) {
+		return err
+	}
+
+	// Transient failure: the connection is likely broken. Acquire a fresh
+	// client before retrying so the retry has a real chance of succeeding.
+	fresh, newErr := getClient(true)
+	if newErr != nil {
+		// Could not get a fresh connection; surface the original transient error.
+		return err
+	}
+	return fn(fresh)
 }

--- a/internal/controller/retry_test.go
+++ b/internal/controller/retry_test.go
@@ -3,6 +3,8 @@ package controller
 import (
 	"errors"
 	"testing"
+
+	aero "github.com/aerospike/aerospike-client-go/v8"
 )
 
 func TestRetryOnTransient_Success(t *testing.T) {
@@ -82,5 +84,135 @@ func TestRetryOnTransient_TransientThenPermanent(t *testing.T) {
 	}
 	if calls != 2 {
 		t.Fatalf("expected 2 calls, got %d", calls)
+	}
+}
+
+// --- retryOnTransientWithReconnect tests ---
+//
+// These use distinct non-nil *aero.Client values purely as identity tokens;
+// the callbacks never dereference them, so no real connection is needed.
+
+func TestRetryOnTransientWithReconnect_Success(t *testing.T) {
+	initial := &aero.Client{}
+	fnCalls := 0
+	getClientCalls := 0
+	err := retryOnTransientWithReconnect(
+		func(forRetry bool) (*aero.Client, error) {
+			getClientCalls++
+			if forRetry {
+				t.Errorf("getClient should not be called for retry on success")
+			}
+			return initial, nil
+		},
+		func(c *aero.Client) error {
+			fnCalls++
+			if c != initial {
+				t.Errorf("expected initial client on first call")
+			}
+			return nil
+		})
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if fnCalls != 1 {
+		t.Fatalf("expected 1 fn call, got %d", fnCalls)
+	}
+	if getClientCalls != 1 {
+		t.Fatalf("expected 1 getClient call on success, got %d", getClientCalls)
+	}
+}
+
+func TestRetryOnTransientWithReconnect_FirstGetClientFails(t *testing.T) {
+	fnCalls := 0
+	connErr := errors.New("connecting to cluster failed")
+	err := retryOnTransientWithReconnect(
+		func(forRetry bool) (*aero.Client, error) { return nil, connErr },
+		func(c *aero.Client) error { fnCalls++; return nil })
+	if err != connErr {
+		t.Fatalf("expected connection error, got %v", err)
+	}
+	if fnCalls != 0 {
+		t.Fatalf("expected 0 fn calls when getClient fails, got %d", fnCalls)
+	}
+}
+
+func TestRetryOnTransientWithReconnect_PermanentErrorNoRetry(t *testing.T) {
+	initial := &aero.Client{}
+	fnCalls := 0
+	getClientCalls := 0
+	permanent := errors.New("invalid privilege")
+	err := retryOnTransientWithReconnect(
+		func(forRetry bool) (*aero.Client, error) { getClientCalls++; return initial, nil },
+		func(c *aero.Client) error { fnCalls++; return permanent })
+	if err != permanent {
+		t.Fatalf("expected permanent error, got %v", err)
+	}
+	if fnCalls != 1 {
+		t.Fatalf("expected 1 fn call (no retry), got %d", fnCalls)
+	}
+	if getClientCalls != 1 {
+		t.Fatalf("expected 1 getClient call (no reconnect) for permanent error, got %d", getClientCalls)
+	}
+}
+
+// TestRetryOnTransientWithReconnect_RetryUsesFreshClient is the core regression
+// test: on a transient error the retry MUST receive a freshly-acquired client,
+// not the stale one. Before the fix the retry reused the stale client and would
+// fail identically.
+func TestRetryOnTransientWithReconnect_RetryUsesFreshClient(t *testing.T) {
+	initial := &aero.Client{}
+	fresh := &aero.Client{}
+	fnCalls := 0
+	getClientCalls := 0
+	err := retryOnTransientWithReconnect(
+		func(forRetry bool) (*aero.Client, error) {
+			getClientCalls++
+			if forRetry {
+				return fresh, nil
+			}
+			return initial, nil
+		},
+		func(c *aero.Client) error {
+			fnCalls++
+			if fnCalls == 1 {
+				if c != initial {
+					t.Errorf("first call: expected initial client")
+				}
+				return errors.New("connection reset by peer")
+			}
+			// Second (retry) call must use the fresh client.
+			if c != fresh {
+				t.Errorf("retry call: expected fresh client, got stale client")
+			}
+			return nil
+		})
+	if err != nil {
+		t.Fatalf("expected nil error after retry with fresh client, got %v", err)
+	}
+	if fnCalls != 2 {
+		t.Fatalf("expected 2 fn calls, got %d", fnCalls)
+	}
+	if getClientCalls != 2 {
+		t.Fatalf("expected 2 getClient calls (initial + reconnect), got %d", getClientCalls)
+	}
+}
+
+func TestRetryOnTransientWithReconnect_ReconnectFailsReturnsOriginalError(t *testing.T) {
+	initial := &aero.Client{}
+	fnCalls := 0
+	transient := errors.New("i/o timeout")
+	err := retryOnTransientWithReconnect(
+		func(forRetry bool) (*aero.Client, error) {
+			if forRetry {
+				return nil, errors.New("dns lookup failed")
+			}
+			return initial, nil
+		},
+		func(c *aero.Client) error { fnCalls++; return transient })
+	if err != transient {
+		t.Fatalf("expected original transient error when reconnect fails, got %v", err)
+	}
+	if fnCalls != 1 {
+		t.Fatalf("expected 1 fn call (retry skipped because reconnect failed), got %d", fnCalls)
 	}
 }


### PR DESCRIPTION
## Summary

Four scoped reconciler correctness fixes found during a code-quality follow-up. No CRD `apiVersion` change, no version bump.

## Fixes

### [P0] `markDirtyVolumes` clobbered concurrent pod status (`reconciler_restart.go`)
`markDirtyVolumes` re-fetched the cluster and called `r.Status().Update(ctx, latest)` — a full status replace. `updateDynamicConfigStatus` and `recordPodRestartStatus` write into the same `Status.Pods` map via `Status().Patch(MergeFrom(...))`. A full `Update` racing those patches silently reverts whichever pod fields were written between the refetch and the write.

**Fix:** take `base := latest.DeepCopy()`, mutate only `DirtyVolumes`, and write via `r.Status().Patch(ctx, latest, client.MergeFrom(base))` — the exact pattern already used by `updateDynamicConfigStatus`.

### [P0] `reconcileACL` transient retry reused a stale broken client (`reconciler_acl.go`, `retry.go`)
On a transient Aerospike connection error (`connection reset`, `timeout`, …) the retry ran `fn()` again against the **same** `aeroClient`. If the connection itself was broken, the retry failed identically — the retry was effectively dead code.

**Fix:** added `retryOnTransientWithReconnect(getClient, fn)` to `retry.go`. It acquires the client via `getClient(false)` for the first attempt and `getClient(true)` for the retry, so the retry always runs against a freshly-acquired connection. `reconcileACL` now tracks every client it opens and closes all of them on return — no stale reuse, no leak. `retryOnTransient`'s signature is unchanged (it has no other callers; the ACL call sites moved to the new helper).

### [P1] `ChangePassword` failure silently swallowed (`reconciler_acl.go`)
In `reconcileUsers`, a `ChangePassword` error was logged at ERROR level but not returned. `reconcileACL` then still reported success and `ACLSynced` was set **True** even though the password was never rotated.

**Fix:** return the error from `reconcileUsers` so it propagates through `reconcileACL` and `ACLSynced` is set **False** with a meaningful reason. Transient `ChangePassword` errors still flow through the `retryOnTransientWithReconnect` wrapper around `reconcileUsers`.

### [P1] `updateStatusAndPhase` conflict-retry published stale pod status (`reconciler_status.go`)
On a 409 conflict, the `RetryOnConflict` block did `refetched.Status = *computedStatus` — stamping a pre-conflict status snapshot (including a possibly-stale `Status.Pods`) onto the refetched object. A concurrent reconcile that had just published newer pod-readiness would be regressed.

**Fix:** the conflict-retry path now re-runs `populateStatus` on the refetched object (re-listing pods for fresh readiness) and re-applies phase / phaseReason / `setFineGrainedConditions` (and the `Completed`-only enrichment). The existing invariant — **do not advance `ObservedGeneration` on a concurrent spec bump** — is preserved: the reconcile's computed `ObservedGeneration` is captured before the retry and restored after `populateStatus` (which would otherwise stamp the new generation).

## Tests

- `retry_test.go` — table-driven unit tests for `retryOnTransientWithReconnect`: success, first-`getClient` failure, permanent-error no-retry, **retry uses a fresh client** (core regression), reconnect-failure returns the original transient error.
- `reconciler_restart_dirty_volumes_test.go` — fake-client + interceptor regression test: a concurrent writer patches a different pod's `DynamicConfigStatus` between `markDirtyVolumes`' refetch and its write. **Fails without the fix** (full `Update` conflicts / clobbers), passes with the `MergeFrom` patch.
- `reconciler_status_conflict_test.go` — fake-client + interceptor regression test: the first `Status().Update` returns a 409 and concurrently flips a pod to Ready. **Fails without the fix** (`Status.Size = 0`, stale snapshot), passes with the recompute.

Each new regression test was verified fails-without-fix / passes-with-fix.

## Verification

- `gofmt -l` clean on all changed files
- `go vet ./...` clean
- `go build ./...` clean
- `make test` (unit + envtest integration) — all packages pass
- `make lint` — only 2 **pre-existing** `goconst` warnings in untouched files (`reconciler_pod_rbac.go`, `reconciler_restart_test.go`), confirmed present on the clean `main` tree; no new lint issues introduced.