### PR TITLE
fix(webhook): skip batch-size warning when size deferred to templateRef

### DIFF
--- a/api/v1alpha1/aerospikecluster_webhook.go
+++ b/api/v1alpha1/aerospikecluster_webhook.go
@@ -1228,7 +1228,16 @@ func (v *AerospikeClusterValidator) validateWorkDirectory(cluster *AerospikeClus
 }
 
 // validateBatchSize checks the rolling update batch size against cluster size.
+//
+// When spec.size is 0 and spec.templateRef is set, the size will be supplied
+// later by the resolved template; the bs > size comparison is skipped to avoid
+// a spurious "all pods may restart simultaneously" warning that fires for every
+// templateRef-backed cluster with rollingUpdateBatchSize>0. Mirrors the
+// sizeDeferredToTemplate pattern used in validateReplicationFactor.
 func (v *AerospikeClusterValidator) validateBatchSize(cluster *AerospikeCluster) admission.Warnings {
+	if cluster.Spec.Size == 0 && cluster.Spec.TemplateRef != nil {
+		return nil
+	}
 	if cluster.Spec.RollingUpdateBatchSize == nil {
 		return nil
 	}

--- a/api/v1alpha1/webhook_test.go
+++ b/api/v1alpha1/webhook_test.go
@@ -941,6 +941,33 @@ func TestValidate_RollingUpdateBatchSizeNil(t *testing.T) {
 	}
 }
 
+// TestValidate_RollingUpdateBatchSizeDeferredToTemplate confirms that the
+// batchSize > size warning is suppressed when spec.size is 0 and a templateRef
+// is set. Without the guard every templateRef-backed cluster with
+// rollingUpdateBatchSize>0 produces a spurious "all pods may restart
+// simultaneously" warning because spec.Size is 0 at admission time.
+func TestValidate_RollingUpdateBatchSizeDeferredToTemplate(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+	cluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:                   0,
+			TemplateRef:            &TemplateRef{Name: "ce-template"},
+			RollingUpdateBatchSize: int32Ptr(2),
+		},
+	}
+
+	warnings, err := v.validate(cluster)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, w := range warnings {
+		if strings.Contains(w, "rollingUpdateBatchSize") {
+			t.Errorf("batchSize warning should be deferred to template resolution, got: %v", w)
+		}
+	}
+}
+
 // --- Defaulter core behavior tests ---
 
 func TestDefault_SetsClusterName(t *testing.T) {


### PR DESCRIPTION
## Summary

- `validateBatchSize` compared `rollingUpdateBatchSize` against `spec.Size` unconditionally, producing a spurious "all pods may restart simultaneously" warning for every `templateRef`-backed cluster (where `spec.Size==0` at admission and the real size is supplied by the template).
- Add an early-return guard at the top of `validateBatchSize` that mirrors the `sizeDeferredToTemplate` pattern already used in `validateReplicationFactor`. When `spec.Size==0 && spec.TemplateRef != nil`, the batch-size check is deferred to post-template-merge validation.

### Out of scope / not changed

The original ask also mentioned adding `case int64` to the `validateNamespaceConfig` replication-factor type switch. On inspection, that case is **already present** in the current `main` (added in #289), so no change was needed there. The PR title and message reflect the actual delivered change.

## Test plan

- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [x] `make manifests generate fmt vet` — no codegen drift
- [x] `go test ./api/... -count=1 -timeout=2m` — PASS (incl. new `TestValidate_RollingUpdateBatchSizeDeferredToTemplate`)
- [x] All 5 `TestValidate_RollingUpdateBatchSize*` tests pass (existing 4 + new 1)