### PR TITLE
fix(webhook): reject empty-string role names in ACL users

### DIFF
--- a/api/v1alpha1/aerospikecluster_webhook.go
+++ b/api/v1alpha1/aerospikecluster_webhook.go
@@ -899,7 +899,11 @@ func (v *AerospikeClusterValidator) validateAccessControl(acl *AerospikeAccessCo
 		definedRoles[role.Name] = true
 	}
 	for _, user := range acl.Users {
-		for _, roleName := range user.Roles {
+		for i, roleName := range user.Roles {
+			if roleName == "" {
+				errors = append(errors, fmt.Sprintf("user %q roles[%d]: role name must not be empty", user.Name, i))
+				continue
+			}
 			if !aerospikeCEBuiltinRoles[roleName] && !definedRoles[roleName] {
 				errors = append(errors, fmt.Sprintf("user %q references undefined role %q", user.Name, roleName))
 			}

--- a/api/v1alpha1/webhook_test.go
+++ b/api/v1alpha1/webhook_test.go
@@ -3428,6 +3428,85 @@ func TestValidate_ACLLeadingTrailingWhitespacePrivilegeRejected(t *testing.T) {
 	}
 }
 
+func TestValidate_ACLUserWithEmptyRoleName(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+	cluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:  3,
+			Image: "aerospike:ce-8.1.1.1",
+			AerospikeAccessControl: &AerospikeAccessControlSpec{
+				Users: []AerospikeUserSpec{
+					{
+						Name:       "admin",
+						SecretName: "admin-secret",
+						Roles:      []string{"sys-admin", "user-admin"},
+					},
+					{
+						Name:       "app-user",
+						SecretName: "app-secret",
+						Roles:      []string{"read", ""},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := v.validate(cluster)
+	if err == nil {
+		t.Fatal("expected error for user with empty role name")
+	}
+	if !strings.Contains(err.Error(), "must not be empty") {
+		t.Errorf("expected 'must not be empty' error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), `"app-user"`) {
+		t.Errorf("expected error to name the offending user 'app-user', got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "roles[1]") {
+		t.Errorf("expected error to name the offending index roles[1], got: %v", err)
+	}
+}
+
+func TestValidate_ACLEmptyRoleNameDoesNotAlsoTriggerUndefinedRole(t *testing.T) {
+	// An empty-string role entry should be flagged once as "must not be empty"
+	// and NOT also flagged as "references undefined role" — the continue in the
+	// validator should skip the defined-role check for that entry.
+	v := &AerospikeClusterValidator{}
+	cluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:  3,
+			Image: "aerospike:ce-8.1.1.1",
+			AerospikeAccessControl: &AerospikeAccessControlSpec{
+				Users: []AerospikeUserSpec{
+					{
+						Name:       "admin",
+						SecretName: "admin-secret",
+						Roles:      []string{"sys-admin", "user-admin"},
+					},
+					{
+						Name:       "app-user",
+						SecretName: "app-secret",
+						Roles:      []string{""},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := v.validate(cluster)
+	if err == nil {
+		t.Fatal("expected error for user with empty role name")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "must not be empty") {
+		t.Errorf("expected 'must not be empty' error, got: %v", err)
+	}
+	// The undefined-role check below the empty-string guard should be skipped
+	// via continue, so we must NOT see the undefined-role message for this user.
+	if strings.Contains(msg, `user "app-user" references undefined role ""`) {
+		t.Errorf("empty role name should not also trigger 'references undefined role' for the same entry, got: %v", err)
+	}
+}
+
 // --- Overrides without TemplateRef validation tests ---
 
 func TestValidate_OverridesWithoutTemplateRefRejected(t *testing.T) {


### PR DESCRIPTION
## Summary

`spec.aerospikeAccessControl.users[].roles` entries containing `""` were accepted by the webhook and surfaced as a confusing `user "foo" references undefined role ""` error in the same validate pass. The empty role would then fail downstream when the reconciler called `CreateUser` with it in the array.

Reject empty strings explicitly at admission with a clear message naming the offending index. Mirrors the validation-hardening pattern in #290.

## What changed

- `api/v1alpha1/aerospikecluster_webhook.go`: in `validateAccessControl()` `user.Roles` loop, added an `if roleName == ""` early branch that appends `user %q roles[%d]: role name must not be empty` and `continue`s, so the same entry can't double-fire the existing `references undefined role` message.
- `api/v1alpha1/webhook_test.go`: added 2 tests:
  - `TestValidate_ACLUserWithEmptyRoleName` — asserts the new error message, user name, and index appear
  - `TestValidate_ACLEmptyRoleNameDoesNotAlsoTriggerUndefinedRole` — confirms the `continue` works (no `references undefined role ""` follow-up)

## Verification

- `go build ./...` clean
- `make lint` (golangci-lint v2.8.0): 0 issues
- `make test` (unit + envtest): all packages green, 5/5 ACL tests passing

## Scope

2 files, +84/-1 LOC. PATCH-class (tightens admission validation; rejects only previously-silently-broken input).