### PR TITLE
fix: emit context-prefixed key for nested dynamic config params

### DIFF
--- a/internal/configdiff/diff.go
+++ b/internal/configdiff/diff.go
@@ -174,7 +174,7 @@ func diffNamespaces(result *DiffResult, oldNS, newNS []any) {
 func classifyChange(result *DiffResult, path string, oldVal, newVal any, namespace string) {
 	change := Change{
 		Path:      path,
-		Key:       lastSegment(path),
+		Key:       keyWithinContext(path),
 		Context:   firstSegment(path),
 		OldValue:  oldVal,
 		NewValue:  newVal,
@@ -206,9 +206,28 @@ func firstSegment(path string) string {
 	return path
 }
 
-func lastSegment(path string) string {
-	for i := len(path) - 1; i >= 0; i-- {
-		if path[i] == '.' {
+// keyWithinContext returns the asinfo set-config parameter key for a config
+// path: the path with its leading context segment (firstSegment) stripped.
+//
+// The asinfo "set-config" command only accepts the top-level contexts
+// service / network / namespace / security / xdr. Sub-stanzas like heartbeat
+// and fabric are NOT contexts — their parameters are addressed by a dotted key
+// within the network context. For example "network.heartbeat.interval" must be
+// applied as:
+//
+//	set-config:context=network;heartbeat.interval=<value>
+//
+// so the key is "heartbeat.interval", not just "interval". Taking only the
+// last path segment produced "interval", yielding the invalid command
+// "set-config:context=network;interval=<value>" which Aerospike rejects — every
+// dynamic heartbeat/fabric/security-sub change then silently fell back to a
+// disruptive cold restart even though it was registered as dynamic.
+//
+// For a two-segment path such as "service.proto-fd-max" this returns
+// "proto-fd-max" (the same value the previous last-segment logic produced).
+func keyWithinContext(path string) string {
+	for i, c := range path {
+		if c == '.' {
 			return path[i+1:]
 		}
 	}

--- a/internal/configdiff/diff_test.go
+++ b/internal/configdiff/diff_test.go
@@ -394,17 +394,72 @@ func TestFirstSegment(t *testing.T) {
 	}
 }
 
-func TestLastSegment(t *testing.T) {
+func TestKeyWithinContext(t *testing.T) {
 	tests := []struct {
 		path, expected string
 	}{
+		// Two-segment paths: the context is stripped, leaving the bare key.
 		{"service.proto-fd-max", "proto-fd-max"},
-		{"network.heartbeat.interval", "interval"},
+		{"namespace.default-ttl", "default-ttl"},
+		// Three-segment paths: only the leading context (network/security) is
+		// stripped — the sub-stanza prefix (heartbeat./fabric./log.) is RETAINED
+		// because it is part of the asinfo set-config parameter key, not a
+		// context of its own.
+		{"network.heartbeat.interval", "heartbeat.interval"},
+		{"network.heartbeat.timeout", "heartbeat.timeout"},
+		{"network.fabric.send-threads", "fabric.send-threads"},
+		{"security.log.report-authentication", "log.report-authentication"},
+		// Single-segment path: nothing to strip.
 		{"single", "single"},
 	}
 	for _, tc := range tests {
-		if got := lastSegment(tc.path); got != tc.expected {
-			t.Errorf("lastSegment(%q) = %q, want %q", tc.path, got, tc.expected)
+		if got := keyWithinContext(tc.path); got != tc.expected {
+			t.Errorf("keyWithinContext(%q) = %q, want %q", tc.path, got, tc.expected)
+		}
+	}
+}
+
+// TestClassifyChange_NestedNetworkKey is the regression test for the dynamic
+// heartbeat/fabric Key bug: Diff() must emit a Change whose Key carries the
+// sub-stanza prefix (e.g. "heartbeat.interval"), so buildSetConfigCommand
+// produces the valid "set-config:context=network;heartbeat.interval=<value>".
+// Before the fix the Key was the bare last segment ("interval"), the command
+// was rejected by Aerospike, and the change fell back to a cold restart.
+func TestClassifyChange_NestedNetworkKey(t *testing.T) {
+	old := map[string]any{
+		"network": map[string]any{
+			"heartbeat": map[string]any{"interval": 150},
+			"fabric":    map[string]any{"send-threads": 4},
+		},
+	}
+	new := map[string]any{
+		"network": map[string]any{
+			"heartbeat": map[string]any{"interval": 250},
+			"fabric":    map[string]any{"send-threads": 8},
+		},
+	}
+
+	result := Diff(old, new)
+	if len(result.Dynamic) != 2 {
+		t.Fatalf("expected 2 dynamic changes, got %d (%+v)", len(result.Dynamic), result.Dynamic)
+	}
+
+	wantKeys := map[string]string{
+		"network.heartbeat.interval":  "heartbeat.interval",
+		"network.fabric.send-threads": "fabric.send-threads",
+	}
+	for _, c := range result.Dynamic {
+		wantKey, ok := wantKeys[c.Path]
+		if !ok {
+			t.Errorf("unexpected change path %q", c.Path)
+			continue
+		}
+		if c.Context != "network" {
+			t.Errorf("change %q: Context = %q, want %q", c.Path, c.Context, "network")
+		}
+		if c.Key != wantKey {
+			t.Errorf("change %q: Key = %q, want %q (asinfo would otherwise reject the command)",
+				c.Path, c.Key, wantKey)
 		}
 	}
 }

--- a/internal/controller/reconciler_dynamic_config_test.go
+++ b/internal/controller/reconciler_dynamic_config_test.go
@@ -66,6 +66,57 @@ func TestBuildSetConfigCommand_NetworkContext(t *testing.T) {
 	}
 }
 
+// TestDiffToSetConfigCommand_HeartbeatDynamic is the end-to-end regression
+// test for the dynamic heartbeat/fabric Key bug. It runs the real diff engine
+// over a heartbeat-interval change and feeds the resulting Change straight into
+// buildSetConfigCommand — the exact path the 2PC dynamic-update loop takes.
+//
+// Before the fix, configdiff emitted Key="interval" (bare last segment), so the
+// command was the invalid "set-config:context=network;interval=250" which
+// Aerospike rejects; the dynamic update then always failed and the pod was
+// cold-restarted even though network.heartbeat.interval is registered dynamic.
+func TestDiffToSetConfigCommand_HeartbeatDynamic(t *testing.T) {
+	oldCfg := map[string]any{
+		"network": map[string]any{
+			"heartbeat": map[string]any{"interval": 150},
+			"fabric":    map[string]any{"send-threads": 4},
+		},
+	}
+	newCfg := map[string]any{
+		"network": map[string]any{
+			"heartbeat": map[string]any{"interval": 250},
+			"fabric":    map[string]any{"send-threads": 8},
+		},
+	}
+
+	diff := configdiff.Diff(oldCfg, newCfg)
+	if diff.HasStaticChanges() {
+		t.Fatalf("heartbeat/fabric changes must be dynamic, got static: %+v", diff.Static)
+	}
+	if len(diff.Dynamic) != 2 {
+		t.Fatalf("expected 2 dynamic changes, got %d (%+v)", len(diff.Dynamic), diff.Dynamic)
+	}
+
+	wantCmd := map[string]string{
+		"network.heartbeat.interval":  "set-config:context=network;heartbeat.interval=250",
+		"network.fabric.send-threads": "set-config:context=network;fabric.send-threads=8",
+	}
+	for _, change := range diff.Dynamic {
+		cmd, err := buildSetConfigCommand(change)
+		if err != nil {
+			t.Fatalf("buildSetConfigCommand(%q) error = %v", change.Path, err)
+		}
+		want, ok := wantCmd[change.Path]
+		if !ok {
+			t.Errorf("unexpected change path %q", change.Path)
+			continue
+		}
+		if cmd != want {
+			t.Errorf("change %q: command = %q, want %q", change.Path, cmd, want)
+		}
+	}
+}
+
 func TestBuildSetConfigCommand_StringValue(t *testing.T) {
 	change := configdiff.Change{
 		Path:     "service.ticker-interval",


### PR DESCRIPTION
## Summary

Fresh code review of `origin/main` (built on top of #286). Found and fixed one genuine correctness bug in the dynamic-config diff engine.

## Bug: nested dynamic config params generate an invalid asinfo command

**Severity: High** — heartbeat/fabric runtime tuning silently never works dynamically.

### Root cause

`configdiff.classifyChange` set `Change.Key` to `lastSegment(path)` — the bare final path component. For a nested config path such as `network.heartbeat.interval`, that produces `Key="interval"`, and `buildSetConfigCommand` then emits:

```
set-config:context=network;interval=<value>
```

Aerospike's `set-config` info command only accepts the top-level contexts `service` / `network` / `namespace` / `security` / `xdr`. `heartbeat` and `fabric` are **not** contexts — they are sub-stanzas whose parameters are addressed by a **dotted key within the `network` context**. The valid command is:

```
set-config:context=network;heartbeat.interval=<value>
```

So the key must be `heartbeat.interval`, not `interval`.

### Impact

`network.heartbeat.*` and `network.fabric.*` (and `security.log.*`) are all registered in `dynamic_params.go` as dynamically-applicable. But because the generated command is malformed, Aerospike rejects it, the 2PC `validateDynamicConfigOnPod` / `applyDynamicConfigOnPod` phase fails, and the reconciler falls back to a **cold restart** for what should have been a no-restart change. Heartbeat-interval and fabric-thread tuning that the operator advertises as dynamic always cause a disruptive rolling restart instead.

This was a producer/consumer mismatch: `buildSetConfigCommand` and its existing `TestBuildSetConfigCommand_NetworkContext` test already expected the prefixed key (`Key: "heartbeat.interval"` → `set-config:context=network;heartbeat.interval=250`). Only the `Change` producer (`classifyChange`) was wrong, so the bug was invisible to the unit tests.

### Fix

Replace `lastSegment` with a new `keyWithinContext` helper that strips **only** the leading context segment and retains the sub-stanza prefix:

- `service.proto-fd-max` → `proto-fd-max` (unchanged — two-segment path)
- `network.heartbeat.interval` → `heartbeat.interval` (fixed)
- `network.fabric.send-threads` → `fabric.send-threads` (fixed)
- `security.log.report-authentication` → `log.report-authentication` (fixed)

`Context` (`firstSegment`) was already correct. `buildRollbackCommand` copies `Key` from the original `Change`, so the rollback command is corrected by the same change. The now-unused `lastSegment` helper and its test were removed (unexported, no public consumer).

### Tests

- `configdiff.TestKeyWithinContext` — table-driven coverage of the new helper across 2-, 3-segment and single-segment paths.
- `configdiff.TestClassifyChange_NestedNetworkKey` — runs the real `Diff()` engine and asserts the emitted `Change.Key`/`Context` for heartbeat + fabric changes.
- `controller.TestDiffToSetConfigCommand_HeartbeatDynamic` — end-to-end regression test: `Diff()` → `buildSetConfigCommand`, asserting the generated command is the valid `set-config:context=network;heartbeat.interval=250` form (the exact path the 2PC dynamic-update loop takes).

## Scope

3 files, +133/-8 LOC (1 source, 2 test). No CRD/type/webhook changes; no manifest regeneration needed. Fully backward compatible.

## Verification

- `make build` — pass (manifests, generate, fmt, vet, build all clean)
- `make test` — pass (unit + envtest integration; configdiff 94.2% coverage)
- `make lint` — pass (golangci-lint custom binary, 0 issues)