### PR TITLE
fix(webhook): validate PodSpec container names + ACL role name

### DIFF
--- a/api/v1alpha1/aerospikecluster_webhook.go
+++ b/api/v1alpha1/aerospikecluster_webhook.go
@@ -487,6 +487,11 @@ func (v *AerospikeClusterValidator) validate(cluster *AerospikeCluster) (admissi
 		}
 	}
 
+	// Validate podSpec.sidecars[] and podSpec.initContainers[] container names.
+	if cluster.Spec.PodSpec != nil {
+		allErrors = append(allErrors, validatePodSpecContainerNames(cluster.Spec.PodSpec)...)
+	}
+
 	// Validate rack config
 	if cluster.Spec.RackConfig != nil {
 		rackErrors := v.validateRackConfig(cluster.Spec.RackConfig)
@@ -886,7 +891,11 @@ func (v *AerospikeClusterValidator) validateAccessControl(acl *AerospikeAccessCo
 
 	// Check for duplicate role names
 	seenRoles := make(map[string]bool)
-	for _, role := range acl.Roles {
+	for i, role := range acl.Roles {
+		if role.Name == "" {
+			errors = append(errors, fmt.Sprintf("accessControl.roles[%d]: role name must not be empty", i))
+			continue
+		}
 		if seenRoles[role.Name] {
 			errors = append(errors, fmt.Sprintf("accessControl.roles: duplicate role name %q", role.Name))
 		}
@@ -1435,6 +1444,65 @@ func validateVolumeAttachments(vol VolumeSpec, index int) []string {
 			errors = append(errors, fmt.Sprintf(
 				"storage.volumes[%d] %q: initContainers[%d] containerName %q duplicates sidecars[%d]",
 				index, vol.Name, j, ic.ContainerName, prev))
+		}
+	}
+
+	return errors
+}
+
+// builtinPodContainerNames lists container names reserved by the operator that
+// users must not reuse for sidecars or extra init containers. The main server
+// container name is sourced from the canonical AerospikeContainerName constant
+// (api/v1alpha1/constants.go); the init container name is hard-coded here to
+// mirror internal/podutil.InitContainerName without introducing an api ->
+// internal import cycle. Keep these two strings in sync with podutil.
+var builtinPodContainerNames = map[string]bool{
+	AerospikeContainerName: true, // "aerospike-server"
+	"aerospike-init":       true, // mirrors internal/podutil.InitContainerName
+}
+
+// validatePodSpecContainerNames rejects user-supplied sidecar / extra init
+// container names that conflict with another user entry or with the operator's
+// built-in containers. Kubernetes itself rejects Pods that share a name across
+// containers / initContainers, so surfacing this at admission time gives a
+// faster, clearer error than waiting for the StatefulSet to fail.
+func validatePodSpecContainerNames(podSpec *AerospikePodSpec) []string {
+	var errors []string
+
+	sidecarNames := make(map[string]int, len(podSpec.Sidecars))
+	for i, sc := range podSpec.Sidecars {
+		if builtinPodContainerNames[sc.Name] {
+			errors = append(errors, fmt.Sprintf(
+				"spec.podSpec.sidecars[%d] name %q conflicts with operator built-in container name",
+				i, sc.Name))
+		}
+		if prev, seen := sidecarNames[sc.Name]; seen {
+			errors = append(errors, fmt.Sprintf(
+				"spec.podSpec.sidecars[%d] name %q duplicates sidecars[%d]",
+				i, sc.Name, prev))
+		} else {
+			sidecarNames[sc.Name] = i
+		}
+	}
+
+	initNames := make(map[string]int, len(podSpec.InitContainers))
+	for i, ic := range podSpec.InitContainers {
+		if builtinPodContainerNames[ic.Name] {
+			errors = append(errors, fmt.Sprintf(
+				"spec.podSpec.initContainers[%d] name %q conflicts with operator built-in container name",
+				i, ic.Name))
+		}
+		if prev, seen := initNames[ic.Name]; seen {
+			errors = append(errors, fmt.Sprintf(
+				"spec.podSpec.initContainers[%d] name %q duplicates initContainers[%d]",
+				i, ic.Name, prev))
+		} else {
+			initNames[ic.Name] = i
+		}
+		if prev, seen := sidecarNames[ic.Name]; seen {
+			errors = append(errors, fmt.Sprintf(
+				"spec.podSpec.initContainers[%d] name %q duplicates sidecars[%d]",
+				i, ic.Name, prev))
 		}
 	}
 

--- a/api/v1alpha1/aerospikecluster_webhook.go
+++ b/api/v1alpha1/aerospikecluster_webhook.go
@@ -1475,6 +1475,7 @@ func validatePodSpecContainerNames(podSpec *AerospikePodSpec) []string {
 			errors = append(errors, fmt.Sprintf(
 				"spec.podSpec.sidecars[%d] name %q conflicts with operator built-in container name",
 				i, sc.Name))
+			continue
 		}
 		if prev, seen := sidecarNames[sc.Name]; seen {
 			errors = append(errors, fmt.Sprintf(
@@ -1491,6 +1492,7 @@ func validatePodSpecContainerNames(podSpec *AerospikePodSpec) []string {
 			errors = append(errors, fmt.Sprintf(
 				"spec.podSpec.initContainers[%d] name %q conflicts with operator built-in container name",
 				i, ic.Name))
+			continue
 		}
 		if prev, seen := initNames[ic.Name]; seen {
 			errors = append(errors, fmt.Sprintf(

--- a/api/v1alpha1/webhook_test.go
+++ b/api/v1alpha1/webhook_test.go
@@ -1475,6 +1475,58 @@ func TestValidate_PodSpec_InitContainerConflictWithBuiltinContainer(t *testing.T
 	}
 }
 
+func TestValidate_PodSpec_BuiltinConflictSuppressesDuplicateError(t *testing.T) {
+	cases := []struct {
+		name        string
+		podSpec     *AerospikePodSpec
+		conflictMsg string
+	}{
+		{
+			name: "sidecars both aerospike-server",
+			podSpec: &AerospikePodSpec{
+				Sidecars: []corev1.Container{
+					{Name: "aerospike-server", Image: "user:v1"},
+					{Name: "aerospike-server", Image: "user:v2"},
+				},
+			},
+			conflictMsg: `spec.podSpec.sidecars[0] name "aerospike-server" conflicts with operator built-in container name`,
+		},
+		{
+			name: "initContainers both aerospike-init",
+			podSpec: &AerospikePodSpec{
+				InitContainers: []corev1.Container{
+					{Name: "aerospike-init", Image: "user:v1"},
+					{Name: "aerospike-init", Image: "user:v2"},
+				},
+			},
+			conflictMsg: `spec.podSpec.initContainers[0] name "aerospike-init" conflicts with operator built-in container name`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			v := &AerospikeClusterValidator{}
+			cluster := &AerospikeCluster{
+				Spec: AerospikeClusterSpec{
+					Size:    3,
+					Image:   "aerospike:ce-8.1.1.1",
+					PodSpec: tc.podSpec,
+				},
+			}
+
+			_, err := v.validate(cluster)
+			if err == nil {
+				t.Fatal("expected built-in conflict error")
+			}
+			if !strings.Contains(err.Error(), tc.conflictMsg) {
+				t.Errorf("error should mention built-in conflict, got: %v", err)
+			}
+			if got := strings.Count(err.Error(), "duplicates"); got != 0 {
+				t.Errorf("expected no duplicate-name errors when built-in conflict fires, got %d in: %v", got, err)
+			}
+		})
+	}
+}
+
 func TestValidate_Storage_DeleteLocalStorageWithoutClasses(t *testing.T) {
 	v := &AerospikeClusterValidator{}
 	cluster := &AerospikeCluster{

--- a/api/v1alpha1/webhook_test.go
+++ b/api/v1alpha1/webhook_test.go
@@ -1331,6 +1331,150 @@ func TestValidate_Storage_DuplicateContainerName_SidecarVsInitContainer(t *testi
 	}
 }
 
+// --- PodSpec sidecar / initContainer name validation tests ---
+
+func TestValidate_PodSpec_DuplicateContainerName_Sidecars(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+	cluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:  3,
+			Image: "aerospike:ce-8.1.1.1",
+			PodSpec: &AerospikePodSpec{
+				Sidecars: []corev1.Container{
+					{Name: "exporter", Image: "exporter:v1"},
+					{Name: "exporter", Image: "exporter:v2"},
+				},
+			},
+		},
+	}
+
+	_, err := v.validate(cluster)
+	if err == nil {
+		t.Fatal("expected error for duplicate container name in podSpec.sidecars")
+	}
+	if !strings.Contains(err.Error(), `spec.podSpec.sidecars[1] name "exporter" duplicates sidecars[0]`) {
+		t.Errorf("error should mention duplicate sidecars name, got: %v", err)
+	}
+}
+
+func TestValidate_PodSpec_DuplicateContainerName_InitContainers(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+	cluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:  3,
+			Image: "aerospike:ce-8.1.1.1",
+			PodSpec: &AerospikePodSpec{
+				InitContainers: []corev1.Container{
+					{Name: "warmup", Image: "warmup:v1"},
+					{Name: "warmup", Image: "warmup:v2"},
+				},
+			},
+		},
+	}
+
+	_, err := v.validate(cluster)
+	if err == nil {
+		t.Fatal("expected error for duplicate container name in podSpec.initContainers")
+	}
+	if !strings.Contains(err.Error(), `spec.podSpec.initContainers[1] name "warmup" duplicates initContainers[0]`) {
+		t.Errorf("error should mention duplicate initContainers name, got: %v", err)
+	}
+}
+
+func TestValidate_PodSpec_DuplicateContainerName_SidecarVsInitContainer(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+	cluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:  3,
+			Image: "aerospike:ce-8.1.1.1",
+			PodSpec: &AerospikePodSpec{
+				Sidecars: []corev1.Container{
+					{Name: "shared", Image: "side:v1"},
+				},
+				InitContainers: []corev1.Container{
+					{Name: "shared", Image: "init:v1"},
+				},
+			},
+		},
+	}
+
+	_, err := v.validate(cluster)
+	if err == nil {
+		t.Fatal("expected error when podSpec sidecars and initContainers share a name")
+	}
+	if !strings.Contains(err.Error(), `spec.podSpec.initContainers[0] name "shared" duplicates sidecars[0]`) {
+		t.Errorf("error should mention cross sidecars/initContainers duplicate, got: %v", err)
+	}
+}
+
+func TestValidate_PodSpec_SidecarConflictWithBuiltinContainer(t *testing.T) {
+	cases := []struct {
+		builtinName string
+	}{
+		{"aerospike-server"},
+		{"aerospike-init"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.builtinName, func(t *testing.T) {
+			v := &AerospikeClusterValidator{}
+			cluster := &AerospikeCluster{
+				Spec: AerospikeClusterSpec{
+					Size:  3,
+					Image: "aerospike:ce-8.1.1.1",
+					PodSpec: &AerospikePodSpec{
+						Sidecars: []corev1.Container{
+							{Name: tc.builtinName, Image: "user:v1"},
+						},
+					},
+				},
+			}
+
+			_, err := v.validate(cluster)
+			if err == nil {
+				t.Fatalf("expected error when sidecar name %q collides with built-in container", tc.builtinName)
+			}
+			want := fmt.Sprintf(`spec.podSpec.sidecars[0] name %q conflicts with operator built-in container name`, tc.builtinName)
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("error should mention built-in conflict, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidate_PodSpec_InitContainerConflictWithBuiltinContainer(t *testing.T) {
+	cases := []struct {
+		builtinName string
+	}{
+		{"aerospike-server"},
+		{"aerospike-init"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.builtinName, func(t *testing.T) {
+			v := &AerospikeClusterValidator{}
+			cluster := &AerospikeCluster{
+				Spec: AerospikeClusterSpec{
+					Size:  3,
+					Image: "aerospike:ce-8.1.1.1",
+					PodSpec: &AerospikePodSpec{
+						InitContainers: []corev1.Container{
+							{Name: tc.builtinName, Image: "user:v1"},
+						},
+					},
+				},
+			}
+
+			_, err := v.validate(cluster)
+			if err == nil {
+				t.Fatalf("expected error when initContainer name %q collides with built-in container", tc.builtinName)
+			}
+			want := fmt.Sprintf(`spec.podSpec.initContainers[0] name %q conflicts with operator built-in container name`, tc.builtinName)
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("error should mention built-in conflict, got: %v", err)
+			}
+		})
+	}
+}
+
 func TestValidate_Storage_DeleteLocalStorageWithoutClasses(t *testing.T) {
 	v := &AerospikeClusterValidator{}
 	cluster := &AerospikeCluster{
@@ -3912,6 +4056,49 @@ func TestValidate_DuplicateRoleNames(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "duplicate role name") {
 		t.Errorf("error should mention 'duplicate role name', got: %v", err)
+	}
+}
+
+func TestValidate_AccessControl_EmptyRoleName(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+	cluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:  3,
+			Image: "aerospike:ce-8.1.1.1",
+			AerospikeAccessControl: &AerospikeAccessControlSpec{
+				Users: []AerospikeUserSpec{
+					{
+						Name:       "admin",
+						SecretName: "admin-secret",
+						Roles:      []string{"sys-admin", "user-admin"},
+					},
+				},
+				Roles: []AerospikeRoleSpec{
+					{
+						Name:       "custom-role",
+						Privileges: []string{"read"},
+					},
+					{
+						Name:       "",
+						Privileges: []string{"write"},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := v.validate(cluster)
+	if err == nil {
+		t.Fatal("expected error for empty role name in accessControl.roles")
+	}
+	if !strings.Contains(err.Error(), "accessControl.roles[1]: role name must not be empty") {
+		t.Errorf("error should mention 'accessControl.roles[1]: role name must not be empty', got: %v", err)
+	}
+	// Empty entry must be skipped (via continue) so it does not collide with a
+	// later empty entry as a "duplicate role name" — there is no defined empty
+	// role on the cluster.
+	if strings.Contains(err.Error(), `duplicate role name ""`) {
+		t.Errorf("empty role name should not also trigger 'duplicate role name', got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Close two webhook validation gaps in `api/v1alpha1/aerospikecluster_webhook.go` by mirroring the established patterns from #291 (empty-string ACL field rejection) and #292 (containerName uniqueness in storage volume attachments).

## Bugs being fixed

### 1. `podSpec.sidecars[]` / `podSpec.initContainers[]` (P0/P1)

Today, `validate()` only inspects `podSpec.HostNetwork` / `podSpec.MultiPodPerHost`. The sidecar and init-container lists are passed through to the StatefulSet untouched. This leaks three classes of bug to pod admission time:

- Two sidecars with the same `name` — K8s rejects the Pod with a generic duplicate-container error, surfaced only via `kubectl describe rs` on a child StatefulSet, with no link back to the offending CR field.
- Two extra init containers with the same `name` — same problem.
- A user sidecar / init container named `aerospike-server` or `aerospike-init` — collides with the operator's built-in containers. Either the user spec silently overrides the operator (volume mounts / env / lifecycle hooks vanish) or the apiserver rejects the StatefulSet with no CR context.

The new `validatePodSpecContainerNames` helper rejects all three at CR admission with messages anchored to the offending list index:

```
spec.podSpec.sidecars[1] name "exporter" duplicates sidecars[0]
spec.podSpec.initContainers[0] name "shared" duplicates sidecars[0]
spec.podSpec.sidecars[0] name "aerospike-server" conflicts with operator built-in container name
```

### 2. `accessControl.roles[i].Name == ""` (P1)

#291 added an empty-string guard for `user.Roles[i]` (user-side references). The role *definition* path was still unguarded:

```yaml
accessControl:
  roles:
    - name: ""          # silently registered as "" in definedRoles
      privileges: [read]
```

Result before this PR: `""` becomes a "defined" role, so a typo'd user reference to `""` later in the spec would pass the "references undefined role" check. With this PR, the definition is rejected up front:

```
accessControl.roles[1]: role name must not be empty
```

The new guard `continue`s past the duplicate-detection step so an empty entry is reported exactly once.

## Implementation details

- `validatePodSpecContainerNames(podSpec *AerospikePodSpec) []string` lives next to `validateVolumeAttachments` (same `map[string]int` pattern as #292).
- `builtinPodContainerNames` is a small package-level map: `AerospikeContainerName` is sourced from the canonical constant in `api/v1alpha1/constants.go`; `"aerospike-init"` is hard-coded with a comment pointing at `internal/podutil.InitContainerName` (importing `internal/podutil` from `api/v1alpha1` would invert the existing dependency direction — `podutil` already aliases the api constants).
- ACL role empty check is index-anchored (`accessControl.roles[%d]`) to match #291's style.

## Tests added (6 funcs / 8 sub-cases in `api/v1alpha1/webhook_test.go`)

| Test | Asserts |
|------|---------|
| `TestValidate_PodSpec_DuplicateContainerName_Sidecars` | within-list sidecars duplicate |
| `TestValidate_PodSpec_DuplicateContainerName_InitContainers` | within-list init duplicate |
| `TestValidate_PodSpec_DuplicateContainerName_SidecarVsInitContainer` | cross-list duplicate |
| `TestValidate_PodSpec_SidecarConflictWithBuiltinContainer` | table-driven: `aerospike-server`, `aerospike-init` |
| `TestValidate_PodSpec_InitContainerConflictWithBuiltinContainer` | table-driven: same two names |
| `TestValidate_AccessControl_EmptyRoleName` | empty role.Name rejected + does NOT also fire `duplicate role name ""` |

## Verification

```
$ go test ./api/v1alpha1/... -run 'TestValidate' -v        # all PASS, incl. existing ACL + storage tests
$ go test ./api/... ./internal/...                          # all PASS
$ ./bin/golangci-lint run ./...                             # 0 issues
$ gofmt -l api/v1alpha1/aerospikecluster_webhook.go api/v1alpha1/webhook_test.go   # clean
```

(`gofmt -l .` flags `test/e2e/e2e_test.go` — pre-existing on main, untouched by this PR.)

## Scope / non-goals

- Webhook-only. No reconciler / controller / CRD changes.
- No version manifests touched.
- The optional `user.Name == ""` check was skipped: adding it would interact with the existing `seenUsers[user.Name]` duplicate map (two empty-name users would also produce a misleading `duplicate user name ""`) and warrants its own focused PR.

Refs: #291, #292