### PR TITLE
fix(chart): default ui.imageTag to "latest" so installs track ACM releases

### DIFF
--- a/charts/aerospike-ce-kubernetes-operator/README.md
+++ b/charts/aerospike-ce-kubernetes-operator/README.md
@@ -414,7 +414,7 @@ You can customize the UI with per-component image, service, resource, and enviro
 helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kubernetes-operator \
   --version 1.3.1 \
   --namespace aerospike-operator --create-namespace \
-  --set ui.imageTag=0.24.0 \
+  --set ui.imageTag=0.30.0 \
   --set ui.api.image.repository=ghcr.io/aerospike-ce-ecosystem/aerospike-cluster-manager-api \
   --set ui.web.image.repository=ghcr.io/aerospike-ce-ecosystem/aerospike-cluster-manager-web \
   --set ui.web.service.type=LoadBalancer \

--- a/charts/aerospike-ce-kubernetes-operator/templates/_helpers.tpl
+++ b/charts/aerospike-ce-kubernetes-operator/templates/_helpers.tpl
@@ -270,11 +270,13 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 UI image helpers (per-component).
 Tag resolution order:
   1. ui.api.image.tag / ui.web.image.tag (per-component override)
-  2. ui.imageTag (shared cluster-manager release, pinned in values.yaml)
+  2. ui.imageTag (shared cluster-manager release; defaults to "latest")
   3. .Chart.AppVersion (last resort)
 aerospike-cluster-manager is versioned independently from the operator, so
 falling straight through to .Chart.AppVersion can resolve to a tag that
-does not exist in ghcr.io. ui.imageTag is the intended default knob.
+does not exist in ghcr.io. ui.imageTag is the intended default knob and
+ships as "latest" so the chart tracks ACM releases without an ACKO bump;
+pullPolicy defaults to Always to match.
 */}}
 {{- define "aerospike-ce-kubernetes-operator.ui.imageTag" -}}
 {{- default .Chart.AppVersion .Values.ui.imageTag | toString -}}

--- a/charts/aerospike-ce-kubernetes-operator/values.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/values.yaml
@@ -400,13 +400,16 @@ ui:
   imagePullSecrets: []
 
   # -- Default tag for both UI components (api + web).
-  # aerospike-cluster-manager is versioned independently from the operator,
-  # so the chart pins a known-good cluster-manager release here rather than
-  # letting the UI image tag fall through to .Chart.AppVersion (which is
-  # the operator's version and may not exist as a cluster-manager tag).
-  # Override per-component via ui.api.image.tag / ui.web.image.tag, or
-  # set this to "" to fall through to .Chart.AppVersion.
-  imageTag: "0.24.0"
+  # aerospike-cluster-manager is versioned independently from the operator
+  # and ships releases more frequently than ACKO. The chart defaults to
+  # "latest" so a fresh install always picks up the most recent ACM image
+  # without waiting for an ACKO release that bumps a pinned tag. Because
+  # "latest" is a mutable tag, ui.api.image.pullPolicy / ui.web.image.pullPolicy
+  # default to Always so pods actually refetch on restart.
+  # Pin to a specific cluster-manager release (e.g. "0.30.0") for
+  # reproducible deployments, or override per-component via
+  # ui.api.image.tag / ui.web.image.tag.
+  imageTag: "latest"
 
   # =============================================================================
   # API (FastAPI) — port 8000 internally, Service port 80
@@ -422,7 +425,10 @@ ui:
       # ui.imageTag (preferred) or .Chart.AppVersion. See the
       # ui.api.image helper in _helpers.tpl.
       tag: ""
-      pullPolicy: IfNotPresent
+      # -- Default Always because ui.imageTag is "latest" — a mutable tag
+      # that IfNotPresent would cache indefinitely. Switch to IfNotPresent
+      # when pinning ui.imageTag to an immutable version.
+      pullPolicy: Always
     service:
       type: ClusterIP
       # -- Service port exposed (HTTP default 80). Traffic is forwarded to containerPort 8000.
@@ -731,7 +737,10 @@ ui:
       # ui.imageTag (preferred) or .Chart.AppVersion. See the
       # ui.web.image helper in _helpers.tpl.
       tag: ""
