### PR TITLE
fix(webhook): reject PodList mutation on InProgress operation

### DIFF
--- a/api/v1alpha1/aerospikecluster_webhook.go
+++ b/api/v1alpha1/aerospikecluster_webhook.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -283,7 +284,8 @@ func (v *AerospikeClusterValidator) ValidateUpdate(ctx context.Context, oldClust
 			return nil, fmt.Errorf("cannot change operations while operation %q is InProgress", oldCluster.Status.OperationStatus.ID)
 		}
 		for i := range oldOps {
-			if oldOps[i].ID != newOps[i].ID || oldOps[i].Kind != newOps[i].Kind {
+			if oldOps[i].ID != newOps[i].ID || oldOps[i].Kind != newOps[i].Kind ||
+				!slices.Equal(oldOps[i].PodList, newOps[i].PodList) {
 				return nil, fmt.Errorf("cannot change operations while operation %q is InProgress", oldCluster.Status.OperationStatus.ID)
 			}
 		}

--- a/api/v1alpha1/webhook_test.go
+++ b/api/v1alpha1/webhook_test.go
@@ -1994,6 +1994,47 @@ func TestValidateUpdate_RejectsOperationChangeWhileInProgress(t *testing.T) {
 	}
 }
 
+func TestValidateUpdate_RejectsPodListChangeWhileInProgress(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+
+	oldCluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:  3,
+			Image: "aerospike:ce-8.1.1.1",
+			Operations: []OperationSpec{
+				{Kind: OperationWarmRestart, ID: "op-1", PodList: []string{"pod-0", "pod-1"}},
+			},
+		},
+		Status: AerospikeClusterStatus{
+			OperationStatus: &OperationStatus{
+				ID:    "op-1",
+				Kind:  OperationWarmRestart,
+				Phase: AerospikePhaseInProgress,
+			},
+		},
+	}
+
+	// Same ID and Kind, but PodList changed — must still be rejected to avoid
+	// silently redirecting an in-flight operation to a different pod set.
+	newCluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:  3,
+			Image: "aerospike:ce-8.1.1.1",
+			Operations: []OperationSpec{
+				{Kind: OperationWarmRestart, ID: "op-1", PodList: []string{"pod-0", "pod-2"}},
+			},
+		},
+	}
+
+	_, err := v.ValidateUpdate(context.Background(), oldCluster, newCluster)
+	if err == nil {
+		t.Fatal("expected error when changing PodList of an InProgress operation")
+	}
+	if !strings.Contains(err.Error(), "InProgress") {
+		t.Errorf("error should mention 'InProgress', got: %v", err)
+	}
+}
+
 func TestValidateUpdate_AllowsSameOperationWhileInProgress(t *testing.T) {
 	v := &AerospikeClusterValidator{}
 


### PR DESCRIPTION
## Summary

\`AerospikeClusterValidator.ValidateUpdate\` already blocks the user from replacing the operations list while an operation is in \`Phase=InProgress\`, but the per-operation equality check only compared \`ID\` and \`Kind\`. A change to \`PodList\` on an in-flight operation slipped through the validator silently, and the reconciler would proceed with the *new* target pod set — restarting the wrong pods.

## Changes

- \`api/v1alpha1/aerospikecluster_webhook.go\`: also compare \`oldOps[i].PodList\` against \`newOps[i].PodList\` via \`slices.Equal\`. Identical error message; same semantics for \`ID\`/\`Kind\` changes.
- \`api/v1alpha1/webhook_test.go\`: add \`TestValidateUpdate_RejectsPodListChangeWhileInProgress\` covering the case where only \`PodList\` differs while ID/Kind stay the same.

## Test plan

- [x] \`go build ./api/v1alpha1/...\` passes
- [x] \`go test ./api/v1alpha1/... -run TestValidateUpdate\` passes (all existing webhook InProgress tests + new PodList test)
- [ ] CI: lint + full unit-test matrix