### PR TITLE
fix: webhook port validation, quiesce recluster, monitoring cleanup error handling

### DIFF
--- a/api/v1alpha1/aerospikecluster_webhook.go
+++ b/api/v1alpha1/aerospikecluster_webhook.go
@@ -1472,9 +1472,23 @@ func (v *AerospikeClusterValidator) validateMonitoring(m *AerospikeMonitoringSpe
 	return errors, warnings
 }
 
+// operatorFixedNetworkPorts maps each network subsection to the single port the
+// operator supports. The Aerospike container's containerPort declarations, the
+// liveness/readiness probes (asinfo -p <port>), the headless/per-pod Services,
+// and the generated NetworkPolicy/CiliumNetworkPolicy all hard-code these
+// values. A CR that sets a different port is silently broken — the probes query
+// the wrong port so pods never become Ready — so admission must reject it
+// instead of letting the cluster fail opaquely at runtime.
+var operatorFixedNetworkPorts = map[string]int{
+	"service":   int(DefaultServicePort),
+	"heartbeat": int(DefaultHeartbeatPort),
+	"fabric":    int(DefaultFabricPort),
+}
+
 // validateNetworkPortUniqueness checks that service, heartbeat, and fabric
-// ports are valid TCP integers, distinct, and do not collide with another
-// Aerospike subsection's reserved port (e.g. service.port=3003 vs info).
+// ports are valid TCP integers, distinct, do not collide with another
+// Aerospike subsection's reserved port (e.g. service.port=3003 vs info), and
+// match the fixed ports the operator hard-codes everywhere else.
 func (v *AerospikeClusterValidator) validateNetworkPortUniqueness(cluster *AerospikeCluster) []string {
 	netCfg, ok := cluster.Spec.AerospikeConfig.Value["network"].(map[string]any)
 	if !ok {
@@ -1554,6 +1568,22 @@ func (v *AerospikeClusterValidator) validateNetworkPortUniqueness(cluster *Aeros
 			}
 		}
 	}
+
+	// Reject ports that differ from the fixed values the operator hard-codes
+	// into container ports, probes, Services and NetworkPolicies. A custom port
+	// is accepted by the API server but produces a cluster whose probes target
+	// the wrong port, so pods never reach Ready. Fail fast at admission with an
+	// actionable message instead.
+	for _, p := range ports {
+		if fixed, known := operatorFixedNetworkPorts[p.name]; known && p.port != fixed {
+			errors = append(errors, fmt.Sprintf(
+				"aerospikeConfig.network.%s.port=%d is not supported; the operator requires the fixed port %d "+
+					"(container ports, health probes, Services and NetworkPolicies all assume it). "+
+					"Remove the port override or set it to %d.",
+				p.name, p.port, fixed, fixed))
+		}
+	}
+
 	return errors
 }
 

--- a/api/v1alpha1/webhook_test.go
+++ b/api/v1alpha1/webhook_test.go
@@ -4383,6 +4383,91 @@ func TestValidate_NetworkPort_StringTypeRejected(t *testing.T) {
 	}
 }
 
