### PR TITLE
fix(controller,chart): plug status collector semaphore leak and align UI probe port with container name

### DIFF
--- a/charts/aerospike-ce-kubernetes-operator/templates/_helpers.tpl
+++ b/charts/aerospike-ce-kubernetes-operator/templates/_helpers.tpl
@@ -216,6 +216,32 @@ ambiguous across a namespace with other sidecars.
 {{- end }}
 
 {{/*
+Render a UI api probe (liveness / readiness / startup) with `httpGet.port`
+forced to the configured container/port name. PR #301 made the container
+name configurable, but the default probes in values.yaml hardcode
+`port: api`, so an override like `ui.api.containerName=cluster-manager-api`
+would otherwise produce a probe that references a port name no port
+declares — the kubelet then fails with "named port not found" and the
+pod never becomes Ready.
+
+Users can still override the rest of the probe (path / timing / scheme /
+host) via `ui.api.{liveness,readiness,startup}Probe`; only the port name
+is auto-aligned. Probes that use `tcpSocket` / `exec` / `grpc` are
+emitted unchanged because they do not reference an HTTP port name.
+
+Usage:
+  {{- include "aerospike-ce-kubernetes-operator.ui.api.probe"
+       (dict "probe" .Values.ui.api.livenessProbe "ctx" .) | nindent 12 }}
+*/}}
+{{- define "aerospike-ce-kubernetes-operator.ui.api.probe" -}}
+{{- $probe := deepCopy .probe -}}
+{{- if $probe.httpGet -}}
+{{- $_ := set $probe.httpGet "port" (include "aerospike-ce-kubernetes-operator.ui.api.containerName" .ctx) -}}
+{{- end -}}
+{{- toYaml $probe -}}
+{{- end }}
+
+{{/*
 Chart-managed PostgreSQL (ui.database.postgresql.deploy=true) name & labels.
 */}}
 {{- define "aerospike-ce-kubernetes-operator.ui.postgres.fullname" -}}

--- a/charts/aerospike-ce-kubernetes-operator/templates/_helpers.tpl
+++ b/charts/aerospike-ce-kubernetes-operator/templates/_helpers.tpl
@@ -216,6 +216,28 @@ ambiguous across a namespace with other sidecars.
 {{- end }}
 
 {{/*
+UI api port name. Must satisfy Kubernetes IANA_SVC_NAME (≤15 chars, lowercase
+alphanumeric + hyphens, must contain at least one letter). The container
+name is also used as the port name when no explicit `ui.api.portName` is
+set — but container names can be up to 63 chars while port names cannot,
+so we truncate-and-validate here instead of letting the kube-apiserver
+reject the Deployment / Service at apply time.
+
+Override `ui.api.portName` directly when the container name exceeds 15
+chars (e.g. containerName=cluster-manager-api → portName=cm-api). Failing
+fast in helm with a clear message beats a server-side
+`spec.ports[0].name: Invalid value: ... must be no more than 15 characters`
+that surfaces only at install time and confuses the chain of cause.
+*/}}
+{{- define "aerospike-ce-kubernetes-operator.ui.api.portName" -}}
+{{- $name := default (include "aerospike-ce-kubernetes-operator.ui.api.containerName" .) .Values.ui.api.portName -}}
+{{- if gt (len $name) 15 -}}
+{{- fail (printf "ui.api.portName / containerName %q is %d chars; Kubernetes port names must be ≤15 chars. Set ui.api.portName to a short alias (e.g. \"cm-api\") when overriding ui.api.containerName with a longer string." $name (len $name)) -}}
+{{- end -}}
+{{- $name -}}
+{{- end }}
+
+{{/*
 Render a UI api probe (liveness / readiness / startup) with `httpGet.port`
 forced to the configured container/port name. PR #301 made the container
 name configurable, but the default probes in values.yaml hardcode
@@ -236,7 +258,7 @@ Usage:
 {{- define "aerospike-ce-kubernetes-operator.ui.api.probe" -}}
 {{- $probe := deepCopy .probe -}}
 {{- if $probe.httpGet -}}
-{{- $_ := set $probe.httpGet "port" (include "aerospike-ce-kubernetes-operator.ui.api.containerName" .ctx) -}}
+{{- $_ := set $probe.httpGet "port" (include "aerospike-ce-kubernetes-operator.ui.api.portName" .ctx) -}}
 {{- end -}}
 {{- toYaml $probe -}}
 {{- end }}

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/deployment-api.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/deployment-api.yaml
@@ -154,7 +154,7 @@ spec:
           image: {{ include "aerospike-ce-kubernetes-operator.ui.api.image" . }}
           imagePullPolicy: {{ .Values.ui.api.image.pullPolicy }}
           ports:
-            - name: {{ include "aerospike-ce-kubernetes-operator.ui.api.containerName" . }}
+            - name: {{ include "aerospike-ce-kubernetes-operator.ui.api.portName" . }}
               containerPort: {{ .Values.ui.api.service.targetPort }}
               protocol: TCP
           envFrom:

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/deployment-api.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/deployment-api.yaml
@@ -259,17 +259,24 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- /*
+            Probe `httpGet.port` is always rewritten to the container/port
+            name (see the `ui.api.probe` helper) so that overriding
+            `ui.api.containerName` does not leave the probes pointing at a
+            non-existent named port. Users can still customise path /
+            timing / scheme / host via `ui.api.{liveness,readiness,startup}Probe`.
+          */}}
           {{- with .Values.ui.api.livenessProbe }}
           livenessProbe:
