### PR TITLE
docs: fix CRD chart URL in Helm notes

### DIFF
--- a/charts/aerospike-ce-kubernetes-operator/templates/NOTES.txt
+++ b/charts/aerospike-ce-kubernetes-operator/templates/NOTES.txt
@@ -95,7 +95,7 @@ in project-hub for `acko-realm.json`).
 
 NOTE: CRD installation is disabled (crds.install=false).
 Ensure acko-crds is installed separately before creating AerospikeCluster resources:
-  helm install acko-crds oci://ghcr.io/aerospike-ce-ecosystem/charts/acko-crds --version {{ .Chart.Version }}
+  helm install acko-crds oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kubernetes-operator-crds --version {{ .Chart.Version }}
 {{- end }}
 
 NOTE: The embedded PostgreSQL *sidecar* has been REMOVED. The api now runs on


### PR DESCRIPTION
## Summary
- Correct the CRD chart URL printed by Helm NOTES when crds.install=false.
- Keeps the release name example as acko-crds while pointing to the actual aerospike-ce-kubernetes-operator-crds OCI chart.

## Testing
- helm install acko charts/aerospike-ce-kubernetes-operator --namespace aerospike-operator --create-namespace --set crds.install=false --dry-run --debug
- helm lint charts/aerospike-ce-kubernetes-operator