### PR TITLE
fix(webhook): reject duplicate containerName in storage volume sidecars/initContainers

### DIFF
--- a/api/v1alpha1/aerospikecluster_webhook.go
+++ b/api/v1alpha1/aerospikecluster_webhook.go
@@ -1389,25 +1389,56 @@ func (v *AerospikeClusterValidator) validateVolume(vol VolumeSpec, index int) ([
 			index, vol.Name))
 	}
 
-	// Validate SubPath and SubPathExpr in sidecar attachments
+	errors = append(errors, validateVolumeAttachments(vol, index)...)
+
+	return errors, warnings
+}
+
+// validateVolumeAttachments validates per-container volume attachments for a
+// single volume: subPath/subPathExpr mutual exclusion and duplicate containerName
+// detection within sidecars, within initContainers, and across the two lists
+// (a Pod cannot have the same container name as both an init and a sidecar/main).
+func validateVolumeAttachments(vol VolumeSpec, index int) []string {
+	var errors []string
+
+	sidecarNames := make(map[string]int, len(vol.Sidecars))
 	for j, sc := range vol.Sidecars {
 		if sc.SubPath != "" && sc.SubPathExpr != "" {
 			errors = append(errors, fmt.Sprintf(
 				"storage.volumes[%d] %q: sidecars[%d] %q subPath and subPathExpr are mutually exclusive",
 				index, vol.Name, j, sc.ContainerName))
 		}
+		if prev, seen := sidecarNames[sc.ContainerName]; seen {
+			errors = append(errors, fmt.Sprintf(
+				"storage.volumes[%d] %q: sidecars[%d] containerName %q duplicates sidecars[%d]",
+				index, vol.Name, j, sc.ContainerName, prev))
+		} else {
+			sidecarNames[sc.ContainerName] = j
+		}
 	}
 
-	// Validate SubPath and SubPathExpr in init container attachments
+	initNames := make(map[string]int, len(vol.InitContainers))
 	for j, ic := range vol.InitContainers {
 		if ic.SubPath != "" && ic.SubPathExpr != "" {
 			errors = append(errors, fmt.Sprintf(
 				"storage.volumes[%d] %q: initContainers[%d] %q subPath and subPathExpr are mutually exclusive",
 				index, vol.Name, j, ic.ContainerName))
 		}
+		if prev, seen := initNames[ic.ContainerName]; seen {
+			errors = append(errors, fmt.Sprintf(
+				"storage.volumes[%d] %q: initContainers[%d] containerName %q duplicates initContainers[%d]",
+				index, vol.Name, j, ic.ContainerName, prev))
+		} else {
+			initNames[ic.ContainerName] = j
+		}
+		if prev, seen := sidecarNames[ic.ContainerName]; seen {
+			errors = append(errors, fmt.Sprintf(
+				"storage.volumes[%d] %q: initContainers[%d] containerName %q duplicates sidecars[%d]",
+				index, vol.Name, j, ic.ContainerName, prev))
+		}
 	}
 
-	return errors, warnings
+	return errors
 }
 
 // aerospikeReservedPorts lists ports used by Aerospike server that must not conflict.

--- a/api/v1alpha1/webhook_test.go
+++ b/api/v1alpha1/webhook_test.go
@@ -1233,6 +1233,104 @@ func TestValidate_Storage_SubPathAndSubPathExprMutuallyExclusive_InitContainer(t
 	}
 }
 
