### PR TITLE
fix(telemetry): cap span/log attribute byte size + honor OTEL_*_EXPORTER=none

### DIFF
--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -41,6 +41,7 @@ package telemetry
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"strings"
 
@@ -60,6 +61,22 @@ import (
 	"go.uber.org/zap/zapcore"
 	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 )
+
+// defaultAttributeValueLengthLimit caps the bytes any single span / log
+// attribute value can grow to before the SDK truncates it. The OTel Go SDK
+// default is -1 (unlimited), which is unsafe for an operator that watches
+// cluster-wide: if any reconcile-path log or span ever carries a serialized
+// Kubernetes object as an attribute (Pod / StatefulSet / Service / Secret),
+// a single OTLP/gRPC export can balloon past 4 MiB and trigger OOMKilled
+// in busy clusters (#299). 4 KiB is enough to keep human-readable identifiers
+// and short error strings intact; anything larger is truncated by the SDK
+// with a deterministic suffix marker, which is the right trade-off for an
+// operator's observability budget.
+//
+// Operators who need a higher cap can override via the standard spec env
+// vars OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT / OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT
+// (and the OTEL_LOGRECORD_* counterparts) — see resolveAttributeValueLengthLimit.
+const defaultAttributeValueLengthLimit = 4096
 
 // ServiceName is the OTel service.name stamped on every signal the operator
 // emits, and the instrumentation-scope name used for its tracer.
@@ -116,18 +133,107 @@ func activated() bool {
 	return v != "true" && v != "1" && v != "yes"
 }
 
+// signalEnabled reports whether the named signal (traces / metrics / logs)
+// should be exported. Returns:
+//
+//   - (true,  nil)  for "otlp" or unset — the spec default
+//   - (false, nil)  for "none"          — caller skips provider construction
+//   - (false, err)  for any other value — typo in chart values, surface loudly
+//
+// This honors the standard OTel SDK env vars OTEL_TRACES_EXPORTER /
+// OTEL_METRICS_EXPORTER / OTEL_LOGS_EXPORTER so operators can disable a single
+// signal (e.g. metrics) when their collector ships traces+logs receivers but
+// no metrics pipeline — without having to disable telemetry wholesale via
+// OTEL_SDK_DISABLED=true. Same workaround channel used by #299 reporters to
+// stop the OOM cycle while keeping logs flowing through fluent-bit.
+//
+// Reference:
+// https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#exporter-selection
+func signalEnabled(signal string) (bool, error) {
+	envKey := "OTEL_" + strings.ToUpper(signal) + "_EXPORTER"
+	v := strings.ToLower(strings.TrimSpace(os.Getenv(envKey)))
+	switch v {
+	case "", "otlp":
+		return true, nil
+	case "none":
+		return false, nil
+	default:
+		return false, fmt.Errorf("unsupported %s=%q; expected 'otlp' or 'none'", envKey, v)
+	}
+}
+
+// resolveAttributeValueLengthLimit picks the effective per-attribute byte cap.
+//
+// The OTel Go SDK's sdktrace.NewSpanLimits() already reads
+// OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT / OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT
+// and applies them, but the SDK's hard-coded default when both are unset is
+// -1 (unlimited). For an operator that watches cluster-wide, unlimited means
+// a single zap field carrying a serialized Pod / StatefulSet body can put the
+// whole OTLP export over the receiver's 4 MiB limit, so we substitute a 4 KiB
+// cap whenever the env vars do not pin a value explicitly.
+//
+// `specific` is the signal-scoped key (e.g. OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT
+// for spans, OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT for logs); `general`
+// is the cross-signal fallback (OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT). The
+// specific key takes precedence so a "tighter logs but laxer traces"
+// configuration is reachable.
+func resolveAttributeValueLengthLimit(specific, general string) int {
+	for _, key := range []string{specific, general} {
+		if raw, ok := os.LookupEnv(key); ok {
+			if n, err := parseIntStrict(raw); err == nil && n >= 0 {
+				return n
+			}
+		}
+	}
+	return defaultAttributeValueLengthLimit
+}
+
+func parseIntStrict(s string) (int, error) {
+	s = strings.TrimSpace(s)
+	n := 0
+	for i, ch := range s {
+		if i == 0 && ch == '-' {
+			return 0, fmt.Errorf("negative limit not allowed")
+		}
+		if ch < '0' || ch > '9' {
+			return 0, fmt.Errorf("non-digit %q", ch)
+		}
+		n = n*10 + int(ch-'0')
+	}
+	if s == "" {
+		return 0, fmt.Errorf("empty")
+	}
+	return n, nil
+}
+
 // Setup builds the OTLP trace/metric/log providers, registers them as the
 // global OpenTelemetry providers, and installs the W3C trace-context + baggage
 // propagator. serviceVersion is stamped onto the resource as service.version.
 //
 // When OTEL_SDK_DISABLED keeps telemetry off, Setup returns a disabled
