### PR TITLE
fix: report ConfigDegraded phase metrics

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,6 @@ on:
     paths-ignore:
       - '**/*.md'
       - 'docs/**'
-      - 'charts/**'
       - 'config/samples/**'
       - 'tokei.toml'
       - '.tokeignore'
@@ -19,7 +18,6 @@ on:
     paths-ignore:
       - '**/*.md'
       - 'docs/**'
-      - 'charts/**'
       - 'config/samples/**'
       - 'tokei.toml'
       - '.tokeignore'

--- a/internal/controller/reconciler_circuit_breaker_test.go
+++ b/internal/controller/reconciler_circuit_breaker_test.go
@@ -555,6 +555,61 @@ func TestBackoffActivePhaseUpdatesMetric(t *testing.T) {
 	}
 }
 
+func TestConfigDegradedPhaseUpdatesMetric(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := ackov1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme() error = %v", err)
+	}
+
+	stored := &ackov1alpha1.AerospikeCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "config-degraded-demo",
+			Namespace: "default",
+		},
+		Status: ackov1alpha1.AerospikeClusterStatus{
+			Phase:       ackov1alpha1.AerospikePhaseInProgress,
+			PhaseReason: "Reconciliation started",
+		},
+	}
+
+	reconciler := &AerospikeClusterReconciler{
+		Client: fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithStatusSubresource(&ackov1alpha1.AerospikeCluster{}).
+			WithObjects(stored).
+			Build(),
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+	}
+
+	metrics.ClusterPhase.WithLabelValues(stored.Namespace, stored.Name).
+		Set(metrics.PhaseToFloat(string(ackov1alpha1.AerospikePhaseInProgress)))
+	t.Cleanup(func() {
+		metrics.ClusterPhase.DeleteLabelValues(stored.Namespace, stored.Name)
+	})
+
+	reconciler.setConfigDegraded(context.Background(), stored, []string{"pod-0"})
+
+	updated := &ackov1alpha1.AerospikeCluster{}
+	if err := reconciler.Get(
+		context.Background(),
+		types.NamespacedName{Name: stored.Name, Namespace: stored.Namespace},
+		updated,
+	); err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if updated.Status.Phase != ackov1alpha1.AerospikePhaseConfigDegraded {
+		t.Fatalf("Phase = %q, want %q", updated.Status.Phase, ackov1alpha1.AerospikePhaseConfigDegraded)
+	}
+
+	gotGauge := testutil.ToFloat64(metrics.ClusterPhase.WithLabelValues(stored.Namespace, stored.Name))
+	wantGauge := metrics.PhaseToFloat(string(ackov1alpha1.AerospikePhaseConfigDegraded))
+	if gotGauge != wantGauge {
+		t.Errorf("acko_cluster_phase = %v, want %v (ConfigDegraded); setConfigDegraded must update the gauge",
+			gotGauge, wantGauge)
+	}
+}
+
 func TestCircuitBreakerResetClearsReconcileHealthyCondition(t *testing.T) {
 	cluster := &ackov1alpha1.AerospikeCluster{
 		ObjectMeta: metav1.ObjectMeta{Generation: 3},

--- a/internal/controller/reconciler_status.go
+++ b/internal/controller/reconciler_status.go
@@ -773,6 +773,8 @@ func (r *AerospikeClusterReconciler) setConfigDegraded(
 		log.Error(err, "Failed to set ConfigDegraded status")
 		return
 	}
+	metrics.ClusterPhase.WithLabelValues(latest.Namespace, latest.Name).
+		Set(metrics.PhaseToFloat(string(ackov1alpha1.AerospikePhaseConfigDegraded)))
 
 	r.Recorder.Eventf(cluster, corev1.EventTypeWarning, EventDynamicConfigDegraded,
 		"Cluster entered ConfigDegraded phase: rollback failed on pods %s", strings.Join(failedPods, ", "))

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -196,6 +196,8 @@ func PhaseToFloat(phase string) float64 {
 		return 10
 	case "BackoffActive":
 		return 11
+	case "ConfigDegraded":
+		return 12
 	default:
 		return 0
 	}

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -23,6 +23,7 @@ func TestPhaseToFloat(t *testing.T) {
 		{"Paused", 9},
 		{"Deleting", 10},
 		{"BackoffActive", 11},
+		{"ConfigDegraded", 12},
 		{"", 0},
 		{"Unknown", 0},
 	}


### PR DESCRIPTION
## Summary
- map ConfigDegraded into the exported cluster phase metric value set
- update the ConfigDegraded status patch path to set acko_cluster_phase immediately
- keep Helm lint active for chart-only PR changes

## Testing
- git diff --check
- go test $(go list ./... | grep -v /test/e2e)
- helm lint charts/aerospike-ce-kubernetes-operator-crds
- helm lint charts/aerospike-ce-kubernetes-operator --set crds.install=false