### PR TITLE
fix(monitoring): wrap r.Update and reconcile errors with context

### DIFF
--- a/internal/controller/reconciler_monitoring.go
+++ b/internal/controller/reconciler_monitoring.go
@@ -44,7 +44,7 @@ func (r *AerospikeClusterReconciler) reconcileMonitoring(
 
 	// Reconcile metrics Service
 	if err := r.reconcileMetricsService(ctx, cluster, monitoringEnabled); err != nil {
-		return err
+		return fmt.Errorf("reconciling metrics service: %w", err)
 	}
 
 	// Reconcile ServiceMonitor
@@ -149,7 +149,10 @@ func (r *AerospikeClusterReconciler) reconcileMetricsService(
 	existing.Spec.Selector = desired.Spec.Selector
 	existing.Labels = labels
 	log.Info("Updating metrics Service", "name", svcName)
-	return r.Update(ctx, existing)
+	if err := r.Update(ctx, existing); err != nil {
+		return fmt.Errorf("updating metrics service %s: %w", svcName, err)
+	}
+	return nil
 }
 
 func (r *AerospikeClusterReconciler) reconcileServiceMonitor(
@@ -238,7 +241,10 @@ func (r *AerospikeClusterReconciler) reconcileServiceMonitor(
 	existing.Object["spec"] = smSpec
 	existing.SetLabels(labels)
 	log.Info("Updating ServiceMonitor", "name", smName)
-	return r.Update(ctx, existing)
+	if err := r.Update(ctx, existing); err != nil {
+		return fmt.Errorf("updating ServiceMonitor %s: %w", smName, err)
+	}
+	return nil
 }
 
 func toStringMap(m map[string]string) map[string]any {
@@ -340,7 +346,10 @@ func (r *AerospikeClusterReconciler) reconcilePrometheusRule(
 	existing.Object["spec"] = prSpec
 	existing.SetLabels(labels)
 	log.Info("Updating PrometheusRule", "name", prName)
-	return r.Update(ctx, existing)
+	if err := r.Update(ctx, existing); err != nil {
+		return fmt.Errorf("updating PrometheusRule %s: %w", prName, err)
+	}
+	return nil
 }
 
 func unstructuredResourceChanged(


### PR DESCRIPTION
## Summary

Pure error-context consistency fix in `internal/controller/reconciler_monitoring.go`. No behavior change.

Four sites were returning bare errors while every sibling code path (create, delete, get, sibling reconcile callers) consistently wraps with `fmt.Errorf("...: %w", err)`. This made operator debug logs inconsistent across monitoring failure modes.

Now wrapped:

- `reconcileMonitoring` -> `reconcileMetricsService` caller: `reconciling metrics service: %w`
- `reconcileMetricsService` -> `r.Update` (metrics Service): `updating metrics service %s: %w`
- `reconcileServiceMonitor` -> `r.Update` (ServiceMonitor): `updating ServiceMonitor %s: %w`
- `reconcilePrometheusRule` -> `r.Update` (PrometheusRule): `updating PrometheusRule %s: %w`

Wrapping format matches the existing patterns in the same file (e.g. `getting metrics service %s: %w`, `reconciling ServiceMonitor: %w`, `reconciling PrometheusRule: %w`).

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [ ] CI lint + unit tests