### PR TITLE
fix: harden CE-constraint validation and transient-error handling

### DIFF
--- a/api/v1alpha1/aerospikecluster_webhook.go
+++ b/api/v1alpha1/aerospikecluster_webhook.go
@@ -491,6 +491,19 @@ func (v *AerospikeClusterValidator) validate(cluster *AerospikeCluster) (admissi
 	if cluster.Spec.RackConfig != nil {
 		rackErrors := v.validateRackConfig(cluster.Spec.RackConfig)
 		allErrors = append(allErrors, rackErrors...)
+
+		// Reject more racks than pods. The reconciler distributes spec.size
+		// evenly across racks (getRackSize); when len(racks) > size at least
+		// one rack is assigned 0 replicas, producing a 0-replica StatefulSet
+		// that never carries data. The size check is skipped when size is
+		// supplied later by a template (size == 0 && templateRef != nil).
+		numRacks := len(cluster.Spec.RackConfig.Racks)
+		if numRacks > 0 && !(cluster.Spec.Size == 0 && cluster.Spec.TemplateRef != nil) &&
+			numRacks > int(cluster.Spec.Size) {
+			allErrors = append(allErrors, fmt.Sprintf(
+				"rackConfig defines %d racks but spec.size is %d; each rack must get at least 1 pod, so the rack count must not exceed spec.size",
+				numRacks, cluster.Spec.Size))
+		}
 	}
 
 	// Validate monitoring
@@ -673,6 +686,15 @@ func (v *AerospikeClusterValidator) validateAerospikeConfig(config map[string]an
 					"(e.g. [{name: foo, ...}, {name: bar, ...}]), got map with %d entries; "+
 					"per-namespace validation cannot run on the map form",
 				len(ns)))
+		default:
+			// Any other scalar shape (string, number, bool, ...) — e.g. the
+			// common YAML mistake `namespaces: default`. Previously this fell
+			// through the type switch silently: the webhook accepted the CR,
+			// then configgen failed permanently at reconcile time. Reject it
+			// here so the user gets an actionable admission error.
+			errors = append(errors, fmt.Sprintf(
+				"aerospikeConfig.namespaces must be a list of namespace maps "+
+					"(e.g. [{name: foo, ...}]), got %T", ns))
 		}
 	}
 