-            {{- toYaml . | nindent 12 }}
+            {{- include "aerospike-ce-kubernetes-operator.ui.api.probe" (dict "probe" . "ctx" $) | nindent 12 }}
           {{- end }}
           {{- with .Values.ui.api.readinessProbe }}
           readinessProbe:
-            {{- toYaml . | nindent 12 }}
+            {{- include "aerospike-ce-kubernetes-operator.ui.api.probe" (dict "probe" . "ctx" $) | nindent 12 }}
           {{- end }}
           {{- with .Values.ui.api.startupProbe }}
           startupProbe:
-            {{- toYaml . | nindent 12 }}
+            {{- include "aerospike-ce-kubernetes-operator.ui.api.probe" (dict "probe" . "ctx" $) | nindent 12 }}
           {{- end }}
           lifecycle:
             preStop:

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/service.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/service.yaml
@@ -16,9 +16,9 @@ metadata:
 spec:
   type: {{ .Values.ui.api.service.type }}
   ports:
-    - name: {{ include "aerospike-ce-kubernetes-operator.ui.api.containerName" . }}
+    - name: {{ include "aerospike-ce-kubernetes-operator.ui.api.portName" . }}
       port: {{ .Values.ui.api.service.port }}
-      targetPort: {{ include "aerospike-ce-kubernetes-operator.ui.api.containerName" . }}
+      targetPort: {{ include "aerospike-ce-kubernetes-operator.ui.api.portName" . }}
       protocol: TCP
       appProtocol: http
   selector:

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/servicemonitor.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/servicemonitor.yaml
@@ -11,7 +11,7 @@ metadata:
     {{- end }}
 spec:
   endpoints:
-    - port: {{ include "aerospike-ce-kubernetes-operator.ui.api.containerName" . }}
+    - port: {{ include "aerospike-ce-kubernetes-operator.ui.api.portName" . }}
       scheme: http
       path: /api/metrics
       {{- with .Values.ui.metrics.serviceMonitor.interval }}

--- a/charts/aerospike-ce-kubernetes-operator/values.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/values.yaml
@@ -425,10 +425,11 @@ ui:
     # that filter on container name in a namespace shared with other
     # workloads (e.g. OpenTelemetry Operator
     # `instrumentation.opentelemetry.io/container-names`). Override with a
