### PR TITLE
fix: maxIgnorablePods=0 clamping, unreachable backoff cap, misleading replication-factor type error

### DIFF
--- a/api/v1alpha1/aerospikecluster_webhook.go
+++ b/api/v1alpha1/aerospikecluster_webhook.go
@@ -1089,6 +1089,14 @@ func (v *AerospikeClusterValidator) validateReplicationFactor(cluster *Aerospike
 				continue
 			}
 			rfInt = int(n)
+		default:
+			// A non-numeric value (most commonly a string from YAML quoting,
+			// e.g. replication-factor: "2") would otherwise fall through with
+			// rfInt=0 and trip the misleading "must be >= 1, got 0" branch
+			// below. Surface the real problem — the wrong type — instead.
+			errors = append(errors, fmt.Sprintf(
+				"namespace %q: replication-factor must be an integer, got %T (%v)", nsName, rf, rf))
+			continue
 		}
 		if rfInt < 1 {
 			errors = append(errors, fmt.Sprintf(

--- a/api/v1alpha1/webhook_test.go
+++ b/api/v1alpha1/webhook_test.go
@@ -2720,6 +2720,42 @@ func TestValidate_ReplicationFactorValidFloat(t *testing.T) {
 	}
 }
 
+// TestValidate_ReplicationFactorStringType verifies that a string-typed
+// replication-factor (the common YAML mistake `replication-factor: "2"`) is
+// rejected with an error that names the real problem — the wrong type — rather
+// than the misleading "must be >= 1, got 0" that the unhandled-type fall-through
+// previously produced.
+func TestValidate_ReplicationFactorStringType(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+	cluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:  3,
+			Image: "aerospike:ce-8.1.1.1",
+			AerospikeConfig: &AerospikeConfigSpec{
+				Value: map[string]any{
+					"namespaces": []any{
+						map[string]any{
+							"name":               "test",
+							"replication-factor": "2",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := v.validate(cluster)
+	if err == nil {
+		t.Fatal("expected error when replication-factor is a string")
+	}
+	if !strings.Contains(err.Error(), "must be an integer") {
+		t.Errorf("error should mention the type mismatch ('must be an integer'), got: %v", err)
+	}
+	if strings.Contains(err.Error(), "got 0") {
+		t.Errorf("error should not report the misleading 'got 0' for a string value, got: %v", err)
+	}
+}
+
 // --- Rack ID validation tests ---
 
 func TestValidate_RackIDZero(t *testing.T) {

--- a/internal/controller/reconciler.go
+++ b/internal/controller/reconciler.go
@@ -516,8 +516,13 @@ func calculateBackoff(failCount int32) time.Duration {
 	if failCount <= 0 {
 		return defaultReconcileRetryInterval
 	}
-	// Cap the exponent to avoid overflow: 2^8 = 256s which is < maxBackoffSeconds (300).
-	exponent := min(failCount, 8)
+	// Cap the exponent at 9 (2^9 = 512s) so the maxBackoffSeconds (300s / 5 min)
+	// cap below is actually reachable. Capping the exponent at 8 (2^8 = 256s)
+	// would keep the result permanently under 300s, making both the
+	// maxBackoffSeconds constant and the clamp dead code and silently lowering
+	// the real maximum backoff to 256s — contrary to this function's documented
+	// 5-minute cap. The exponent cap also still guards against math.Pow overflow.
+	exponent := min(failCount, 9)
 	seconds := math.Pow(2, float64(exponent))
 	if seconds > float64(maxBackoffSeconds) {
 		seconds = float64(maxBackoffSeconds)

--- a/internal/controller/reconciler_circuit_breaker_test.go
+++ b/internal/controller/reconciler_circuit_breaker_test.go
@@ -75,19 +75,19 @@ func TestCalculateBackoff(t *testing.T) {
 			want:      256 * time.Second,
 		},
 		{
-			name:      "9 failures: capped at 2^8 = 256s (exponent capped at 8)",
+			name:      "9 failures: 2^9 = 512s capped at maxBackoffSeconds (300s)",
 			failCount: 9,
-			want:      256 * time.Second,
+			want:      time.Duration(maxBackoffSeconds) * time.Second,
 		},
 		{
-			name:      "10 failures: capped at 2^8 = 256s",
+			name:      "10 failures: capped at maxBackoffSeconds (300s)",
 			failCount: 10,
-			want:      256 * time.Second,
+			want:      time.Duration(maxBackoffSeconds) * time.Second,
 		},
 		{
-			name:      "100 failures: capped at 2^8 = 256s",
+			name:      "100 failures: capped at maxBackoffSeconds (300s)",
 			failCount: 100,
-			want:      256 * time.Second,
+			want:      time.Duration(maxBackoffSeconds) * time.Second,
 		},
 	}
 
@@ -122,6 +122,23 @@ func TestCalculateBackoff_NeverExceedsMax(t *testing.T) {
 		if got > maxDuration {
 			t.Errorf("calculateBackoff(%d) = %v exceeds maxBackoffSeconds (%v)", i, got, maxDuration)
 		}
+	}
+}
+
+// TestCalculateBackoff_ReachesDocumentedMax verifies the documented 5-minute
+// (maxBackoffSeconds) cap is actually reached at a high failure count. A prior
+// implementation capped the exponent at 8 (2^8 = 256s), which kept the result
+// permanently below 300s and made the cap dead code.
+func TestCalculateBackoff_ReachesDocumentedMax(t *testing.T) {
+	maxDuration := time.Duration(maxBackoffSeconds) * time.Second
+	got := calculateBackoff(maxFailedReconciles)
+	if got != maxDuration {
+		t.Errorf("calculateBackoff(%d) = %v, want documented max %v",
+			maxFailedReconciles, got, maxDuration)
+	}
+	// Sustained failures must stay pinned at the documented maximum.
+	if got := calculateBackoff(1000); got != maxDuration {
+		t.Errorf("calculateBackoff(1000) = %v, want %v", got, maxDuration)
 	}
 }
 

--- a/internal/controller/reconciler_restart.go
+++ b/internal/controller/reconciler_restart.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -646,11 +647,43 @@ func (r *AerospikeClusterReconciler) getRollingUpdateBatchSize(cluster *ackov1al
 }
 
 // getMaxIgnorablePods returns the number of pods that can be ignored.
+//
+// Unlike the batch-size fields, maxIgnorablePods has a meaningful zero value:
+// it means "ignore no unhealthy pods" (the strict default), and the webhook
+// explicitly validates maxIgnorablePods with a minimum of 0. resolveIntOrPercent
+// clamps its result to a minimum of 1 (correct for batch sizes, which must move
+// at least one pod), so calling it directly on an explicit 0 / "0%" would
+// silently bump the value to 1 and let the rolling restart skip one unhealthy
+// pod the user explicitly told it not to skip. An explicit zero is therefore
+// resolved to 0 here before delegating to resolveIntOrPercent.
 func (r *AerospikeClusterReconciler) getMaxIgnorablePods(cluster *ackov1alpha1.AerospikeCluster, totalPods int32) int32 {
 	if cluster.Spec.RackConfig != nil && cluster.Spec.RackConfig.MaxIgnorablePods != nil {
-		return resolveIntOrPercent(cluster.Spec.RackConfig.MaxIgnorablePods, totalPods)
+		mip := cluster.Spec.RackConfig.MaxIgnorablePods
+		if isExplicitZeroIntOrPercent(mip) {
+			return 0
+		}
+		return resolveIntOrPercent(mip, totalPods)
 	}
 	return 0
+}
+
+// isExplicitZeroIntOrPercent reports whether an IntOrString represents an
+// explicit zero — either the integer 0 or the percentage "0%". A zero result
+// from a non-zero percentage (e.g. "10%" of a 3-pod cluster rounding down) is
+// NOT treated as explicit zero; only a literally-zero spec value is.
+func isExplicitZeroIntOrPercent(val *intstr.IntOrString) bool {
+	if val == nil {
+		return false
+	}
+	if val.Type == intstr.Int {
+		return val.IntVal == 0
+	}
+	numStr, ok := strings.CutSuffix(val.StrVal, "%")
+	if !ok {
+		return false
+	}
+	n, err := strconv.Atoi(numStr)
+	return err == nil && n == 0
 }
 
 // listRackPods fetches all pods for a specific rack in a single API call,

--- a/internal/controller/reconciler_scaledown_test.go
+++ b/internal/controller/reconciler_scaledown_test.go
@@ -244,3 +244,64 @@ func TestGetMaxIgnorablePods_NilMaxIgnorablePods(t *testing.T) {
 		t.Errorf("getMaxIgnorablePods with nil MaxIgnorablePods = %d, want 0", got)
 	}
 }
+
+// TestGetMaxIgnorablePods_ExplicitZeroInt verifies that an explicit integer 0
+// resolves to 0 ("ignore no unhealthy pods"). resolveIntOrPercent clamps to a
+// minimum of 1, so without special handling an explicit 0 would silently become
+// 1 and let the rolling restart skip one unhealthy pod the user told it not to.
+func TestGetMaxIgnorablePods_ExplicitZeroInt(t *testing.T) {
+	r := &AerospikeClusterReconciler{}
+	maxIgnorable := intstr.FromInt32(0)
+	cluster := &ackov1alpha1.AerospikeCluster{
+		Spec: ackov1alpha1.AerospikeClusterSpec{
+			RackConfig: &ackov1alpha1.RackConfig{
+				MaxIgnorablePods: &maxIgnorable,
+			},
+		},
+	}
+
+	got := r.getMaxIgnorablePods(cluster, 5)
+	if got != 0 {
+		t.Errorf("getMaxIgnorablePods with explicit int 0 = %d, want 0", got)
+	}
+}
+
+// TestGetMaxIgnorablePods_ExplicitZeroPercent verifies that an explicit "0%"
+// resolves to 0 rather than being clamped up to 1.
+func TestGetMaxIgnorablePods_ExplicitZeroPercent(t *testing.T) {
+	r := &AerospikeClusterReconciler{}
+	maxIgnorable := intstr.FromString("0%")
+	cluster := &ackov1alpha1.AerospikeCluster{
+		Spec: ackov1alpha1.AerospikeClusterSpec{
+			RackConfig: &ackov1alpha1.RackConfig{
+				MaxIgnorablePods: &maxIgnorable,
+			},
+		},
+	}
+
+	got := r.getMaxIgnorablePods(cluster, 10)
+	if got != 0 {
+		t.Errorf("getMaxIgnorablePods with explicit \"0%%\" = %d, want 0", got)
+	}
+}
+
+// TestGetMaxIgnorablePods_PercentRoundsDownToZero verifies that a non-zero
+// percentage that rounds down to zero (e.g. "10%" of a 3-pod cluster) is NOT
+// treated as an explicit zero: resolveIntOrPercent's minimum-of-1 clamp still
+// applies so the user's intent ("ignore a small fraction") yields at least 1.
+func TestGetMaxIgnorablePods_PercentRoundsDownToZero(t *testing.T) {
+	r := &AerospikeClusterReconciler{}
+	maxIgnorable := intstr.FromString("10%")
+	cluster := &ackov1alpha1.AerospikeCluster{
+		Spec: ackov1alpha1.AerospikeClusterSpec{
+			RackConfig: &ackov1alpha1.RackConfig{
+				MaxIgnorablePods: &maxIgnorable,
+			},
+		},
+	}
+
+	got := r.getMaxIgnorablePods(cluster, 3)
+	if got != 1 {
+		t.Errorf("getMaxIgnorablePods with \"10%%\" of 3 pods = %d, want 1", got)
+	}
+}


### PR DESCRIPTION
## Summary

Three genuine correctness defects found during an automated review of `internal/controller/` and `api/v1alpha1/`. Each is a small, targeted fix with unit-test coverage. No public API, CRD, or version changes.

---

### Issue 1 — `getMaxIgnorablePods` silently ignores an explicit `0`

**Problem.** Setting `rackConfig.maxIgnorablePods: 0` (or `"0%"`) — the strict "do not skip any unhealthy pod" setting — was silently treated as `1`.

**Root cause.** `getMaxIgnorablePods` delegates to `resolveIntOrPercent`, which clamps its result to a minimum of `1` (correct for batch sizes, which must always move at least one pod). But `maxIgnorablePods` has a meaningful zero value, and the webhook explicitly validates it with `minValue=0`. An explicit `0` therefore became `1`, letting the rolling restart skip one pending/failed pod that the user explicitly told it not to skip.

**Fix.** `getMaxIgnorablePods` now detects an explicit zero (`intstr` int `0` or the percentage string `"0%"`) via the new `isExplicitZeroIntOrPercent` helper and returns `0` directly. A non-zero percentage that merely rounds down to zero (e.g. `"10%"` of a 3-pod cluster) still goes through the minimum-of-1 clamp, preserving the user's intent.

**Test.** `TestGetMaxIgnorablePods_ExplicitZeroInt`, `TestGetMaxIgnorablePods_ExplicitZeroPercent`, `TestGetMaxIgnorablePods_PercentRoundsDownToZero` in `reconciler_scaledown_test.go`.

---

### Issue 2 — `calculateBackoff` never reaches the documented 5-minute cap

**Problem.** The circuit-breaker backoff is documented (and constant-defined, `maxBackoffSeconds = 300`) to cap at 5 minutes, but the real maximum was 256s.

**Root cause.** `exponent := min(failCount, 8)` capped the exponent at 8, so `2^8 = 256s` was the largest value possible. Since `256 < 300`, the `if seconds > maxBackoffSeconds` clamp and the `maxBackoffSeconds` constant were dead code, and the documented "5 min" cap was unreachable.

**Fix.** Cap the exponent at `9` (`2^9 = 512s`), so the `maxBackoffSeconds` clamp actually fires and pins the backoff at the documented 300s for sustained failures. The exponent cap still guards `math.Pow` against overflow.

**Test.** New `TestCalculateBackoff_ReachesDocumentedMax`; updated the `failCount` 9/10/100 cases in `TestCalculateBackoff`.

---

### Issue 3 — Misleading webhook error for a string-typed `replication-factor`

**Problem.** A namespace config with `replication-factor: "2"` (the common YAML-quoting mistake) was rejected with the confusing message `replication-factor must be >= 1, got 0` — the value is neither `0` nor `< 1`.

**Root cause.** `validateReplicationFactor`'s type switch handled `int/int32/int64/float64/json.Number` but had no `default` case. A string value fell through with `rfInt` left at its `0` zero value and tripped the `rfInt < 1` branch, reporting `got 0`.

**Fix.** Added a `default` case that surfaces the actual problem — the wrong type — with `replication-factor must be an integer, got string (2)`. This matches the type-mismatch errors the existing `float64`/`json.Number` cases already produce.

**Test.** `TestValidate_ReplicationFactorStringType` in `webhook_test.go`.

---

## Verification

- `go build ./...` — passes.
- `go vet ./internal/controller/... ./api/v1alpha1/...` — clean.
- `gofmt -l` on touched files — no diff.
- `go test ./...` — all packages pass. The envtest-backed Ginkgo suite is gated behind the `//go:build integration` tag and was not run (envtest binaries not provisioned in this environment); all non-integration unit tests, including the new ones, pass.
- `make lint` (custom golangci-lint v2.8.0 with the `logcheck` plugin) — 0 issues.

## Scope

6 files, ~169 insertions / 9 deletions. No version keys, CRD `apiVersion`, public types, or CLI surface touched. No breaking changes.