--- a/api/v1alpha1/aerospikecluster_webhook.go
+++ b/api/v1alpha1/aerospikecluster_webhook.go
@@ -498,8 +498,8 @@ func (v *AerospikeClusterValidator) validate(cluster *AerospikeCluster) (admissi
 		// that never carries data. The size check is skipped when size is
 		// supplied later by a template (size == 0 && templateRef != nil).
 		numRacks := len(cluster.Spec.RackConfig.Racks)
-		if numRacks > 0 && !(cluster.Spec.Size == 0 && cluster.Spec.TemplateRef != nil) &&
-			numRacks > int(cluster.Spec.Size) {
+		sizeKnownNow := cluster.Spec.Size != 0 || cluster.Spec.TemplateRef == nil
+		if numRacks > 0 && sizeKnownNow && numRacks > int(cluster.Spec.Size) {
 			allErrors = append(allErrors, fmt.Sprintf(
 				"rackConfig defines %d racks but spec.size is %d; each rack must get at least 1 pod, so the rack count must not exceed spec.size",
 				numRacks, cluster.Spec.Size))

--- a/api/v1alpha1/webhook_test.go
+++ b/api/v1alpha1/webhook_test.go
@@ -5090,3 +5090,114 @@ func TestValidate_NamespacesAsMapRejected(t *testing.T) {
 		t.Errorf("expected 'must be a list' in error, got: %v", err)
 	}
 }
+
+// TestValidate_NamespacesAsScalarRejected covers the remaining shape gap: when
+// aerospikeConfig.namespaces is a scalar (string/number/bool) — e.g. the common
+// YAML mistake `namespaces: default` — the type switch previously fell through
+// silently, so the CR was admitted and configgen failed later at reconcile time.
+func TestValidate_NamespacesAsScalarRejected(t *testing.T) {
+	scalarValues := []any{
+		"default",      // string
+		3,              // int
+		true,           // bool
+		[]string{"ns"}, // typed slice (not []any)
+	}
+	for _, scalar := range scalarValues {
+		v := &AerospikeClusterValidator{}
+		cluster := &AerospikeCluster{
+			Spec: AerospikeClusterSpec{
+				Size:  3,
+				Image: "aerospike:ce-8.1.1.1",
+				AerospikeConfig: &AerospikeConfigSpec{
+					Value: map[string]any{
+						"namespaces": scalar,
+					},
+				},
+			},
+		}
+
+		_, err := v.validate(cluster)
+		if err == nil {
+			t.Fatalf("expected error when aerospikeConfig.namespaces is %T", scalar)
+		}
+		if !strings.Contains(err.Error(), "must be a list") {
+			t.Errorf("expected 'must be a list' in error for %T, got: %v", scalar, err)
+		}
+	}
+}
+
+// --- rack count vs cluster size (more racks than pods) ---
+
+// TestValidate_MoreRacksThanSizeRejected covers the footgun where rackConfig
+// defines more racks than spec.size: getRackSize then assigns 0 replicas to at
+// least one rack, producing a 0-replica StatefulSet that never carries data.
+func TestValidate_MoreRacksThanSizeRejected(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+	cluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:  2,
+			Image: "aerospike:ce-8.1.1.1",
+			RackConfig: &RackConfig{
+				Racks: []Rack{
+					{ID: 1},
+					{ID: 2},
+					{ID: 3},
+				},
+			},
+		},
+	}
+
+	_, err := v.validate(cluster)
+	if err == nil {
+		t.Fatal("expected error when rack count exceeds spec.size")
+	}
+	if !strings.Contains(err.Error(), "rack count must not exceed spec.size") {
+		t.Errorf("error should mention the rack-count/size mismatch, got: %v", err)
+	}
+}
+
+// TestValidate_RackCountEqualToSizeAccepted confirms the boundary case
+// (one pod per rack) is allowed.
+func TestValidate_RackCountEqualToSizeAccepted(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+	cluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:  3,
+			Image: "aerospike:ce-8.1.1.1",
+			RackConfig: &RackConfig{
+				Racks: []Rack{
+					{ID: 1},
+					{ID: 2},
+					{ID: 3},
+				},
+			},
+		},
+	}
+
+	if _, err := v.validate(cluster); err != nil {
+		t.Fatalf("rack count equal to spec.size should be accepted, got: %v", err)
+	}
+}
+
+// TestValidate_MoreRacksThanSizeAllowedWithTemplate confirms the rack/size
+// cross-check is deferred when size is supplied by a referenced template
+// (size == 0 && templateRef != nil).
+func TestValidate_MoreRacksThanSizeAllowedWithTemplate(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+	cluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:        0,
+			TemplateRef: &TemplateRef{Name: "ce-template"},
+			RackConfig: &RackConfig{
+				Racks: []Rack{
+					{ID: 1},
+					{ID: 2},
+				},
+			},
+		},
+	}
+
+	if _, err := v.validate(cluster); err != nil {
+		t.Fatalf("rack/size check should be deferred to template resolution, got: %v", err)
+	}
+}

--- a/internal/controller/reconciler_acl.go
+++ b/internal/controller/reconciler_acl.go
@@ -438,17 +438,36 @@ func privilegeSet(privs []aero.Privilege) map[string]aero.Privilege {
 	return set
 }
 
+// transientAeroErrorSubstrings lists case-insensitive substrings that mark an
+// Aerospike error as transient (worth a single retry). These cover the failure
+// modes seen when a node is briefly unavailable during a rolling restart:
+// connection drops, timeouts, and not-yet-connected states. "i/o timeout" is a
+// subset of "timeout" but kept explicit for readability.
+var transientAeroErrorSubstrings = []string{
+	"connection reset",
+	"connection refused",
+	"timeout",
+	"i/o timeout",
+	"broken pipe",
+	"eof",
+	"network is unreachable",
+	"no available connections",
+	"not connected",
+}
+
 // isTransientAeroError checks if an Aerospike error is transient and worth retrying.
-// This includes connection resets, timeouts, and cluster-not-ready errors.
+// The match is case-insensitive so wrapped/uppercased error strings still match.
 func isTransientAeroError(err error) bool {
 	if err == nil {
 		return false
 	}
-	msg := err.Error()
-	return strings.Contains(msg, "connection reset") ||
-		strings.Contains(msg, "timeout") ||
-		strings.Contains(msg, "i/o timeout") ||
-		strings.Contains(msg, "connection refused")
+	msg := strings.ToLower(err.Error())
+	for _, sub := range transientAeroErrorSubstrings {
+		if strings.Contains(msg, sub) {
+			return true
+		}
+	}
+	return false
 }
 
 // newAdminPolicy returns an AdminPolicy with the standard operator timeout.