+func TestValidate_Storage_DuplicateContainerName_Sidecars(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+	cluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:  3,
+			Image: "aerospike:ce-8.1.1.1",
+			Storage: &AerospikeStorageSpec{
+				Volumes: []VolumeSpec{
+					{
+						Name: "data",
+						Source: VolumeSource{
+							EmptyDir: &corev1.EmptyDirVolumeSource{},
+						},
+						Sidecars: []VolumeAttachment{
+							{ContainerName: "exporter", Path: "/data"},
+							{ContainerName: "exporter", Path: "/data2"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := v.validate(cluster)
+	if err == nil {
+		t.Fatal("expected error for duplicate containerName in sidecars")
+	}
+	if !strings.Contains(err.Error(), "sidecars[1] containerName \"exporter\" duplicates sidecars[0]") {
+		t.Errorf("error should mention duplicate sidecars containerName, got: %v", err)
+	}
+}
+
+func TestValidate_Storage_DuplicateContainerName_InitContainers(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+	cluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:  3,
+			Image: "aerospike:ce-8.1.1.1",
+			Storage: &AerospikeStorageSpec{
+				Volumes: []VolumeSpec{
+					{
+						Name: "data",
+						Source: VolumeSource{
+							EmptyDir: &corev1.EmptyDirVolumeSource{},
+						},
+						InitContainers: []VolumeAttachment{
+							{ContainerName: "init", Path: "/data"},
+							{ContainerName: "init", Path: "/data2"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := v.validate(cluster)
+	if err == nil {
+		t.Fatal("expected error for duplicate containerName in initContainers")
+	}
+	if !strings.Contains(err.Error(), "initContainers[1] containerName \"init\" duplicates initContainers[0]") {
+		t.Errorf("error should mention duplicate initContainers containerName, got: %v", err)
+	}
+}
+
+func TestValidate_Storage_DuplicateContainerName_SidecarVsInitContainer(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+	cluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:  3,
+			Image: "aerospike:ce-8.1.1.1",
+			Storage: &AerospikeStorageSpec{
+				Volumes: []VolumeSpec{
+					{
+						Name: "data",
+						Source: VolumeSource{
+							EmptyDir: &corev1.EmptyDirVolumeSource{},
+						},
+						Sidecars: []VolumeAttachment{
+							{ContainerName: "shared", Path: "/data"},
+						},
+						InitContainers: []VolumeAttachment{
+							{ContainerName: "shared", Path: "/data"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := v.validate(cluster)
+	if err == nil {
+		t.Fatal("expected error when sidecars and initContainers share a containerName")
+	}
+	if !strings.Contains(err.Error(), "initContainers[0] containerName \"shared\" duplicates sidecars[0]") {
+		t.Errorf("error should mention sidecars/initContainers cross duplicate, got: %v", err)
+	}
+}
+
 func TestValidate_Storage_DeleteLocalStorageWithoutClasses(t *testing.T) {
 	v := &AerospikeClusterValidator{}
 	cluster := &AerospikeCluster{


### PR DESCRIPTION
## Summary

`spec.storage.volumes[].sidecars[]` and `.initContainers[]` accepted duplicate `containerName` entries. Two ways this silently went wrong:

1. Two `sidecars[]` entries with the same `containerName` would generate duplicate `VolumeMount`s on that container (the same volume mounted twice into the same container).
2. The same `containerName` appearing in both `sidecars[]` and `initContainers[]` is rejected by K8s at Pod creation time (container names must be unique per Pod), so the operator would create an `AerospikeCluster` that could never produce a runnable Pod.

Both classes now reject at admission with a precise, index-naming error. Mirrors the validation-hardening pattern in #290 / #291.

## What changed

- `api/v1alpha1/aerospikecluster_webhook.go`:
  - Extracted the per-attachment validation loop out of `validateVolume` into a new helper `validateVolumeAttachments(vol, index)`. This keeps the subPath/subPathExpr mutual-exclusion check intact and adds the new duplicate-`containerName` checks (within `sidecars[]`, within `initContainers[]`, and across the two lists). Extraction was also needed to keep `validateVolume` below the `gocyclo` 30 threshold.
- `api/v1alpha1/webhook_test.go`: added 3 tests covering each duplicate class:
  - `TestValidate_Storage_DuplicateContainerName_Sidecars`
  - `TestValidate_Storage_DuplicateContainerName_InitContainers`
  - `TestValidate_Storage_DuplicateContainerName_SidecarVsInitContainer`

## ACL retry note (initially scoped to this PR)

The original task scope also considered adding transient-error retry around `ChangePassword` in `internal/controller/reconciler_acl.go`. Inspection showed it is already covered: `reconcileUsers` (which calls `ChangePassword`) is wrapped in `retryOnTransientWithReconnect` at `reconciler_acl.go:101`, mirroring the existing `reconcileRoles` retry. No change needed — kept the PR focused on the webhook fix.

## Verification

- `go build ./...` clean
- `make lint` (golangci-lint v2.8.0): 0 issues
- `make test-unit`: all packages green
- `make test-integration` (envtest, K8s 1.35): all packages green
- `go test ./api/v1alpha1/... -run TestValidate_Storage -v`: 18/18 storage validation tests pass (15 existing + 3 new)

## Scope

2 files, +132/-3 LOC. PATCH-class — tightens admission validation; rejects only previously-silently-broken input. No CRD apiVersion / public contract change.
