### PR TITLE
fix(webhook): skip maxUnavailable/rackBatchSize warnings when size deferred to templateRef

### DIFF
--- a/api/v1alpha1/aerospikecluster_webhook.go
+++ b/api/v1alpha1/aerospikecluster_webhook.go
@@ -1249,7 +1249,16 @@ func (v *AerospikeClusterValidator) validateBatchSize(cluster *AerospikeCluster)
 }
 
 // validateMaxUnavailable warns if maxUnavailable is >= cluster size.
+//
+// When spec.size is 0 and spec.templateRef is set, the size will be supplied
+// later by the resolved template; the mu >= size comparison is skipped to avoid
+// a spurious "PodDisruptionBudget will not prevent full disruption" warning
+// that fires for every templateRef-backed cluster with maxUnavailable set.
+// Mirrors the sizeDeferredToTemplate pattern used in validateBatchSize (#305).
 func (v *AerospikeClusterValidator) validateMaxUnavailable(cluster *AerospikeCluster) admission.Warnings {
+	if cluster.Spec.Size == 0 && cluster.Spec.TemplateRef != nil {
+		return nil
+	}
 	if cluster.Spec.MaxUnavailable == nil {
 		return nil
 	}
@@ -1798,8 +1807,18 @@ func (v *AerospikeClusterValidator) validateNetworkPortUniqueness(cluster *Aeros
 }
 
 // validateRackBatchSize warns when a rack-level percentage batch size resolves to 0 pods.
+//
+// When spec.size is 0 and spec.templateRef is set, the size will be supplied
+// later by the resolved template; the percentage-resolves-to-0 check is skipped
+// to avoid a spurious "resolves to 0 pods for cluster size 0" warning that
+// fires for every templateRef-backed cluster with a percentage
+// rackConfig.rollingUpdateBatchSize. Mirrors the sizeDeferredToTemplate pattern
+// used in validateBatchSize (#305).
 func (v *AerospikeClusterValidator) validateRackBatchSize(cluster *AerospikeCluster) admission.Warnings {
 	if cluster.Spec.RackConfig == nil || cluster.Spec.RackConfig.RollingUpdateBatchSize == nil {
+		return nil
+	}
+	if cluster.Spec.Size == 0 && cluster.Spec.TemplateRef != nil {
 		return nil
 	}
 	bs := cluster.Spec.RackConfig.RollingUpdateBatchSize

--- a/api/v1alpha1/webhook_test.go
+++ b/api/v1alpha1/webhook_test.go
@@ -3604,6 +3604,34 @@ func TestValidate_MaxUnavailableNil(t *testing.T) {
 	}
 }
 
+// TestValidate_MaxUnavailableDeferredToTemplate confirms that the
+// maxUnavailable >= size warning is suppressed when spec.size is 0 and a
+// templateRef is set. Without the guard every templateRef-backed cluster with
+// maxUnavailable set produces a spurious "PodDisruptionBudget will not prevent
+// full disruption" warning because spec.Size is 0 at admission time.
+func TestValidate_MaxUnavailableDeferredToTemplate(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+	mu := intstr.FromInt32(1)
+	cluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:           0,
+			TemplateRef:    &TemplateRef{Name: "ce-template"},
+			MaxUnavailable: &mu,
+		},
+	}
+
+	warnings, err := v.validate(cluster)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, w := range warnings {
+		if strings.Contains(w, "maxUnavailable") {
+			t.Errorf("maxUnavailable warning should be deferred to template resolution, got: %v", w)
+		}
+	}
+}
+
 // --- ServiceMonitor / Monitoring consistency tests ---
 
 func TestValidate_ServiceMonitorEnabledWithoutMonitoring(t *testing.T) {
@@ -5195,6 +5223,38 @@ func TestValidate_RackBatchSize_NilRackConfig(t *testing.T) {
 	for _, w := range warnings {
 		if strings.Contains(w, "resolves to 0 pods") {
 			t.Errorf("unexpected rack batch size warning when rackConfig is nil: %v", w)
+		}
+	}
+}
+
+// TestValidate_RackBatchSizeDeferredToTemplate confirms that the
+// rackConfig.rollingUpdateBatchSize percentage-resolves-to-0 warning is
+// suppressed when spec.size is 0 and a templateRef is set. Without the guard
+// every templateRef-backed cluster with a percentage
+// rackConfig.rollingUpdateBatchSize produces a spurious "resolves to 0 pods
+// for cluster size 0" warning because spec.Size is 0 at admission time.
+func TestValidate_RackBatchSizeDeferredToTemplate(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+	bs := intstr.FromString("50%")
+	cluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:        0,
+			TemplateRef: &TemplateRef{Name: "ce-template"},
+			RackConfig: &RackConfig{
+				Racks:                  []Rack{{ID: 1}},
+				RollingUpdateBatchSize: &bs,
+			},
+		},
+	}
+
+	warnings, err := v.validate(cluster)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, w := range warnings {
+		if strings.Contains(w, "rackConfig.rollingUpdateBatchSize") || strings.Contains(w, "resolves to 0 pods") {
+			t.Errorf("rackConfig.rollingUpdateBatchSize warning should be deferred to template resolution, got: %v", w)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Recently merged PR #305 added a templateRef defer-guard to `validateBatchSize`. Two sister validators have the **exact same bug pattern**: they compare against `cluster.Spec.Size` unconditionally, producing spurious / mathematically-bogus warnings on every CREATE/UPDATE of a templateRef-backed cluster (Size=0 at admission, resolved by the template later).

This PR ports the same one-liner guard to both.

### Bug shape

For any templateRef-backed cluster (`spec.size: 0`, `spec.templateRef.name: <template>`):

- **`validateMaxUnavailable`** fires `"maxUnavailable (N) is >= cluster size (0); PodDisruptionBudget will not prevent full disruption"` whenever `maxUnavailable` is set, because `N >= 0` is always true.
- **`validateRackBatchSize`** fires `"rackConfig.rollingUpdateBatchSize \"X%\" resolves to 0 pods for cluster size 0; effective batch size will be clamped to 1"` for any percentage value, because `int(0) * num / 100 == 0`.

Both warnings are mathematically meaningless until the templateRef is resolved.

### Changes

`api/v1alpha1/aerospikecluster_webhook.go`:
- `validateMaxUnavailable` (line ~1252): add `if cluster.Spec.Size == 0 && cluster.Spec.TemplateRef != nil { return nil }` at the very top, with a comment mirroring #305.
- `validateRackBatchSize` (line ~1801): same one-liner guard placed right after the existing `RackConfig == nil || RollingUpdateBatchSize == nil` early-return.

`api/v1alpha1/webhook_test.go`:
- `TestValidate_MaxUnavailableDeferredToTemplate` — Size=0, TemplateRef set, `MaxUnavailable=1`; asserts no warning contains "maxUnavailable".
- `TestValidate_RackBatchSizeDeferredToTemplate` — Size=0, TemplateRef set, `RackConfig.RollingUpdateBatchSize="50%"`; asserts no warning contains "rackConfig.rollingUpdateBatchSize" or "resolves to 0 pods".

### Precedent

- #305 — `fix(webhook): skip batch-size warning when size deferred to templateRef` (the literal template this PR follows).
- `validateReplicationFactor` already uses the same `sizeDeferredToTemplate` pattern.

## Test plan

- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `go test ./api/... -count=1 -timeout=2m` passes (both new tests + all existing MaxUnavailable / RackBatchSize tests)
- [x] `make manifests generate fmt vet` clean (no codegen drift)
- [ ] CI passes