--- a/internal/controller/reconciler_acl_test.go
+++ b/internal/controller/reconciler_acl_test.go
@@ -324,6 +324,16 @@ func TestIsTransientAeroError_TransientErrors(t *testing.T) {
 		"i/o timeout",
 		"read tcp 10.0.0.1:3000: timeout",
 		"querying roles: connection reset",
+		// Failure modes seen during rolling restarts that the original
+		// substring list missed.
+		"write tcp 10.0.0.1:3000->10.0.0.2:3000: write: broken pipe",
+		"unexpected EOF",
+		"dial tcp 10.0.0.1:3000: connect: network is unreachable",
+		"no available connections to the node",
+		"connection error: node not connected",
+		// Case-insensitive matching: wrapped errors may uppercase the message.
+		"Connection Reset By Peer",
+		"QUERYING USERS: TIMEOUT",
 	}
 	for _, msg := range transientMessages {
 		err := errors.New(msg)

--- a/internal/controller/reconciler_status.go
+++ b/internal/controller/reconciler_status.go
@@ -234,7 +234,18 @@ func (r *AerospikeClusterReconciler) enrichStatusWithAerospikeInfo(
 // It sets MigratingPartitions on pods whose IP matches a key in perNode, clears
 // MigratingPartitions on pods not present in perNode, and updates the cluster-level
 // MigrationStatus and MigrationComplete condition.
+//
+// An empty perNode map means no node reported a usable migration stat (every
+// node had a nil host, or the stat was absent everywhere). Treating that as
+// "0 partitions remaining" would falsely flip MigrationComplete to True, which
+// could let a deferred scale-down or rolling restart proceed before migration
+// actually finished. In that case the previous MigrationStatus/condition is
+// left untouched so a stale-but-safe value is kept instead of a false positive.
 func applyMigrationStats(cluster *ackov1alpha1.AerospikeCluster, perNode map[string]int64) {
+	if len(perNode) == 0 {
+		return
+	}
+
 	// Build pod-IP → pod-name lookup.
 	podIPToPodName := make(map[string]string, len(cluster.Status.Pods))
 	for podName, ps := range cluster.Status.Pods {

--- a/internal/controller/reconciler_status_test.go
+++ b/internal/controller/reconciler_status_test.go
@@ -1189,24 +1189,52 @@ func TestApplyMigrationStats(t *testing.T) {
 		}
 	})
 
-	t.Run("empty perNode with no pods", func(t *testing.T) {
+	// An empty perNode map means no node reported a usable migration stat.
+	// applyMigrationStats must NOT treat that as "migration complete": doing so
+	// would falsely flip MigrationComplete to True (RemainingPartitions=0) and
+	// could unblock a deferred scale-down / rolling restart before migration
+	// actually finished. The previous MigrationStatus/condition is left intact.
+	t.Run("empty perNode does not overwrite migration status (no false complete)", func(t *testing.T) {
+		existingStatus := &ackov1alpha1.MigrationStatus{
+			InProgress:          true,
+			RemainingPartitions: 42,
+		}
 		cluster := &ackov1alpha1.AerospikeCluster{
 			Status: ackov1alpha1.AerospikeClusterStatus{
-				Pods: map[string]ackov1alpha1.AerospikePodStatus{},
+				Pods:            map[string]ackov1alpha1.AerospikePodStatus{},
+				MigrationStatus: existingStatus,
 			},
 		}
 		perNode := map[string]int64{}
 
 		applyMigrationStats(cluster, perNode)
 
+		// The prior (stale-but-safe) MigrationStatus must be preserved untouched.
 		if cluster.Status.MigrationStatus == nil {
-			t.Fatal("MigrationStatus should not be nil")
+			t.Fatal("MigrationStatus should be preserved, not cleared")
 		}
-		if cluster.Status.MigrationStatus.InProgress {
-			t.Error("InProgress should be false for empty perNode")
+		if !cluster.Status.MigrationStatus.InProgress {
+			t.Error("InProgress should remain true; empty perNode must not flip it to false")
 		}
-		if cluster.Status.MigrationStatus.RemainingPartitions != 0 {
-			t.Errorf("RemainingPartitions = %d, want 0", cluster.Status.MigrationStatus.RemainingPartitions)
+		if cluster.Status.MigrationStatus.RemainingPartitions != 42 {
+			t.Errorf("RemainingPartitions = %d, want 42 (preserved)", cluster.Status.MigrationStatus.RemainingPartitions)
+		}
+	})
+
+	t.Run("empty perNode with nil prior status leaves it nil", func(t *testing.T) {
+		cluster := &ackov1alpha1.AerospikeCluster{
+			Status: ackov1alpha1.AerospikeClusterStatus{
+				Pods: map[string]ackov1alpha1.AerospikePodStatus{},
+			},
+		}
+
+		applyMigrationStats(cluster, map[string]int64{})
+
+		// No data → no claim. MigrationStatus stays nil rather than a
+		// fabricated "0 remaining / complete".
+		if cluster.Status.MigrationStatus != nil {
+			t.Errorf("MigrationStatus = %+v, want nil for empty perNode with no prior data",
+				cluster.Status.MigrationStatus)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

A fresh deep review of `origin/main` (after the recent code-quality hardening in #285) surfaced four genuine correctness bugs. This PR fixes all four with table-driven test coverage. No CRD `apiVersion` or version-key changes; no breaking API changes.

## Fixes

### 1. Webhook: reject scalar `aerospikeConfig.namespaces` (Medium-High)
`validateAerospikeConfig`'s type switch only handled `[]any` and `map[string]any`. A scalar value — e.g. the common YAML mistake `namespaces: default` — fell through the switch **silently**: the webhook admitted the CR, then `configgen` failed permanently at reconcile time with no admission-time signal. Now rejected at admission with an actionable `must be a list of namespace maps, got <type>` error. Companion to the existing map-shape rejection.

### 2. Webhook: reject more racks than `spec.size` (Medium)
`getRackSize` distributes `spec.size` evenly across racks. When `len(racks) > size`, at least one rack is assigned **0 replicas**, producing a 0-replica StatefulSet that never carries data — a silent footgun. The validator now rejects this. The check is correctly skipped when size is supplied later by a referenced template (`size == 0 && templateRef != nil`), so template-based clusters are unaffected.

### 3. Controller: broaden `isTransientAeroError` (Medium)
The transient-error detector only matched `connection reset`, `timeout`, `i/o timeout`, `connection refused`. It missed failure modes routinely seen when a node is briefly unavailable during a rolling restart: `broken pipe`, `EOF`, `network is unreachable`, `no available connections`, `not connected`. It was also case-sensitive, so a wrapped/uppercased error string would not match. As a result, ACL sync and dynamic-config 2PC retries gave up on genuinely transient failures. The list is extended and matching is now case-insensitive.

### 4. Controller: don't fabricate "migration complete" from an empty stat map (Medium-High)
`applyMigrationStats` treated an empty `perNode` map (no node reported a usable migration stat — e.g. every node had a nil host) as "0 partitions remaining". That falsely flipped the `MigrationComplete` condition to **True** with `RemainingPartitions=0`, which could unblock a deferred scale-down or rolling restart **before migration actually finished** — a data-safety risk. It now returns early on an empty map, leaving the prior (stale-but-safe) `MigrationStatus`/condition untouched instead of writing a false positive.

## Tests
- `TestValidate_NamespacesAsScalarRejected` — string/int/bool/typed-slice all rejected.
- `TestValidate_MoreRacksThanSizeRejected`, `TestValidate_RackCountEqualToSizeAccepted`, `TestValidate_MoreRacksThanSizeAllowedWithTemplate` — rack/size cross-check including the boundary and template-deferred cases.
- `TestIsTransientAeroError_TransientErrors` — extended with the newly-covered substrings + case-insensitivity.
- `TestApplyMigrationStats` — replaced the subtest that asserted the buggy behavior with two subtests covering both empty-map paths (preserve prior status; leave nil when no prior data).

## Verification
- `go build ./...` — pass
- `go vet ./...` — pass
- `gofmt -l` on changed files — clean
- `go test ./internal/... ./api/...` — pass

envtest/e2e suites that require a live cluster were not run in this environment.