+func TestValidate_NetworkPort_CustomServicePortRejected(t *testing.T) {
+	// A custom service port is syntactically valid but unsupported: the operator
+	// hard-codes the container port and the asinfo health probes to 3000, so a
+	// cluster with service.port=4000 never reaches Ready. Admission must reject it.
+	v := &AerospikeClusterValidator{}
+	cluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:  3,
+			Image: "aerospike:ce-8.1.1.1",
+			AerospikeConfig: &AerospikeConfigSpec{
+				Value: map[string]any{
+					"network": map[string]any{
+						"service":   map[string]any{"port": 4000},
+						"heartbeat": map[string]any{"port": 3002, "mode": "mesh"},
+						"fabric":    map[string]any{"port": 3001},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := v.validate(cluster)
+	if err == nil {
+		t.Fatal("expected error for custom service.port=4000, got nil")
+	}
+	if !strings.Contains(err.Error(), "network.service.port=4000 is not supported") {
+		t.Errorf("expected unsupported-port error for service.port=4000, got: %v", err)
+	}
+}
+
+func TestValidate_NetworkPort_CustomHeartbeatAndFabricPortRejected(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+	cluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:  3,
+			Image: "aerospike:ce-8.1.1.1",
+			AerospikeConfig: &AerospikeConfigSpec{
+				Value: map[string]any{
+					"network": map[string]any{
+						"service":   map[string]any{"port": 3000},
+						"heartbeat": map[string]any{"port": 3100, "mode": "mesh"},
+						"fabric":    map[string]any{"port": 3200},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := v.validate(cluster)
+	if err == nil {
+		t.Fatal("expected error for custom heartbeat/fabric ports, got nil")
+	}
+	if !strings.Contains(err.Error(), "network.heartbeat.port=3100 is not supported") {
+		t.Errorf("expected unsupported-port error for heartbeat.port=3100, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "network.fabric.port=3200 is not supported") {
+		t.Errorf("expected unsupported-port error for fabric.port=3200, got: %v", err)
+	}
+}
+
+func TestValidate_NetworkPort_DefaultPortsAccepted(t *testing.T) {
+	// The exact fixed ports must pass cleanly — this guards against the
+	// fixed-port check rejecting a correctly-configured cluster.
+	v := &AerospikeClusterValidator{}
+	cluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:  3,
+			Image: "aerospike:ce-8.1.1.1",
+			AerospikeConfig: &AerospikeConfigSpec{
+				Value: map[string]any{
+					"network": map[string]any{
+						"service":   map[string]any{"port": int(DefaultServicePort)},
+						"heartbeat": map[string]any{"port": int(DefaultHeartbeatPort), "mode": "mesh"},
+						"fabric":    map[string]any{"port": int(DefaultFabricPort)},
+					},
+				},
+			},
+		},
+	}
+
+	if errs := v.validateNetworkPortUniqueness(cluster); len(errs) != 0 {
+		t.Errorf("expected no errors for default ports, got: %v", errs)
+	}
+}
+
 func TestValidate_NetworkPortUniqueness_NoNetworkSection(t *testing.T) {
 	v := &AerospikeClusterValidator{}
 	cluster := &AerospikeCluster{

--- a/internal/controller/aero_client.go
+++ b/internal/controller/aero_client.go
@@ -10,6 +10,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/remotecommand"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -155,9 +156,17 @@ func (r *AerospikeClusterReconciler) getPasswordFromSecret(
 	return string(password), nil
 }
 
-// quiesceNode sends the "quiesce:" command to an Aerospike node via pod exec,
-// so the node gracefully stops accepting new transactions before being removed.
-// The command is executed inside the Aerospike container using asinfo.
+// quiesceNode quiesces an Aerospike node via pod exec so it gracefully stops
+// owning partitions before being removed. It runs TWO asinfo commands in
+// sequence: "quiesce:" marks the node as pending-quiesce, and "recluster:"
+// makes that pending state take effect cluster-wide.
+//
+// Sending "quiesce:" alone is a no-op for the feature's purpose: until a
+// "recluster:" runs, the cluster does not recompute its partition map, so the
+// node keeps owning (master) partitions and clients are NOT failed over before
+// the pod is deleted — exactly the disruption quiesce is meant to prevent.
+// recluster: is idempotent and may be issued on any node.
+//
 // This is a best-effort operation: the caller should proceed with pod deletion
 // even if quiesce fails (e.g., node is already down, asinfo not available).
 func (r *AerospikeClusterReconciler) quiesceNode(
@@ -190,13 +199,36 @@ func (r *AerospikeClusterReconciler) quiesceNode(
 		adminPassword = pw
 	}
 
-	// Build the asinfo command. If ACL is enabled, include auth flags.
-	cmd := buildQuiesceCommand(cluster, port, adminPassword)
-
 	// Apply quiesce-specific timeout to prevent blocking pod deletion indefinitely.
+	// The same budget covers both the quiesce and recluster exec calls.
 	execCtx, cancel := context.WithTimeout(ctx, quiesceTimeout)
 	defer cancel()
 
+	// Step 1: mark the node as pending-quiesce.
+	if err := r.execAsinfoVerb(execCtx, clientset, pod, "quiesce:", buildQuiesceCommand(cluster, port, adminPassword)); err != nil {
+		return err
+	}
+	log.Info("Quiesce command completed", "pod", pod.Name)
+
+	// Step 2: trigger a recluster so the pending-quiesce takes effect and the
+	// node sheds its partitions before the pod is deleted.
+	if err := r.execAsinfoVerb(execCtx, clientset, pod, "recluster:", buildAsinfoCommand("recluster:", cluster, port, adminPassword)); err != nil {
+		return fmt.Errorf("recluster after quiesce failed (quiesce will not take effect): %w", err)
+	}
+	log.Info("Recluster command completed; quiesce is now in effect", "pod", pod.Name)
+
+	return nil
+}
+
+// execAsinfoVerb runs a single asinfo command inside the Aerospike container of
+// pod and verifies the response is "ok". verb is used only for error messages.
+func (r *AerospikeClusterReconciler) execAsinfoVerb(
+	ctx context.Context,
+	clientset kubernetes.Interface,
+	pod *corev1.Pod,
+	verb string,
+	cmd []string,
+) error {
 	req := clientset.CoreV1().RESTClient().
 		Post().
 		Resource("pods").
@@ -212,40 +244,35 @@ func (r *AerospikeClusterReconciler) quiesceNode(
 
 	exec, err := remotecommand.NewSPDYExecutor(r.RestConfig, "POST", req.URL())
 	if err != nil {
-		return fmt.Errorf("creating SPDY executor for quiesce: %w", err)
+		return fmt.Errorf("creating SPDY executor for %s: %w", verb, err)
 	}
 
 	var stdout, stderr bytes.Buffer
-	if err := exec.StreamWithContext(execCtx, remotecommand.StreamOptions{
+	if err := exec.StreamWithContext(ctx, remotecommand.StreamOptions{
 		Stdout: &stdout,
 		Stderr: &stderr,
 	}); err != nil {
-		return fmt.Errorf("executing quiesce command: %w (stderr: %s)", err, stderr.String())
+		return fmt.Errorf("executing %s command: %w (stderr: %s)", verb, err, stderr.String())
 	}
-
-	output := strings.TrimSpace(stdout.String())
-	log.Info("Quiesce command completed", "pod", pod.Name, "output", output)
 
 	// Aerospike returns "ok" on success. Any other response (including empty) indicates a problem.
-	if output != "ok" {
-		return fmt.Errorf("quiesce returned unexpected response: %q", output)
+	if output := strings.TrimSpace(stdout.String()); output != "ok" {
+		return fmt.Errorf("%s returned unexpected response: %q", verb, output)
 	}
-
 	return nil
 }
 
-// buildQuiesceCommand constructs the asinfo command to quiesce a node.
-// If ACL is enabled, both -U and -P authentication flags are included.
-// Passing -U without -P would cause asinfo to prompt for a password on stdin
-// and hang/fail without a TTY, so the caller must resolve adminPassword from
-// the same Secret used by getPasswordFromSecret. An empty adminPassword with
-// an admin user present results in -U only (preserved for callers that need
-// to inspect the command shape, e.g. tests), but the production caller
-// (quiesceNode) always supplies it.
-func buildQuiesceCommand(cluster *ackov1alpha1.AerospikeCluster, port int, adminPassword string) []string {
+// buildAsinfoCommand constructs an asinfo command for an arbitrary verb (e.g.
+// "quiesce:", "recluster:"). If ACL is enabled, both -U and -P authentication
+// flags are included. Passing -U without -P would cause asinfo to prompt for a
+// password on stdin and hang/fail without a TTY, so the caller must resolve
+// adminPassword from the same Secret used by getPasswordFromSecret. An empty
+// adminPassword with an admin user present results in -U only (preserved for
+// callers that need to inspect the command shape, e.g. tests).
+func buildAsinfoCommand(verb string, cluster *ackov1alpha1.AerospikeCluster, port int, adminPassword string) []string {
 	cmd := []string{
 		"asinfo",
-		"-v", "quiesce:",
+		"-v", verb,
 		"-h", "localhost",
 		"-p", fmt.Sprintf("%d", port),
 	}
@@ -259,4 +286,11 @@ func buildQuiesceCommand(cluster *ackov1alpha1.AerospikeCluster, port int, admin
 	}
 
 	return cmd
+}
+
+// buildQuiesceCommand constructs the asinfo command to quiesce a node.
+// It is a thin wrapper over buildAsinfoCommand for the "quiesce:" verb,
+// retained for callers and tests that reference it by name.
+func buildQuiesceCommand(cluster *ackov1alpha1.AerospikeCluster, port int, adminPassword string) []string {
+	return buildAsinfoCommand("quiesce:", cluster, port, adminPassword)
 }

--- a/internal/controller/aero_client_test.go
+++ b/internal/controller/aero_client_test.go
@@ -244,3 +244,62 @@ func TestBuildQuiesceCommand(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildAsinfoCommand(t *testing.T) {
+	aclCluster := &ackov1alpha1.AerospikeCluster{
+		Spec: ackov1alpha1.AerospikeClusterSpec{
+			AerospikeAccessControl: &ackov1alpha1.AerospikeAccessControlSpec{
+				Users: []ackov1alpha1.AerospikeUserSpec{
+					{Name: "admin", SecretName: "admin-secret", Roles: []string{"sys-admin", "user-admin"}},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		verb     string
+		cluster  *ackov1alpha1.AerospikeCluster
+		port     int
+		password string
+		want     []string
+	}{
+		{
+			name:    "recluster — no ACL",
+			verb:    "recluster:",
+			cluster: &ackov1alpha1.AerospikeCluster{},
+			port:    3000,
+			want:    []string{"asinfo", "-v", "recluster:", "-h", "localhost", "-p", "3000"},
+		},
+		{
+			name:     "recluster — ACL enabled includes auth flags",
+			verb:     "recluster:",
+			cluster:  aclCluster,
+			port:     3000,
+			password: "s3cret",
+			want:     []string{"asinfo", "-v", "recluster:", "-h", "localhost", "-p", "3000", "-U", "admin", "-P", "s3cret"},
+		},
+		{
+			name:    "quiesce verb matches buildQuiesceCommand",
+			verb:    "quiesce:",
+			cluster: &ackov1alpha1.AerospikeCluster{},
+			port:    4000,
+			want:    []string{"asinfo", "-v", "quiesce:", "-h", "localhost", "-p", "4000"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildAsinfoCommand(tc.verb, tc.cluster, tc.port, tc.password)
+			if len(got) != len(tc.want) {
+				t.Fatalf("buildAsinfoCommand() returned %d args, want %d: got %v, want %v",
+					len(got), len(tc.want), got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("buildAsinfoCommand()[%d] = %q, want %q", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}

--- a/internal/controller/reconciler_monitoring.go
+++ b/internal/controller/reconciler_monitoring.go
@@ -94,6 +94,13 @@ func (r *AerospikeClusterReconciler) reconcileMetricsService(
 			if delErr := r.Delete(ctx, existing); delErr != nil && !errors.IsNotFound(delErr) {
 				return delErr
 			}
+			return nil
+		}
+		// A non-NotFound Get error during cleanup must not be swallowed:
+		// otherwise a transient API failure makes the operator report success
+		// while the metrics Service is never deleted, leaking the resource.
+		if !errors.IsNotFound(err) {
+			return fmt.Errorf("getting metrics service %s for cleanup: %w", svcName, err)
 		}
 		return nil
 	}
@@ -164,8 +171,15 @@ func (r *AerospikeClusterReconciler) reconcileServiceMonitor(
 			if delErr := r.Delete(ctx, existing); delErr != nil && !errors.IsNotFound(delErr) {
 				return delErr
 			}
+			return nil
 		}
-		return nil
+		// NotFound or a missing CRD means there is nothing to clean up. Any
+		// other Get error must be surfaced — swallowing it would let a transient
+		// API failure leak a stale ServiceMonitor while reporting success.
+		if errors.IsNotFound(err) || meta.IsNoMatchError(err) {
+			return nil
+		}
+		return fmt.Errorf("getting ServiceMonitor %s for cleanup: %w", smName, err)
 	}
 
 	// CRD not installed — return the error so the caller can decide
@@ -261,8 +275,15 @@ func (r *AerospikeClusterReconciler) reconcilePrometheusRule(
 			if delErr := r.Delete(ctx, existing); delErr != nil && !errors.IsNotFound(delErr) {
 				return delErr
 			}
+			return nil
 		}
-		return nil
+		// NotFound or a missing CRD means there is nothing to clean up. Any
+		// other Get error must be surfaced — swallowing it would let a transient
+		// API failure leak a stale PrometheusRule while reporting success.
+		if errors.IsNotFound(err) || meta.IsNoMatchError(err) {
+			return nil
+		}
+		return fmt.Errorf("getting PrometheusRule %s for cleanup: %w", prName, err)
 	}
 
 	// CRD not installed — return the error so the caller can decide

--- a/internal/controller/reconciler_monitoring_unit_test.go
+++ b/internal/controller/reconciler_monitoring_unit_test.go
@@ -1,14 +1,26 @@
 package controller
 
 import (
+	"context"
+	"errors"
 	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
 )
+
+// errMonitoringGetFailure is a sentinel non-NotFound error used to simulate an
+// API failure during monitoring-resource cleanup.
+var errMonitoringGetFailure = errors.New("simulated API server failure")
 
 func TestToStringMap(t *testing.T) {
 	tests := []struct {
@@ -307,5 +319,42 @@ func TestMetricsServiceNeedsUpdate(t *testing.T) {
 				t.Fatalf("metricsServiceNeedsUpdate() = %v, want %v", got, tc.want)
 			}
 		})
+	}
+}
+
+// TestReconcileMetricsService_CleanupGetErrorNotSwallowed is the regression test
+// for the monitoring cleanup error-masking fix. When monitoring is disabled and
+// the Get for the existing metrics Service fails with a non-NotFound error, the
+// reconcile must surface that error instead of silently returning nil — a
+// swallowed error would leak the Service while reporting success.
+func TestReconcileMetricsService_CleanupGetErrorNotSwallowed(t *testing.T) {
+	scheme := rollingRestartScheme(t)
+
+	cluster := &ackov1alpha1.AerospikeCluster{}
+	cluster.Name = "demo"
+	cluster.Namespace = ctrlTestNamespace
+
+	base := fake.NewClientBuilder().
+		WithScheme(scheme).
+		Build()
+
+	wrapped := interceptor.NewClient(base, interceptor.Funcs{
+		Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey,
+			obj client.Object, opts ...client.GetOption) error {
+			if _, ok := obj.(*corev1.Service); ok {
+				return apierrors.NewInternalError(errMonitoringGetFailure)
+			}
+			return c.Get(ctx, key, obj, opts...)
+		},
+	})
+
+	r := &AerospikeClusterReconciler{Client: wrapped, Scheme: scheme}
+
+	err := r.reconcileMetricsService(context.Background(), cluster, false)
+	if err == nil {
+		t.Fatal("expected error when cleanup Get fails with a non-NotFound error, got nil")
+	}
+	if !strings.Contains(err.Error(), "getting metrics service") {
+		t.Errorf("expected wrapped cleanup Get error, got: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

Three correctness fixes found by analyzing `origin/main`. Each is independent, has test coverage, and changes no CRD/webhook public contract (one fix *adds* a rejection for an already-broken config). No version bumps.

Production code: 3 files, ~114 insertions / 29 deletions. Tests: 3 files.

---

### Fix 1 — Webhook rejects unsupported non-default network ports

**Problem:** A CR setting `aerospikeConfig.network.{service,heartbeat,fabric}.port` to a custom value (e.g. `service.port: 4000`) was accepted by the webhook.

**Root cause:** The operator hard-codes ports 3000/3001/3002 into the Aerospike container's `containerPort` declarations, the asinfo-based liveness/readiness probes, the headless and per-pod Services, and the generated NetworkPolicy/CiliumNetworkPolicy. `validateNetworkPortUniqueness` only checked that each port was a distinct, in-range integer — it never checked the value matched what the operator actually uses. A cluster with a custom port is silently broken: the Aerospike process listens on the custom port but the probes still query the fixed port, so pods never reach Ready and reconciliation stalls with no clear cause.

**Fix:** `validateNetworkPortUniqueness` now rejects any of the three ports that differs from the operator's fixed value, with an actionable admission error. This turns an opaque runtime failure into an immediate, explainable rejection. Not a breaking change — the only CRs newly rejected are ones that were already non-functional.

**Tests:** `TestValidate_NetworkPort_CustomServicePortRejected`, `TestValidate_NetworkPort_CustomHeartbeatAndFabricPortRejected`, `TestValidate_NetworkPort_DefaultPortsAccepted`. (`api/v1alpha1/aerospikecluster_webhook.go`)

---

### Fix 2 — Issue `recluster:` after `quiesce:` so quiesce takes effect

**Problem:** `quiesceNode` (called before a cold restart / pod deletion) sent only the asinfo `quiesce:` command.

**Root cause:** In Aerospike, `quiesce:` only *marks* a node as pending-quiesce. The cluster does not recompute its partition map — and so does not shed the node's master partitions or fail clients over — until a `recluster:` command runs. Without it, the entire quiesce-before-delete step was a no-op for its stated purpose: clients were still routed to the node at the moment its pod was deleted.

**Fix:** `quiesceNode` now sends `recluster:` immediately after a successful `quiesce:`, within the same `quiesceTimeout` budget. `recluster:` is idempotent and may run on any node. Shared exec/asinfo logic extracted into `execAsinfoVerb` + `buildAsinfoCommand`; `buildQuiesceCommand` kept as a thin wrapper.

**Tests:** `TestBuildAsinfoCommand` (covers the `recluster:` verb, with/without ACL auth flags); `TestBuildQuiesceCommand` unchanged and still passing. (`internal/controller/aero_client.go`)

---

### Fix 3 — Do not swallow Get errors during monitoring cleanup

**Problem:** When monitoring (or a sub-feature) is disabled, `reconcileMetricsService` / `reconcileServiceMonitor` / `reconcilePrometheusRule` fetch the existing resource and delete it.

**Root cause:** The cleanup branch only acted when the `Get` returned `nil`; for any non-nil error it fell straight through to `return nil`. A transient API failure on that `Get` made the operator report the monitoring reconcile as successful while the resource was never deleted — a silently leaked metrics Service / ServiceMonitor / PrometheusRule that survives until a later `Get` happens to succeed.

**Fix:** Non-`NotFound` `Get` errors are now surfaced so the reconcile retries with backoff. `NotFound` (nothing to delete) and `IsNoMatchError` (CRD not installed) remain clean no-ops for the unstructured-typed resources.

**Test:** `TestReconcileMetricsService_CleanupGetErrorNotSwallowed`. (`internal/controller/reconciler_monitoring.go`)

---

## Verification

- `go build ./...` — pass
- `go vet ./...` — pass
- `go test ./...` — pass
- `go test -tags integration ./...` (envtest) — pass
- `gofmt -l` — clean for all 6 touched files (a pre-existing `test/e2e/e2e_test.go` formatting issue on `main` is unrelated and left untouched per scope)

## Smoke-test note

Fixes 1 and 2 affect webhook/reconcile behavior and are worth a kind-cluster smoke test:
- Fix 1: apply a CR with a custom `network.service.port` and confirm it is rejected at admission.
- Fix 2: trigger a rolling restart and confirm `quiesce:` is followed by `recluster:` (operator events `NodeQuiesced`, then pod deletion). Fix 3 is internal error-handling and needs no cluster test.