### PR TITLE
fix: restore kustomize image placeholder

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -43,7 +43,7 @@ spec:
         args:
           - --leader-elect
           - --health-probe-bind-address=:8081
-        image: ghcr.io/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator:1.3.1
+        image: controller:latest
         imagePullPolicy: IfNotPresent
         name: manager
         ports: []


### PR DESCRIPTION
## Summary
- Restore the manager deployment image to the Kubebuilder controller placeholder.
- This lets kustomize edit set image controller=... and IMG=... deployment flows override the rendered image again.

## Testing
- tmp=$(mktemp -d); cp -R config "$tmp/config"; (cd "$tmp/config/manager" && go run sigs.k8s.io/kustomize/kustomize/v5@v5.8.1 edit set image controller=example.com/acko:test); go run sigs.k8s.io/kustomize/kustomize/v5@v5.8.1 build "$tmp/config/default" | rg 'image: example.com/acko:test'