### PR TITLE
feat(chart): make ui.api container / port name configurable

### DIFF
--- a/charts/aerospike-ce-kubernetes-operator/Chart.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: aerospike-ce-kubernetes-operator
 description: Kubernetes Operator for Aerospike Community Edition clusters
 type: application
-version: 1.3.1
+version: 1.3.2
 appVersion: "1.3.1"
 kubeVersion: ">=1.26.0-0"
 home: https://github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator

--- a/charts/aerospike-ce-kubernetes-operator/templates/_helpers.tpl
+++ b/charts/aerospike-ce-kubernetes-operator/templates/_helpers.tpl
@@ -198,6 +198,24 @@ app.kubernetes.io/component: ui-web
 {{- end }}
 
 {{/*
+UI api container / port name. The value is used in five places that must
+agree (otherwise probes fail or Service selects nothing):
+  - Deployment containers[0].name
+  - Deployment containers[0].ports[0].name
+  - Service ports[0].name
+  - Service ports[0].targetPort (port name reference, not number)
+  - ServiceMonitor endpoints[0].port
+The default `api` keeps backwards compatibility. Override with
+`ui.api.containerName` when integrating with admission webhooks that match
+on container name (e.g. OpenTelemetry Operator
+`instrumentation.opentelemetry.io/container-names`) — generic `api` is
+ambiguous across a namespace with other sidecars.
+*/}}
+{{- define "aerospike-ce-kubernetes-operator.ui.api.containerName" -}}
+{{- default "api" .Values.ui.api.containerName -}}
+{{- end }}
+
+{{/*
 Chart-managed PostgreSQL (ui.database.postgresql.deploy=true) name & labels.
 */}}
 {{- define "aerospike-ce-kubernetes-operator.ui.postgres.fullname" -}}

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/deployment-api.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/deployment-api.yaml
@@ -150,11 +150,11 @@ spec:
         {{- end }}
       {{- end }}
       containers:
-        - name: api
+        - name: {{ include "aerospike-ce-kubernetes-operator.ui.api.containerName" . }}
           image: {{ include "aerospike-ce-kubernetes-operator.ui.api.image" . }}
           imagePullPolicy: {{ .Values.ui.api.image.pullPolicy }}
           ports:
-            - name: api
+            - name: {{ include "aerospike-ce-kubernetes-operator.ui.api.containerName" . }}
               containerPort: {{ .Values.ui.api.service.targetPort }}
               protocol: TCP
           envFrom:

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/service.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/service.yaml
@@ -16,9 +16,9 @@ metadata:
 spec:
   type: {{ .Values.ui.api.service.type }}
   ports:
-    - name: api
+    - name: {{ include "aerospike-ce-kubernetes-operator.ui.api.containerName" . }}
       port: {{ .Values.ui.api.service.port }}
-      targetPort: api
+      targetPort: {{ include "aerospike-ce-kubernetes-operator.ui.api.containerName" . }}
       protocol: TCP
       appProtocol: http
   selector:

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/servicemonitor.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/servicemonitor.yaml
@@ -11,7 +11,7 @@ metadata:
     {{- end }}
 spec:
   endpoints:
-    - port: api
+    - port: {{ include "aerospike-ce-kubernetes-operator.ui.api.containerName" . }}
       scheme: http
       path: /api/metrics
       {{- with .Values.ui.metrics.serviceMonitor.interval }}

--- a/charts/aerospike-ce-kubernetes-operator/values.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/values.yaml
@@ -419,6 +419,17 @@ ui:
     # Set to false to deploy only the web frontend (then set
     # `ui.web.env.apiUrl` to your external API endpoint).
     enabled: true
+    # -- Container / port name used by the api Deployment and its Service
+    # (and ServiceMonitor port reference). Default `api` keeps backwards
+    # compatibility, but the generic name collides with admission webhooks
+    # that filter on container name in a namespace shared with other
+    # workloads (e.g. OpenTelemetry Operator
+    # `instrumentation.opentelemetry.io/container-names`). Override with a
+    # specific name like `cluster-manager-api` to disambiguate. When
+    # overridden, the api `livenessProbe` / `readinessProbe` / `startupProbe`
+    # `httpGet.port` (named port reference) under `ui.api.*Probe` must be
+    # updated to the same value.
+    containerName: api
     image:
       repository: ghcr.io/aerospike-ce-ecosystem/aerospike-cluster-manager-api
       # -- Container image tag. Leave empty to fall through to


### PR DESCRIPTION
## Motivation

The api Deployment hard-codes the container name and port name to the generic `api`. This makes admission webhooks filtering on container name ambiguous when the namespace contains other workloads exposing a container named `api`.

Concrete example: OpenTelemetry Operator's `instrumentation.opentelemetry.io/container-names: "api"` annotation will match any sibling container in the same pod (or any other pod the same annotation is attached to) that happens to be named `api`. Users that want a precise, descriptive name like `cluster-manager-api` currently have to apply a kustomize patch with five coordinated edits.

## Change

Expose a new value `ui.api.containerName` (default `api` — backwards compatible) and route the five hard-coded references through a single helper template `aerospike-ce-kubernetes-operator.ui.api.containerName`:

- `Deployment.spec.template.spec.containers[0].name`
- `Deployment.spec.template.spec.containers[0].ports[0].name`
- `Service.spec.ports[0].name`
- `Service.spec.ports[0].targetPort` (named-port reference)
- `ServiceMonitor.spec.endpoints[0].port`

## Probe ports — manual sync

`livenessProbe` / `readinessProbe` / `startupProbe` `httpGet.port` (in values.yaml under `ui.api.*Probe`) are also named-port references. They are not templated through the helper because the whole probe block is `toYaml`-rendered from user-supplied values. When overriding `containerName`, users must update the three probe ports to the same value. The behavior is documented in `values.yaml` next to the new `containerName` field.

## Validation

\`helm template\` with default values produces identical output to the previous chart (port name `api`).

With \`--set ui.api.containerName=cluster-manager-api\` and the three probe port overrides, all five references + three probes resolve to the new name consistently — verified by inspecting the rendered Deployment / Service / ServiceMonitor.

## Versioning

Chart version 1.3.1 → 1.3.2. Additive, no breaking changes (default behavior unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)