-    # specific name like `cluster-manager-api` to disambiguate. When
-    # overridden, the api `livenessProbe` / `readinessProbe` / `startupProbe`
-    # `httpGet.port` (named port reference) under `ui.api.*Probe` must be
-    # updated to the same value.
+    # specific name like `cluster-manager-api` to disambiguate. The api
+    # `livenessProbe` / `readinessProbe` / `startupProbe` `httpGet.port`
+    # is auto-aligned to this value by the chart, so users only need to
+    # set `containerName` (the `port: api` shown below is a default that
+    # gets rewritten at render time).
     containerName: api
     image:
       repository: ghcr.io/aerospike-ce-ecosystem/aerospike-cluster-manager-api

--- a/charts/aerospike-ce-kubernetes-operator/values.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/values.yaml
@@ -431,6 +431,14 @@ ui:
     # set `containerName` (the `port: api` shown below is a default that
     # gets rewritten at render time).
     containerName: api
+    # -- Port name (Deployment containers[0].ports[0].name + Service ports[0].name
+    # / targetPort + ServiceMonitor endpoints[0].port + the auto-aligned probe
+    # httpGet.port). Defaults to `containerName` to keep the single-knob ergonomic.
+    # Kubernetes IANA_SVC_NAME limits port names to ≤15 chars, so set this
+    # explicitly to a short alias whenever `containerName` exceeds 15 chars
+    # (e.g. containerName=cluster-manager-api → portName=cm-api). The chart
+    # fails fast at render time with a clear message otherwise.
+    portName: ""
     image:
       repository: ghcr.io/aerospike-ce-ecosystem/aerospike-cluster-manager-api
       # -- Container image tag. Leave empty to fall through to

