### PR TITLE
fix(webhook): enforce array type for prometheusRule.customRules[].rules

### DIFF
--- a/api/v1alpha1/aerospikecluster_webhook.go
+++ b/api/v1alpha1/aerospikecluster_webhook.go
@@ -1468,11 +1468,25 @@ func (v *AerospikeClusterValidator) validateMonitoring(m *AerospikeMonitoringSpe
 				errors = append(errors, fmt.Sprintf("monitoring.prometheusRule.customRules[%d]: invalid JSON: %v", i, err))
 				continue
 			}
-			if _, ok := ruleGroup["name"]; !ok {
+			if name, ok := ruleGroup["name"]; !ok {
 				errors = append(errors, fmt.Sprintf("monitoring.prometheusRule.customRules[%d]: missing required field 'name'", i))
+			} else if nameStr, ok := name.(string); !ok {
+				errors = append(errors, fmt.Sprintf("monitoring.prometheusRule.customRules[%d]: field 'name' must be a string, got %T", i, name))
+			} else if nameStr == "" {
+				errors = append(errors, fmt.Sprintf("monitoring.prometheusRule.customRules[%d]: field 'name' must not be empty", i))
 			}
-			if _, ok := ruleGroup["rules"]; !ok {
+			rules, ok := ruleGroup["rules"]
+			if !ok {
 				errors = append(errors, fmt.Sprintf("monitoring.prometheusRule.customRules[%d]: missing required field 'rules'", i))
+				continue
+			}
+			rulesArr, ok := rules.([]any)
+			if !ok {
+				errors = append(errors, fmt.Sprintf("monitoring.prometheusRule.customRules[%d]: field 'rules' must be a JSON array, got %T", i, rules))
+				continue
+			}
+			if len(rulesArr) == 0 {
+				errors = append(errors, fmt.Sprintf("monitoring.prometheusRule.customRules[%d]: field 'rules' must contain at least one rule", i))
 			}
 		}
 	}

--- a/api/v1alpha1/webhook_test.go
+++ b/api/v1alpha1/webhook_test.go
@@ -2182,6 +2182,93 @@ func TestValidate_CustomRules_MissingBothFields(t *testing.T) {
 	}
 }
 