-// Provider and no error. When a provider fails to build, any partially
+// Provider and no error. Per-signal disable (OTEL_TRACES_EXPORTER=none /
+// OTEL_METRICS_EXPORTER=none / OTEL_LOGS_EXPORTER=none) is honored: the
+// matching provider is left as the global NoOp default while the remaining
+// signals still export. When a provider fails to build, any partially
 // constructed providers are flushed and stopped, an inert Provider is
 // returned, and the error is surfaced so the caller can keep running the
 // operator with telemetry off.
 func Setup(ctx context.Context, serviceVersion string) (*Provider, error) {
 	if !activated() {
 		return &Provider{}, nil
+	}
+
+	tracesOn, err := signalEnabled("traces")
+	if err != nil {
+		return &Provider{}, err
+	}
+	metricsOn, err := signalEnabled("metrics")
+	if err != nil {
+		return &Provider{}, err
+	}
+	logsOn, err := signalEnabled("logs")
+	if err != nil {
+		return &Provider{}, err
 	}
 
 	p := &Provider{}
@@ -158,15 +264,30 @@ func Setup(ctx context.Context, serviceVersion string) (*Provider, error) {
 	// operator continues cleanly with telemetry off.
 
 	// --- Traces ---------------------------------------------------------
-	traceExp, err := otlptrace.New(ctx)
-	if err != nil {
-		return fail(err)
+	var tp *sdktrace.TracerProvider
+	if tracesOn {
+		traceExp, terr := otlptrace.New(ctx)
+		if terr != nil {
+			return fail(terr)
+		}
+		// SpanLimits.AttributeValueLengthLimit defaults to -1 (unlimited) in
+		// the SDK. That is unsafe for a cluster-wide watcher because any zap
+		// field or span attribute carrying a serialized Kubernetes object
+		// would let a single OTLP export grow past the 4 MiB collector default
+		// and crash the operator with OOMKilled (#299). Cap the length and
+		// keep all other count limits at their 128 SDK defaults.
+		spanLimits := sdktrace.NewSpanLimits()
+		spanLimits.AttributeValueLengthLimit = resolveAttributeValueLengthLimit(
+			"OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT",
+			"OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT",
+		)
+		tp = sdktrace.NewTracerProvider(
+			sdktrace.WithBatcher(traceExp),
+			sdktrace.WithResource(res),
+			sdktrace.WithRawSpanLimits(spanLimits),
+		)
+		p.shutdownFuncs = append(p.shutdownFuncs, tp.Shutdown)
 	}
-	tp := sdktrace.NewTracerProvider(
-		sdktrace.WithBatcher(traceExp),
-		sdktrace.WithResource(res),
-	)
-	p.shutdownFuncs = append(p.shutdownFuncs, tp.Shutdown)
 
 	// --- Metrics --------------------------------------------------------
 	// The Prometheus bridge republishes the controller-runtime metrics
@@ -174,46 +295,73 @@ func Setup(ctx context.Context, serviceVersion string) (*Provider, error) {
 	// custom metric from internal/metrics — through OTLP. No metric
 	// definition changes: the same series stay scrapable at /metrics and
 	// are additionally pushed to the collector.
-	metricExp, err := otlpmetric.New(ctx)
-	if err != nil {
-		return fail(err)
+	var mp *sdkmetric.MeterProvider
+	if metricsOn {
+		metricExp, merr := otlpmetric.New(ctx)
+		if merr != nil {
+			return fail(merr)
+		}
+		reader := sdkmetric.NewPeriodicReader(metricExp,
+			sdkmetric.WithProducer(prombridge.NewMetricProducer(
+				prombridge.WithGatherer(ctrlmetrics.Registry),
+			)),
+		)
+		mp = sdkmetric.NewMeterProvider(
+			sdkmetric.WithReader(reader),
+			sdkmetric.WithResource(res),
+		)
+		p.shutdownFuncs = append(p.shutdownFuncs, mp.Shutdown)
 	}
-	reader := sdkmetric.NewPeriodicReader(metricExp,
-		sdkmetric.WithProducer(prombridge.NewMetricProducer(
-			prombridge.WithGatherer(ctrlmetrics.Registry),
-		)),
-	)
-	mp := sdkmetric.NewMeterProvider(
-		sdkmetric.WithReader(reader),
-		sdkmetric.WithResource(res),
-	)
-	p.shutdownFuncs = append(p.shutdownFuncs, mp.Shutdown)
 
 	// --- Logs -----------------------------------------------------------
-	logExp, err := otlplog.New(ctx)
-	if err != nil {
-		return fail(err)
+	var lp *sdklog.LoggerProvider
+	if logsOn {
+		logExp, lerr := otlplog.New(ctx)
+		if lerr != nil {
+			return fail(lerr)
+		}
+		logAttrValLimit := resolveAttributeValueLengthLimit(
+			"OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT",
+			"OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT",
+		)
+		lp = sdklog.NewLoggerProvider(
+			sdklog.WithProcessor(sdklog.NewBatchProcessor(logExp)),
+			sdklog.WithResource(res),
+			// Cap per-log-record attribute byte size for the same reason as
+			// SpanLimits above. Zap fields that wrap a Pod/StatefulSet via
+			// otelzap would otherwise produce multi-megabyte LogRecords on
+			// every reconcile in a cluster-wide watch (#299).
+			sdklog.WithAttributeValueLengthLimit(logAttrValLimit),
+		)
+		p.shutdownFuncs = append(p.shutdownFuncs, lp.Shutdown)
 	}
-	lp := sdklog.NewLoggerProvider(
-		sdklog.WithProcessor(sdklog.NewBatchProcessor(logExp)),
-		sdklog.WithResource(res),
-	)
-	p.shutdownFuncs = append(p.shutdownFuncs, lp.Shutdown)
 
-	// All three providers built successfully — now publish them globally.
-	otel.SetTracerProvider(tp)
-	otel.SetMeterProvider(mp)
-	logglobal.SetLoggerProvider(lp)
+	// All providers built successfully — now publish them globally. Skip the
+	// SetXProvider call for any disabled signal so the global NoOp survives.
+	if tp != nil {
+		otel.SetTracerProvider(tp)
+	}
+	if mp != nil {
+		otel.SetMeterProvider(mp)
+	}
+	if lp != nil {
+		logglobal.SetLoggerProvider(lp)
+		// otelzap core — cmd/main.go tees this into the zap logger so operator
+		// log lines are exported as OTLP log records alongside traces. Only
+		// attach the core when logs are actually enabled; otherwise leave
+		// p.zapCore nil so the zap tee is skipped.
+		p.zapCore = otelzap.NewCore(ServiceName, otelzap.WithLoggerProvider(lp))
+	}
 	// W3C TraceContext + Baggage so operator spans stitch with the
 	// cluster-manager API and any other OTel-instrumented service.
 	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
 		propagation.TraceContext{},
 		propagation.Baggage{},
 	))
-	// otelzap core — cmd/main.go tees this into the zap logger so operator
-	// log lines are exported as OTLP log records alongside traces.
-	p.zapCore = otelzap.NewCore(ServiceName, otelzap.WithLoggerProvider(lp))
 
-	p.enabled = true
+	// Enabled reflects whether ANY signal is being exported. All-three-off via
+	// per-signal flags is a legitimate no-op configuration — the caller will
+	// log "OpenTelemetry export enabled" only when at least one pipeline runs.
+	p.enabled = tp != nil || mp != nil || lp != nil
 	return p, nil
 }

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -43,6 +43,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
 	"go.opentelemetry.io/contrib/bridges/otelzap"
@@ -73,9 +74,12 @@ import (
 // with a deterministic suffix marker, which is the right trade-off for an
 // operator's observability budget.
 //
-// Operators who need a higher cap can override via the standard spec env
-// vars OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT / OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT
-// (and the OTEL_LOGRECORD_* counterparts) — see resolveAttributeValueLengthLimit.
+// Trade-off worth knowing: long stacktraces and controller-runtime error
+// strings that embed YAML diffs are the most common casualty of this cap.
+// Operators who need to see full error context can raise it via the standard
+// spec env vars OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT /
+// OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT (and the OTEL_LOGRECORD_*
+// counterparts) — e.g. =16384 for 16 KiB. See resolveAttributeValueLengthLimit.
 const defaultAttributeValueLengthLimit = 4096
 
 // ServiceName is the OTel service.name stamped on every signal the operator
@@ -170,40 +174,29 @@ func signalEnabled(signal string) (bool, error) {
 // -1 (unlimited). For an operator that watches cluster-wide, unlimited means
 // a single zap field carrying a serialized Pod / StatefulSet body can put the
 // whole OTLP export over the receiver's 4 MiB limit, so we substitute a 4 KiB
-// cap whenever the env vars do not pin a value explicitly.
+// cap whenever the env vars do not pin a non-negative value explicitly.
 //
 // `specific` is the signal-scoped key (e.g. OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT
 // for spans, OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT for logs); `general`
 // is the cross-signal fallback (OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT). The
 // specific key takes precedence so a "tighter logs but laxer traces"
-// configuration is reachable.
+// configuration is reachable. Malformed values (non-integer, negative) silently
+// fall back to the safe default — surfacing a startup error would refuse to
+// start the operator over a typo in an observability env var, which is the
+// wrong trade-off.
 func resolveAttributeValueLengthLimit(specific, general string) int {
 	for _, key := range []string{specific, general} {
-		if raw, ok := os.LookupEnv(key); ok {
-			if n, err := parseIntStrict(raw); err == nil && n >= 0 {
-				return n
-			}
+		raw, ok := os.LookupEnv(key)
+		if !ok {
+			continue
 		}
+		n, err := strconv.Atoi(strings.TrimSpace(raw))
+		if err != nil || n < 0 {
+			continue
+		}
+		return n
 	}
 	return defaultAttributeValueLengthLimit
-}
-
-func parseIntStrict(s string) (int, error) {
-	s = strings.TrimSpace(s)
-	n := 0
-	for i, ch := range s {
-		if i == 0 && ch == '-' {
-			return 0, fmt.Errorf("negative limit not allowed")
-		}
-		if ch < '0' || ch > '9' {
-			return 0, fmt.Errorf("non-digit %q", ch)
-		}
-		n = n*10 + int(ch-'0')
-	}
-	if s == "" {
-		return 0, fmt.Errorf("empty")
-	}
-	return n, nil
 }
 
 // Setup builds the OTLP trace/metric/log providers, registers them as the
@@ -270,17 +263,16 @@ func Setup(ctx context.Context, serviceVersion string) (*Provider, error) {
 		if terr != nil {
 			return fail(terr)
 		}
-		// SpanLimits.AttributeValueLengthLimit defaults to -1 (unlimited) in
-		// the SDK. That is unsafe for a cluster-wide watcher because any zap
-		// field or span attribute carrying a serialized Kubernetes object
-		// would let a single OTLP export grow past the 4 MiB collector default
-		// and crash the operator with OOMKilled (#299). Cap the length and
-		// keep all other count limits at their 128 SDK defaults.
+		// NewSpanLimits() already honors OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT
+		// (specific) and OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT (general fallback);
+		// see sdk/trace/internal/env. We only override the value when the SDK
+		// has it at its hard-coded -1 (unlimited) default, which is unsafe for
+		// a cluster-wide watcher (#299). All other count limits stay at the
+		// SDK's 128 defaults.
 		spanLimits := sdktrace.NewSpanLimits()
-		spanLimits.AttributeValueLengthLimit = resolveAttributeValueLengthLimit(
-			"OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT",
-			"OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT",
-		)
+		if spanLimits.AttributeValueLengthLimit < 0 {
+			spanLimits.AttributeValueLengthLimit = defaultAttributeValueLengthLimit
+		}
 		tp = sdktrace.NewTracerProvider(
 			sdktrace.WithBatcher(traceExp),
 			sdktrace.WithResource(res),

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -166,24 +166,21 @@ func signalEnabled(signal string) (bool, error) {
 	}
 }
 
-// resolveAttributeValueLengthLimit picks the effective per-attribute byte cap.
+// resolveAttributeValueLengthLimit picks the effective per-attribute byte cap
+// for the LOGS pipeline only. The spans pipeline uses sdktrace.NewSpanLimits(),
+// which the OTel Go SDK already wires up to honor both
+// OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT and the cross-signal
+// OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT fallback; the Setup() code there just
+// substitutes the safe default when the SDK reports -1. sdklog has no
+// equivalent env-aware limit constructor, so we resolve manually here.
 //
-// The OTel Go SDK's sdktrace.NewSpanLimits() already reads
-// OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT / OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT
-// and applies them, but the SDK's hard-coded default when both are unset is
-// -1 (unlimited). For an operator that watches cluster-wide, unlimited means
-// a single zap field carrying a serialized Pod / StatefulSet body can put the
-// whole OTLP export over the receiver's 4 MiB limit, so we substitute a 4 KiB
-// cap whenever the env vars do not pin a non-negative value explicitly.
-//
-// `specific` is the signal-scoped key (e.g. OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT
-// for spans, OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT for logs); `general`
-// is the cross-signal fallback (OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT). The
-// specific key takes precedence so a "tighter logs but laxer traces"
-// configuration is reachable. Malformed values (non-integer, negative) silently
-// fall back to the safe default — surfacing a startup error would refuse to
-// start the operator over a typo in an observability env var, which is the
-// wrong trade-off.
+// `specific` is the signal-scoped key (OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT
+// for log records); `general` is the cross-signal fallback
+// (OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT). The specific key takes precedence so a
+// "tighter logs but laxer traces" configuration is reachable. Malformed values
+// (non-integer, negative) silently fall back to the safe default — surfacing a
+// startup error would refuse to start the operator over a typo in an
+// observability env var, which is the wrong trade-off.
 func resolveAttributeValueLengthLimit(specific, general string) int {
 	for _, key := range []string{specific, general} {
 		raw, ok := os.LookupEnv(key)

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -166,23 +166,28 @@ func signalEnabled(signal string) (bool, error) {
 	}
 }
 
-// resolveAttributeValueLengthLimit picks the effective per-attribute byte cap
-// for the LOGS pipeline only. The spans pipeline uses sdktrace.NewSpanLimits(),
+// resolveLogAttributeValueLengthLimit picks the effective per-attribute byte
+// cap for the LOGS pipeline. The spans pipeline uses sdktrace.NewSpanLimits(),
 // which the OTel Go SDK already wires up to honor both
 // OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT and the cross-signal
 // OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT fallback; the Setup() code there just
 // substitutes the safe default when the SDK reports -1. sdklog has no
-// equivalent env-aware limit constructor, so we resolve manually here.
+// equivalent env-aware limit constructor, so we resolve manually here:
 //
-// `specific` is the signal-scoped key (OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT
-// for log records); `general` is the cross-signal fallback
-// (OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT). The specific key takes precedence so a
-// "tighter logs but laxer traces" configuration is reachable. Malformed values
-// (non-integer, negative) silently fall back to the safe default — surfacing a
-// startup error would refuse to start the operator over a typo in an
-// observability env var, which is the wrong trade-off.
-func resolveAttributeValueLengthLimit(specific, general string) int {
-	for _, key := range []string{specific, general} {
+//   - OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT (signal-scoped, takes precedence)
+//   - OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT (cross-signal fallback)
+//
+// Letting the specific key win on top of the general makes a "tighter logs but
+// laxer traces" configuration reachable. Malformed values (non-integer,
+// negative) silently fall back to the safe default — surfacing a startup error
+// would refuse to start the operator over a typo in an observability env var,
+// which is the wrong trade-off.
+func resolveLogAttributeValueLengthLimit() int {
+	keys := []string{
+		"OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT",
+		"OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT",
+	}
+	for _, key := range keys {
 		raw, ok := os.LookupEnv(key)
 		if !ok {
 			continue
@@ -309,10 +314,6 @@ func Setup(ctx context.Context, serviceVersion string) (*Provider, error) {
 		if lerr != nil {
 			return fail(lerr)
 		}
-		logAttrValLimit := resolveAttributeValueLengthLimit(
-			"OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT",
-			"OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT",
-		)
 		lp = sdklog.NewLoggerProvider(
 			sdklog.WithProcessor(sdklog.NewBatchProcessor(logExp)),
 			sdklog.WithResource(res),
@@ -320,7 +321,7 @@ func Setup(ctx context.Context, serviceVersion string) (*Provider, error) {
 			// SpanLimits above. Zap fields that wrap a Pod/StatefulSet via
 			// otelzap would otherwise produce multi-megabyte LogRecords on
 			// every reconcile in a cluster-wide watch (#299).
-			sdklog.WithAttributeValueLengthLimit(logAttrValLimit),
+			sdklog.WithAttributeValueLengthLimit(resolveLogAttributeValueLengthLimit()),
 		)
 		p.shutdownFuncs = append(p.shutdownFuncs, lp.Shutdown)
 	}

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -18,6 +18,7 @@ package telemetry
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 )
@@ -113,5 +114,230 @@ func TestProviderNilSafe(t *testing.T) {
 	}
 	if err := p.Shutdown(context.Background()); err != nil {
 		t.Errorf("nil Provider Shutdown() = %v, want nil", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Per-signal exporter selection (#299)
+// ---------------------------------------------------------------------------
+
+func TestSignalEnabled(t *testing.T) {
+	cases := []struct {
+		name      string
+		signal    string
+		val       string
+		want      bool
+		wantError bool
+	}{
+		{name: "unset traces -> enabled", signal: "traces", val: "", want: true},
+		{name: "otlp metrics -> enabled", signal: "metrics", val: "otlp", want: true},
+		{name: "OTLP uppercase -> enabled", signal: "logs", val: "OTLP", want: true},
+		{name: "padded otlp -> enabled", signal: "logs", val: "  otlp  ", want: true},
+		{name: "none traces -> disabled", signal: "traces", val: "none", want: false},
+		{name: "NONE metrics -> disabled", signal: "metrics", val: "NONE", want: false},
+		{name: "padded none -> disabled", signal: "logs", val: " none ", want: false},
+		{name: "jaeger traces -> error", signal: "traces", val: "jaeger", wantError: true},
+		{name: "console logs -> error", signal: "logs", val: "console", wantError: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("OTEL_"+strings.ToUpper(tc.signal)+"_EXPORTER", tc.val)
+			got, err := signalEnabled(tc.signal)
+			if (err != nil) != tc.wantError {
+				t.Fatalf("signalEnabled(%q) err = %v, wantError %v", tc.signal, err, tc.wantError)
+			}
+			if got != tc.want {
+				t.Errorf("signalEnabled(%q)=%v, want %v", tc.signal, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSetupTracesDisabled(t *testing.T) {
+	// OTEL_LOGS_EXPORTER=none must keep metrics+logs running but suppress the
+	// trace pipeline. zapCore must be present because logs are still on; the
+	// global TracerProvider is left as the NoOp default.
+	t.Setenv("OTEL_SDK_DISABLED", "false")
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "localhost:4317")
+	t.Setenv("OTEL_TRACES_EXPORTER", "none")
+
+	p, err := Setup(context.Background(), "test")
+	if err != nil {
+		t.Fatalf("Setup() error = %v", err)
+	}
+	if !p.Enabled() {
+		t.Fatal("Enabled()=false, want true (logs and metrics are still on)")
+	}
+	if p.ZapCore() == nil {
+		t.Error("ZapCore()=nil, want non-nil when logs are on")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	_ = p.Shutdown(ctx)
+}
+
+func TestSetupMetricsDisabled(t *testing.T) {
+	t.Setenv("OTEL_SDK_DISABLED", "false")
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "localhost:4317")
+	t.Setenv("OTEL_METRICS_EXPORTER", "none")
+
+	p, err := Setup(context.Background(), "test")
+	if err != nil {
+		t.Fatalf("Setup() error = %v", err)
+	}
+	if !p.Enabled() {
+		t.Fatal("Enabled()=false, want true (traces and logs still on)")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	_ = p.Shutdown(ctx)
+}
+
+func TestSetupLogsDisabled(t *testing.T) {
+	t.Setenv("OTEL_SDK_DISABLED", "false")
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "localhost:4317")
+	t.Setenv("OTEL_LOGS_EXPORTER", "none")
+
+	p, err := Setup(context.Background(), "test")
+	if err != nil {
+		t.Fatalf("Setup() error = %v", err)
+	}
+	if !p.Enabled() {
+		t.Fatal("Enabled()=false, want true (traces and metrics still on)")
+	}
+	if p.ZapCore() != nil {
+		t.Error("ZapCore()!=nil when logs are disabled; would still tee log records into the OTLP pipeline")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	_ = p.Shutdown(ctx)
+}
+
+func TestSetupAllSignalsDisabled(t *testing.T) {
+	// Disabling every signal individually is a legitimate no-op configuration.
+	// Setup must not crash and must report Enabled()=false so the caller's
+	// "OpenTelemetry export enabled" log is suppressed.
+	t.Setenv("OTEL_SDK_DISABLED", "false")
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "localhost:4317")
+	t.Setenv("OTEL_TRACES_EXPORTER", "none")
+	t.Setenv("OTEL_METRICS_EXPORTER", "none")
+	t.Setenv("OTEL_LOGS_EXPORTER", "none")
+
+	p, err := Setup(context.Background(), "test")
+	if err != nil {
+		t.Fatalf("Setup() error = %v", err)
+	}
+	if p.Enabled() {
+		t.Error("Enabled()=true when every signal is disabled")
+	}
+	if p.ZapCore() != nil {
+		t.Error("ZapCore()!=nil when every signal is disabled")
+	}
+}
+
+func TestSetupRejectsUnknownExporter(t *testing.T) {
+	// A typo in chart values (e.g. OTEL_TRACES_EXPORTER=jaeger) must surface
+	// as a startup error rather than silently disabling the signal.
+	t.Setenv("OTEL_SDK_DISABLED", "false")
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "localhost:4317")
+	t.Setenv("OTEL_TRACES_EXPORTER", "jaeger")
+
+	p, err := Setup(context.Background(), "test")
+	if err == nil {
+		t.Fatal("Setup() error = nil, want error for unsupported OTEL_TRACES_EXPORTER")
+	}
+	if p.Enabled() {
+		t.Error("Enabled()=true on a failed Setup")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Attribute-value length caps (#299 OOM root cause)
+// ---------------------------------------------------------------------------
+
+func TestResolveAttributeValueLengthLimitDefault(t *testing.T) {
+	t.Setenv("OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT", "")
+	t.Setenv("OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT", "")
+
+	got := resolveAttributeValueLengthLimit(
+		"OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT",
+		"OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT",
+	)
+	if got != defaultAttributeValueLengthLimit {
+		t.Errorf("resolveAttributeValueLengthLimit() = %d, want %d", got, defaultAttributeValueLengthLimit)
+	}
+}
+
+func TestResolveAttributeValueLengthLimitSpecificOverridesGeneral(t *testing.T) {
+	t.Setenv("OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT", "1024")
+	t.Setenv("OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT", "8192")
+
+	got := resolveAttributeValueLengthLimit(
+		"OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT",
+		"OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT",
+	)
+	if got != 8192 {
+		t.Errorf("specific=8192 should win over general=1024, got %d", got)
+	}
+}
+
+func TestResolveAttributeValueLengthLimitGeneralFallback(t *testing.T) {
+	t.Setenv("OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT", "")
+	t.Setenv("OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT", "2048")
+
+	got := resolveAttributeValueLengthLimit(
+		"OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT",
+		"OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT",
+	)
+	if got != 2048 {
+		t.Errorf("general=2048 should be used when specific is unset, got %d", got)
+	}
+}
+
+func TestResolveAttributeValueLengthLimitMalformedFallsBackToDefault(t *testing.T) {
+	// Malformed values must not silently revert to SDK unlimited (-1); we
+	// pretend the env var was not set and apply the safe default cap.
+	t.Setenv("OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT", "abc")
+	t.Setenv("OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT", "")
+
+	got := resolveAttributeValueLengthLimit(
+		"OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT",
+		"OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT",
+	)
+	if got != defaultAttributeValueLengthLimit {
+		t.Errorf("malformed value should fall back to %d, got %d", defaultAttributeValueLengthLimit, got)
+	}
+}
+
+func TestResolveAttributeValueLengthLimitNegativeFallsBackToDefault(t *testing.T) {
+	// A negative override would mean "unlimited" per the OTel SDK, which is
+	// exactly the unsafe configuration #299 hit. Force the safe default
+	// instead of trusting the user-supplied -1.
+	t.Setenv("OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT", "-1")
+	t.Setenv("OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT", "")
+
+	got := resolveAttributeValueLengthLimit(
+		"OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT",
+		"OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT",
+	)
+	if got != defaultAttributeValueLengthLimit {
+		t.Errorf("negative override should fall back to %d, got %d", defaultAttributeValueLengthLimit, got)
+	}
+}
+
+func TestDefaultAttributeValueLengthLimitIsCappedForOOMProtection(t *testing.T) {
+	// Sanity guard: the constant must remain a finite, OTLP-receiver-safe cap.
+	// Anyone bumping it past the 4 MiB gRPC default needs to revisit #299 and
+	// coordinate with the collector configuration.
+	if defaultAttributeValueLengthLimit <= 0 {
+		t.Fatalf("defaultAttributeValueLengthLimit must be a positive byte cap, got %d",
+			defaultAttributeValueLengthLimit)
+	}
+	if defaultAttributeValueLengthLimit > 64*1024 {
+		t.Fatalf("defaultAttributeValueLengthLimit=%d > 64 KiB; revisit #299 before raising",
+			defaultAttributeValueLengthLimit)
 	}
 }

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -258,71 +258,56 @@ func TestSetupRejectsUnknownExporter(t *testing.T) {
 // Attribute-value length caps (#299 OOM root cause)
 // ---------------------------------------------------------------------------
 
-func TestResolveAttributeValueLengthLimitDefault(t *testing.T) {
-	t.Setenv("OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT", "")
+func TestResolveLogAttributeValueLengthLimitDefault(t *testing.T) {
+	t.Setenv("OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT", "")
 	t.Setenv("OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT", "")
 
-	got := resolveAttributeValueLengthLimit(
-		"OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT",
-		"OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT",
-	)
+	got := resolveLogAttributeValueLengthLimit()
 	if got != defaultAttributeValueLengthLimit {
-		t.Errorf("resolveAttributeValueLengthLimit() = %d, want %d", got, defaultAttributeValueLengthLimit)
+		t.Errorf("resolveLogAttributeValueLengthLimit() = %d, want %d", got, defaultAttributeValueLengthLimit)
 	}
 }
 
-func TestResolveAttributeValueLengthLimitSpecificOverridesGeneral(t *testing.T) {
+func TestResolveLogAttributeValueLengthLimitSpecificOverridesGeneral(t *testing.T) {
 	t.Setenv("OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT", "1024")
-	t.Setenv("OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT", "8192")
+	t.Setenv("OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT", "8192")
 
-	got := resolveAttributeValueLengthLimit(
-		"OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT",
-		"OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT",
-	)
+	got := resolveLogAttributeValueLengthLimit()
 	if got != 8192 {
-		t.Errorf("specific=8192 should win over general=1024, got %d", got)
+		t.Errorf("logrecord-specific=8192 should win over general=1024, got %d", got)
 	}
 }
 
-func TestResolveAttributeValueLengthLimitGeneralFallback(t *testing.T) {
-	t.Setenv("OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT", "")
+func TestResolveLogAttributeValueLengthLimitGeneralFallback(t *testing.T) {
+	t.Setenv("OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT", "")
 	t.Setenv("OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT", "2048")
 
-	got := resolveAttributeValueLengthLimit(
-		"OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT",
-		"OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT",
-	)
+	got := resolveLogAttributeValueLengthLimit()
 	if got != 2048 {
-		t.Errorf("general=2048 should be used when specific is unset, got %d", got)
+		t.Errorf("general=2048 should be used when logrecord-specific is unset, got %d", got)
 	}
 }
 
-func TestResolveAttributeValueLengthLimitMalformedFallsBackToDefault(t *testing.T) {
+func TestResolveLogAttributeValueLengthLimitMalformedFallsBackToDefault(t *testing.T) {
 	// Malformed values must not silently revert to SDK unlimited (-1); we
 	// pretend the env var was not set and apply the safe default cap.
-	t.Setenv("OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT", "abc")
+	t.Setenv("OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT", "abc")
 	t.Setenv("OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT", "")
 
-	got := resolveAttributeValueLengthLimit(
-		"OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT",
-		"OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT",
-	)
+	got := resolveLogAttributeValueLengthLimit()
 	if got != defaultAttributeValueLengthLimit {
 		t.Errorf("malformed value should fall back to %d, got %d", defaultAttributeValueLengthLimit, got)
 	}
 }
 
-func TestResolveAttributeValueLengthLimitNegativeFallsBackToDefault(t *testing.T) {
+func TestResolveLogAttributeValueLengthLimitNegativeFallsBackToDefault(t *testing.T) {
 	// A negative override would mean "unlimited" per the OTel SDK, which is
 	// exactly the unsafe configuration #299 hit. Force the safe default
 	// instead of trusting the user-supplied -1.
-	t.Setenv("OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT", "-1")
+	t.Setenv("OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT", "-1")
 	t.Setenv("OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT", "")
 
-	got := resolveAttributeValueLengthLimit(
-		"OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT",
-		"OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT",
-	)
+	got := resolveLogAttributeValueLengthLimit()
 	if got != defaultAttributeValueLengthLimit {
 		t.Errorf("negative override should fall back to %d, got %d", defaultAttributeValueLengthLimit, got)
 	}


### PR DESCRIPTION
## Summary

Closes #299.

Enabling `observability.otel.enabled=true` on operator deployments that watch a cluster-wide scope with non-trivial workload counts produced single OTLP/gRPC export messages of 17-255 MiB, exceeding the collector's default 4 MiB `MaxRecvMsgSize` and outgrowing the operator's `resources.limits.memory: 2Gi` inside ~20 s. The resulting `OOMKilled` / leader-election thrash (>20 lease transitions / h in the reporter's environment) made tracing on busy clusters impossible without the all-or-nothing `OTEL_SDK_DISABLED=true` workaround.

## Root cause

The SDK's default `AttributeValueLengthLimit` is `-1` (unlimited) — see `sdktrace.NewSpanLimits()`. Any zap field or span attribute that wraps a serialized Kubernetes object (a Pod / StatefulSet / Service body via `otelzap`, or a future tracing addition) becomes multi-megabyte, and `BatchSpanProcessor` / `BatchLogProcessor` accumulate the unbounded payloads faster than the configured BSP/queue caps can drain them.

`OTEL_BSP_MAX_EXPORT_BATCH_SIZE` and `OTEL_BSP_MAX_QUEUE_SIZE` only bound the *count* of records per export, not the *byte* size of any individual record, so they cannot rescue a watch-cluster-wide pipeline.

## What changes

1. **4 KiB `AttributeValueLengthLimit` default** applied to both the `TracerProvider` (via `WithRawSpanLimits`) and the `LoggerProvider` (via `sdklog.WithAttributeValueLengthLimit`). This guarantees that no single attribute can blow up a batch even if a future code path embeds a large object.
2. **Standard OTel env-var overrides** are honored: `OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT`, `OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT`, and the cross-signal fallback `OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT`. A negative override is coerced back to the safe default — unlimited would re-enable the bug.
3. **Per-signal disable** via `OTEL_TRACES_EXPORTER=none` / `OTEL_METRICS_EXPORTER=none` / `OTEL_LOGS_EXPORTER=none` is now honored, mirroring the cluster-manager PR (aerospike-cluster-manager#403). Operators can keep logs+metrics flowing while turning traces off if a single signal misbehaves, instead of disabling the entire SDK. Unsupported values fail loud at startup.
4. **`ZapCore()` is now nil when logs are disabled** so `cmd/main.go`'s `zap.WrapCore(zapcore.NewTee(...))` skips the OTLP log tee.
5. **`Provider.Enabled()` reflects "at least one signal exporting"**, so all-three-off via per-signal flags is a clean no-op and the `OpenTelemetry export enabled` setup log stays suppressed.

## Test plan

- [x] `internal/telemetry/telemetry_test.go`: signal disable matrix, unsupported-value rejection, attribute length resolver tests (default, specific-overrides-general, malformed/negative coercion), and an "all signals off" smoke test.
- [x] `go build ./...` clean.
- [x] `go test ./internal/telemetry/...` all passing.
- [ ] QA on Kind cluster: deploy the operator with `observability.otel.enabled=true` and a cluster-wide watch against a workload-heavy namespace; verify no `ResourceExhausted` `received message larger than max` from the collector and no OOMKills in the operator pod.
- [ ] Re-run with `OTEL_METRICS_EXPORTER=none` against a collector missing the metrics receiver; verify operator starts cleanly and only traces+logs flow.

## Migration notes

Existing deployments that rely on unlimited attribute values (none expected — the operator did not embed large attributes pre-fix either) can restore the prior SDK default with `OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT=99999` (any positive cap larger than 64 KiB requires bumping the test guard).