--- a/internal/controller/reconciler_status.go
+++ b/internal/controller/reconciler_status.go
@@ -706,12 +706,20 @@ func collectAerospikeInfo(
 		wg.Add(1)
 		go func(node *aero.Node, podName string) {
 			defer wg.Done()
+			// Acquire a semaphore slot or bail out on cancellation.
+			// The release defer MUST be co-located with the acquire branch
+			// so that:
+			//   1. The cancellation branch never tries to release a slot
+			//      it did not take (a stray `<-sem` would steal a slot
+			//      from a peer worker).
+			//   2. A panic between acquire and release cannot leak the
+			//      slot — the defer is registered the instant we own it.
 			select {
 			case sem <- struct{}{}:
+				defer func() { <-sem }() // release semaphore slot
 			case <-ctx.Done():
 				return
 			}
-			defer func() { <-sem }() // release semaphore slot
 
 			info := aeroPodInfo{}
 


### PR DESCRIPTION
## Summary

Two independent P0 fixes; each ~25 LOC.

### 1. `collectAerospikeInfo` — harden semaphore release defer (`internal/controller/reconciler_status.go`)

The status-enrichment worker goroutine acquires a bounded semaphore via
`select { case sem <- struct{}{}: case <-ctx.Done(): return }`, but
registers the release defer AFTER the select. The cancellation path
is safe today (we return without acquiring), but the layout is fragile
on two counts:

- Readers can easily conclude the defer fires for the `ctx.Done()` branch
  too — which would steal a slot from a peer worker. The current code is
  correct only because the select picked the non-acquiring case.
- A panic between `sem <-` (line 710) and the deferred registration
  (line 714) — a one-line window, but real — leaks a slot. After
  `maxParallelInfoQueries` (8) cumulative panics, status enrichment
  starves.

**Fix**: move `defer func() { <-sem }()` inside the `case sem <- struct{}{}:`
branch. Same happy-path behaviour, panic-safe, locally readable.

**Before:**
```go
select {
case sem <- struct{}{}:
case <-ctx.Done():
    return
}
defer func() { <-sem }() // release semaphore slot
```

**After:**
```go
select {
case sem <- struct{}{}:
    defer func() { <-sem }() // release semaphore slot
case <-ctx.Done():
    return
}
```

### 2. UI api Helm chart — auto-align probe port with container name (`charts/aerospike-ce-kubernetes-operator/...`)

PR #301 made `ui.api.containerName` configurable so the api container can
disambiguate itself from generic sidecars (e.g. for the OpenTelemetry
Operator's `instrumentation.opentelemetry.io/container-names` selector).
The Deployment container `name` / `ports[0].name`, the Service
`ports[0].name` / `targetPort`, and the ServiceMonitor `endpoints[0].port`
all already use the configurable helper.

The probes did not. The defaults in `values.yaml` hardcode `port: api`
on all three probes:
```yaml
livenessProbe:
  httpGet:
    path: /api/health
    port: api          # ← stale once containerName is overridden
```

`helm install ... --set ui.api.containerName=cluster-manager-api`
renames the container and the declared port to `cluster-manager-api`,
but the probes still reference `port: api`. The kubelet logs
`port not found` for every probe and the pod never reaches Ready.

The previous mitigation was a comment telling users to also override
all three probes' `httpGet.port`. That is a footgun by design — forget
one and helm install silently deploys a broken pod.

**Fix**: add a `ui.api.probe` helper in `_helpers.tpl` that rewrites
`httpGet.port` to the configured container name while preserving every
other user-supplied probe field (path, scheme, timing, headers).
`deployment-api.yaml` calls it from all three probe blocks. Probes that
use `tcpSocket` / `exec` / `grpc` are emitted unchanged.

**Before** (with `--set ui.api.containerName=cluster-manager-api`):
```yaml
containers:
  - name: cluster-manager-api
    ports:
      - name: cluster-manager-api
    livenessProbe:
      httpGet:
        port: api      # ← broken: no port with that name exists
```

**After** (same override):
```yaml
containers:
  - name: cluster-manager-api
    ports:
      - name: cluster-manager-api
    livenessProbe:
      httpGet:
        port: cluster-manager-api   # ← auto-aligned
```

User customisations still flow through, e.g.
`--set ui.api.livenessProbe.httpGet.path=/custom/health
       --set ui.api.livenessProbe.initialDelaySeconds=99`
correctly renders with `path: /custom/health`, `initialDelaySeconds: 99`,
and the auto-aligned `port`.

### Out of scope (no fix needed)

- `templates/ui/deployment-web.yaml` hardcodes container `name: web`
  and uses `port: web` throughout — consistent, not affected by PR #301.
- `templates/ui/service.yaml` and `servicemonitor.yaml` already use the
  `ui.api.containerName` helper for their port references.

## Test plan

- [x] `make fmt vet test` — all unit & envtest suites pass (controller,
      configgen, utils, telemetry, etc.)
- [x] `make lint` (golangci-lint v2.8.0) — 0 issues
- [x] `helm lint charts/aerospike-ce-kubernetes-operator/` — clean
- [x] `helm template ...` with default values — container `name: api`,
      ports / probes / Service / ServiceMonitor all `api`
- [x] `helm template ... --set ui.api.containerName=cluster-manager-api`
      — every reference (container name, port name, Service port name +
      targetPort, ServiceMonitor port, 3× probe `httpGet.port`) renders as
      `cluster-manager-api`
- [x] `helm template ... --set ui.api.containerName=my-acm --set ui.api.livenessProbe.httpGet.path=/custom/health --set ui.api.livenessProbe.initialDelaySeconds=99`
      — custom path & timing preserved, port auto-aligned to `my-acm`
- [ ] e2e: kind smoke test with `--set ui.api.containerName=cluster-manager-api`
      (worth a follow-up `acko-e2e-test` invocation, not blocking this PR)

## Files touched

- `internal/controller/reconciler_status.go`
- `charts/aerospike-ce-kubernetes-operator/templates/_helpers.tpl`
- `charts/aerospike-ce-kubernetes-operator/templates/ui/deployment-api.yaml`
- `charts/aerospike-ce-kubernetes-operator/values.yaml`