+func TestValidate_CustomRulesRulesMustBeArray(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+	cluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:  3,
+			Image: "aerospike:ce-8.1.1.1",
+			Monitoring: &AerospikeMonitoringSpec{
+				Enabled:       true,
+				ExporterImage: "exporter:v1",
+				Port:          9145,
+				PrometheusRule: &PrometheusRuleSpec{
+					Enabled: true,
+					CustomRules: []apiextensionsv1.JSON{
+						{Raw: []byte(`{"name":"custom.rules","rules":{}}`)},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := v.validate(cluster)
+	if err == nil {
+		t.Fatal("expected error for custom rule with object-typed 'rules'")
+	}
+	if !strings.Contains(err.Error(), "'rules' must be a JSON array") {
+		t.Errorf("error should mention type mismatch for 'rules', got: %v", err)
+	}
+}
+
+func TestValidate_CustomRulesRulesEmptyArray(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+	cluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:  3,
+			Image: "aerospike:ce-8.1.1.1",
+			Monitoring: &AerospikeMonitoringSpec{
+				Enabled:       true,
+				ExporterImage: "exporter:v1",
+				Port:          9145,
+				PrometheusRule: &PrometheusRuleSpec{
+					Enabled: true,
+					CustomRules: []apiextensionsv1.JSON{
+						{Raw: []byte(`{"name":"custom.rules","rules":[]}`)},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := v.validate(cluster)
+	if err == nil {
+		t.Fatal("expected error for custom rule with empty 'rules' array")
+	}
+	if !strings.Contains(err.Error(), "must contain at least one rule") {
+		t.Errorf("error should mention empty rules array, got: %v", err)
+	}
+}
+
+func TestValidate_CustomRulesNameMustBeString(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+	cluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:  3,
+			Image: "aerospike:ce-8.1.1.1",
+			Monitoring: &AerospikeMonitoringSpec{
+				Enabled:       true,
+				ExporterImage: "exporter:v1",
+				Port:          9145,
+				PrometheusRule: &PrometheusRuleSpec{
+					Enabled: true,
+					CustomRules: []apiextensionsv1.JSON{
+						{Raw: []byte(`{"name":123,"rules":[{"alert":"TestAlert","expr":"up==0"}]}`)},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := v.validate(cluster)
+	if err == nil {
+		t.Fatal("expected error for custom rule with non-string 'name'")
+	}
+	if !strings.Contains(err.Error(), "'name' must be a string") {
+		t.Errorf("error should mention type mismatch for 'name', got: %v", err)
+	}
+}
+
 // --- MetricLabels validation tests ---
 
 func TestValidate_MetricLabels_ValidLabels(t *testing.T) {


### PR DESCRIPTION
## Summary

The `AerospikeMonitoringSpec.PrometheusRule.CustomRules` validator only checked for the **presence** of the `name` and `rules` fields, not their JSON type. A user could submit `"rules": {}` (object), `"rules": "oops"` (string), or `"name": 123` (number) and the webhook would accept the CR. The controller's PrometheusRule renderer in `internal/controller/reconciler_monitoring.go` would then either crash (type assertion / nil-deref) or emit a structurally invalid `PrometheusRule` CR that prometheus-operator's own webhook rejects -- producing a confusing failure mode far downstream from where the user can fix it.

Tighten validation to match what the rendered PrometheusRule spec actually requires.

---

### Issue — `customRules[].rules` was only checked for presence

**Problem.** `validateMonitoring` did:

```go
if _, ok := ruleGroup["rules"]; !ok {
    errors = append(errors, "... missing required field 'rules'")
}
```

So `"rules": {}`, `"rules": "x"`, and `"rules": []` all passed admission. The first two crash the controller at apply; the third produces an empty rule group that downstream rejects.

The `name` field was checked the same way -- `name: 123` cleared the webhook and then broke later.

**Fix.** Replace the existence-only check with existence + type + non-empty checks:

- `rules` must be a JSON array (`[]any`); distinct error messages for missing-field, wrong-type (includes `%T`), and empty-array.
- `name` must be a non-empty string when present; the existing missing-field error is preserved, with two new errors for wrong-type and empty-string.

Errors keep the existing `monitoring.prometheusRule.customRules[%d]: ...` prefix style so multi-error aggregation reads the same as before.

**Tests** (in `api/v1alpha1/webhook_test.go`):

- `TestValidate_CustomRulesRulesMustBeArray` — `"rules": {}` is rejected, message mentions "must be a JSON array".
- `TestValidate_CustomRulesRulesEmptyArray` — `"rules": []` is rejected, message mentions "must contain at least one rule".
- `TestValidate_CustomRulesNameMustBeString` — `"name": 123` is rejected, message mentions "'name' must be a string".

Existing `TestValidate_CustomRules_ValidStructure`, `_MissingName`, `_MissingRules`, `_InvalidJSON`, `_MissingBothFields` are unchanged and still pass.

---

## Verification

- `go build ./...` — passes.
- `go vet ./api/v1alpha1/... ./internal/controller/...` — clean.
- `gofmt -l api/v1alpha1/` — no diff.
- `go test ./api/v1alpha1/... ./internal/controller/... -count=1` — all packages pass, including the 3 new tests. Envtest-backed Ginkgo integration tests skipped (no envtest binaries provisioned).
- `make lint` (custom golangci-lint v2.8.0 with the `logcheck` plugin) — 0 issues.

## Scope

2 files, 103 insertions / 2 deletions. No public types, no CRD `apiVersion` change, no CLI surface touched. This is strictly stricter input validation — input that was previously **silently invalid** is now rejected at the webhook with a clear message. Not a MAJOR change.