-      pullPolicy: IfNotPresent
+      # -- Default Always because ui.imageTag is "latest" — a mutable tag
+      # that IfNotPresent would cache indefinitely. Switch to IfNotPresent
+      # when pinning ui.imageTag to an immutable version.
+      pullPolicy: Always
     service:
       type: ClusterIP
       port: 3100

--- a/docs/content/getting-started/cluster-manager-ui.md
+++ b/docs/content/getting-started/cluster-manager-ui.md
@@ -613,7 +613,7 @@ restore → upgrade runbook.
 | `ui.api.enabled` | Deploy the Cluster Manager API (FastAPI). Combine with `ui.web.enabled=false` for both-off (operator-only). | `true` |
 | `ui.web.enabled` | Deploy the Cluster Manager web (Next.js). Combine with `ui.api.enabled=false` for both-off (operator-only). | `true` |
 | `ui.replicaCount` | Replica count for each UI Deployment (api / web) | `1` |
-| `ui.imageTag` | Default image tag for both UI components (api + web) | `"0.24.0"` |
+| `ui.imageTag` | Default image tag for both UI components (api + web). Defaults to `latest` so installs track the newest ACM release; pin to a specific version (e.g. `"0.30.0"`) for reproducible deployments. | `"latest"` |
 | `ui.api.image.repository` | API (FastAPI) container image | `ghcr.io/aerospike-ce-ecosystem/aerospike-cluster-manager-api` |
 | `ui.web.image.repository` | Web (Next.js) container image | `ghcr.io/aerospike-ce-ecosystem/aerospike-cluster-manager-web` |
 | `ui.api.service.type` / `ui.web.service.type` | Service type for each component | `ClusterIP` |

--- a/docs/content/getting-started/install.md
+++ b/docs/content/getting-started/install.md
@@ -65,14 +65,14 @@ To see all available values:
 helm show values oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kubernetes-operator
 ```
 
-#### Pin a different Cluster Manager UI release
+#### Pin a Cluster Manager UI release
 
-The Cluster Manager UI (`ui-api` and `ui-web` Deployments) is versioned independently from the operator. The chart pins a known-good `aerospike-cluster-manager` release in `ui.imageTag`. To track a different release, override it globally:
+The Cluster Manager UI (`ui-api` and `ui-web` Deployments) is versioned independently from the operator. The chart defaults `ui.imageTag` to `latest` so a fresh install always picks up the newest `aerospike-cluster-manager` image (Deployment `imagePullPolicy` defaults to `Always` to match). For reproducible deployments, override it with a specific cluster-manager release:
 
 ```bash
 helm install aerospike-ce-kubernetes-operator oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kubernetes-operator \
   -n aerospike-operator --create-namespace \
-  --set ui.imageTag=0.24.0
+  --set ui.imageTag=0.30.0
 ```
 
 Or override a single component via `ui.api.image.tag` / `ui.web.image.tag`. Available tags are listed at [aerospike-cluster-manager-api](https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager/pkgs/container/aerospike-cluster-manager-api) and [aerospike-cluster-manager-web](https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager/pkgs/container/aerospike-cluster-manager-web).

--- a/docs/content/reference/helm-values.md
+++ b/docs/content/reference/helm-values.md
@@ -152,13 +152,13 @@ The Aerospike Cluster Manager is a full-stack web dashboard deployed alongside t
 | `ui.api.enabled` | bool | `true` | Deploy the Cluster Manager API (FastAPI) component. Set to false together with `ui.web.enabled=false` to skip the UI entirely. |
 | `ui.web.enabled` | bool | `true` | Deploy the Cluster Manager web (Next.js) component. Set to false together with `ui.api.enabled=false` to skip the UI entirely. |
 | `ui.replicaCount` | int | `1` | Number of replicas for each UI Deployment (api / web). |
-| `ui.imageTag` | string | `"0.24.0"` | Default image tag for both UI components. `aerospike-cluster-manager` is versioned independently from the operator, so the chart pins a known-good release here. Set to `""` to fall through to `.Chart.AppVersion`. |
+| `ui.imageTag` | string | `"latest"` | Default image tag for both UI components. `aerospike-cluster-manager` is versioned independently from the operator and releases more frequently; defaulting to `latest` lets a fresh install track the newest ACM image without an ACKO release. Pin to a specific version (e.g. `"0.30.0"`) for reproducible deployments. |
 | `ui.api.image.repository` | string | `ghcr.io/aerospike-ce-ecosystem/aerospike-cluster-manager-api` | API (FastAPI) container image repository. |
 | `ui.api.image.tag` | string | `""` | API image tag. Empty falls through to `ui.imageTag`. |
-| `ui.api.image.pullPolicy` | string | `IfNotPresent` | API image pull policy. |
+| `ui.api.image.pullPolicy` | string | `Always` | API image pull policy. Defaults to `Always` because `ui.imageTag` is `latest` (mutable). Switch to `IfNotPresent` when pinning to an immutable tag. |
 | `ui.web.image.repository` | string | `ghcr.io/aerospike-ce-ecosystem/aerospike-cluster-manager-web` | Web (Next.js) container image repository. |
 | `ui.web.image.tag` | string | `""` | Web image tag. Empty falls through to `ui.imageTag`. |
-| `ui.web.image.pullPolicy` | string | `IfNotPresent` | Web image pull policy. |
+| `ui.web.image.pullPolicy` | string | `Always` | Web image pull policy. Defaults to `Always` because `ui.imageTag` is `latest` (mutable). Switch to `IfNotPresent` when pinning to an immutable tag. |
 | `ui.imagePullSecrets` | list | `[]` | Image pull secrets for private registries (applied to all UI Deployments). |
 
 ### Service Account & RBAC

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/getting-started/cluster-manager-ui.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/getting-started/cluster-manager-ui.md
@@ -78,7 +78,7 @@ helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kuber
 | `ui.api.enabled` | Cluster Manager API (FastAPI) 컴포넌트 배포. `ui.web.enabled=false`와 함께 false로 설정하면 UI를 완전히 끔 (operator-only). | `true` |
 | `ui.web.enabled` | Cluster Manager web (Next.js) 컴포넌트 배포. `ui.api.enabled=false`와 함께 false로 설정하면 UI를 완전히 끔 (operator-only). | `true` |
 | `ui.replicaCount` | 각 UI Deployment(api / web)의 레플리카 수 | `1` |
-| `ui.imageTag` | api/web 두 컴포넌트의 기본 이미지 태그 | `"0.24.0"` |
+| `ui.imageTag` | api/web 두 컴포넌트의 기본 이미지 태그. 기본값 `latest`로 ACM 최신 릴리스를 자동 추적하며, 재현 가능한 배포가 필요하면 특정 버전(예: `"0.30.0"`)으로 핀. | `"latest"` |
 | `ui.api.image.repository` | API(FastAPI) 컨테이너 이미지 | `ghcr.io/aerospike-ce-ecosystem/aerospike-cluster-manager-api` |
 | `ui.web.image.repository` | Web(Next.js) 컨테이너 이미지 | `ghcr.io/aerospike-ce-ecosystem/aerospike-cluster-manager-web` |
 | `ui.api.service.type` / `ui.web.service.type` | 컴포넌트별 서비스 타입 | `ClusterIP` |

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/reference/helm-values.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/reference/helm-values.md
@@ -145,13 +145,13 @@ Aerospike Cluster Manager는 오퍼레이터와 함께 두 개의 독립적인 D
 | `ui.api.enabled` | bool | `true` | Cluster Manager API (FastAPI) 컴포넌트 배포. `ui.web.enabled=false`와 함께 false로 설정하면 UI를 완전히 끔. |
 | `ui.web.enabled` | bool | `true` | Cluster Manager web (Next.js) 컴포넌트 배포. `ui.api.enabled=false`와 함께 false로 설정하면 UI를 완전히 끔. |
 | `ui.replicaCount` | int | `1` | 각 UI Deployment(api / web)의 레플리카 수. |
-| `ui.imageTag` | string | `"0.24.0"` | api/web 두 컴포넌트의 기본 이미지 태그. `aerospike-cluster-manager`는 오퍼레이터와 독립적으로 버전 관리되므로 차트가 검증된 릴리스를 여기에 핀. `""`로 설정 시 `.Chart.AppVersion` 사용. |
+| `ui.imageTag` | string | `"latest"` | api/web 두 컴포넌트의 기본 이미지 태그. `aerospike-cluster-manager`는 오퍼레이터와 독립적으로 더 자주 릴리스되므로 기본값 `latest`로 새 설치가 ACKO 릴리스 없이도 최신 ACM 이미지를 추적. 재현 가능한 배포가 필요하면 특정 버전(예: `"0.30.0"`)으로 핀. Pod `pullPolicy`는 mutable 태그 재페치를 위해 기본 `Always`. |
 | `ui.api.image.repository` | string | `ghcr.io/aerospike-ce-ecosystem/aerospike-cluster-manager-api` | API(FastAPI) 컨테이너 이미지 리포지토리. |
 | `ui.api.image.tag` | string | `""` | API 이미지 태그. 비어 있으면 `ui.imageTag` 사용. |
-| `ui.api.image.pullPolicy` | string | `IfNotPresent` | API 이미지 풀 정책. |
+| `ui.api.image.pullPolicy` | string | `Always` | API 이미지 풀 정책. `ui.imageTag`가 `latest`(mutable)이라 기본 `Always`. immutable 태그로 핀하면 `IfNotPresent`로 변경 권장. |
 | `ui.web.image.repository` | string | `ghcr.io/aerospike-ce-ecosystem/aerospike-cluster-manager-web` | Web(Next.js) 컨테이너 이미지 리포지토리. |
 | `ui.web.image.tag` | string | `""` | Web 이미지 태그. 비어 있으면 `ui.imageTag` 사용. |
-| `ui.web.image.pullPolicy` | string | `IfNotPresent` | Web 이미지 풀 정책. |
+| `ui.web.image.pullPolicy` | string | `Always` | Web 이미지 풀 정책. `ui.imageTag`가 `latest`(mutable)이라 기본 `Always`. immutable 태그로 핀하면 `IfNotPresent`로 변경 권장. |
 | `ui.imagePullSecrets` | list | `[]` | 프라이빗 레지스트리용 이미지 풀 시크릿 (모든 UI Deployment에 적용). |
 
 ### 서비스 어카운트 & RBAC


### PR DESCRIPTION
## Summary

- `ui.imageTag` 기본값을 `"0.24.0"` → `"latest"`로 변경하여 helm 설치가 ACM 최신 릴리스를 자동 추적
- `ui.api.image.pullPolicy` / `ui.web.image.pullPolicy` 기본값을 `IfNotPresent` → `Always`로 변경 (mutable 태그가 재시작 시 실제로 재페치되도록)
- README, install guide, helm-values reference, cluster-manager-ui guide (en + ko) 문서 정리: 새 기본값 설명 + 특정 ACM 버전 핀하는 방법 안내

## Motivation

aerospike-cluster-manager는 ACKO와 독립적으로 더 자주 릴리스됩니다. 차트에 ACM 버전을 핀해두면, 새 helm 설치가 매번 ACKO 릴리스를 기다려야 최신 UI를 받는 구조였습니다.

| 시점 | ACM 최신 | ACKO 핀 |
|---|---|---|
| 변경 전 | v0.30.0 (2026-05-26) | 0.24.0 (2026-05-11) |
| 변경 후 | (latest 태그가 따라감) | latest |

기본값을 `latest`로 두고, 재현 가능한 배포가 필요한 사용자는 `--set ui.imageTag=0.30.0` 식으로 명시적으로 핀하는 흐름이 됩니다.

## Test plan

- [x] `helm lint charts/aerospike-ce-kubernetes-operator` 통과
- [x] `helm template` 렌더 결과: `cluster-manager-api:latest` + `pullPolicy: Always`, `cluster-manager-web:latest` + `pullPolicy: Always` 확인
- [x] `npm run build` (Docusaurus en/ko) 통과
- [x] `ghcr.io/aerospike-ce-ecosystem/aerospike-cluster-manager-{api,web}` 레지스트리에 `latest` 태그 publish 확인
- [ ] 머지 후 daily-release.yml이 PATCH bump(v1.7.4) 생성하는지 확인

## Notes

이 변경은 `aerospike-cluster-manager`가 자체 릴리스 워크플로에서 `latest` 태그를 안정적으로 push한다는 가정에 의존합니다. 현재 두 이미지 모두 `5bbd1a7` SHA로 `latest`/`main` 태그가 publish되어 있음을 확인했습니다.