### PR TITLE
fix(controller): correct ConfigApplied condition for per-rack config overrides

### DIFF
--- a/internal/controller/reconciler.go
+++ b/internal/controller/reconciler.go
@@ -667,10 +667,7 @@ func (r *AerospikeClusterReconciler) reconcileCluster(
 	// ConfigApplied condition accepts pods in racks that override config. Each
 	// pod carries its rack's effective hash (rackInfos[i].hash), not a single
 	// cluster-level hash.
-	validConfigHashes := make(map[string]bool, len(rackInfos))
-	for i := range rackInfos {
-		validConfigHashes[rackInfos[i].hash] = true
-	}
+	validConfigHashes := buildValidConfigHashes(rackInfos)
 
 	// Update status and set phase to Completed.
 	statusOpts := StatusUpdateOpts{ACLErr: aclErr, ACLSynced: aclSynced, ValidConfigHashes: validConfigHashes}
@@ -695,6 +692,18 @@ func (r *AerospikeClusterReconciler) reconcileCluster(
 	}
 
 	return ctrl.Result{}, nil
+}
+
+// buildValidConfigHashes returns the set of acceptable effective per-rack
+// config hashes. A pod is considered to carry the desired config when its
+// ConfigHash is a key in this set (see setFineGrainedConditions). Extracted
+// from reconcileCluster to keep that function's cyclomatic complexity in check.
+func buildValidConfigHashes(rackInfos []rackInfo) map[string]bool {
+	validConfigHashes := make(map[string]bool, len(rackInfos))
+	for i := range rackInfos {
+		validConfigHashes[rackInfos[i].hash] = true
+	}
+	return validConfigHashes
 }
 
 // rackInfo holds pre-computed per-rack configuration used during reconciliation.

--- a/internal/controller/reconciler.go
+++ b/internal/controller/reconciler.go
@@ -663,8 +663,17 @@ func (r *AerospikeClusterReconciler) reconcileCluster(
 		aclSynced = synced
 	}
 
+	// Build the set of acceptable effective per-rack config hashes so the
+	// ConfigApplied condition accepts pods in racks that override config. Each
+	// pod carries its rack's effective hash (rackInfos[i].hash), not a single
+	// cluster-level hash.
+	validConfigHashes := make(map[string]bool, len(rackInfos))
+	for i := range rackInfos {
+		validConfigHashes[rackInfos[i].hash] = true
+	}
+
 	// Update status and set phase to Completed.
-	statusOpts := StatusUpdateOpts{ACLErr: aclErr, ACLSynced: aclSynced}
+	statusOpts := StatusUpdateOpts{ACLErr: aclErr, ACLSynced: aclSynced, ValidConfigHashes: validConfigHashes}
 	if err := r.updateStatusAndPhase(ctx, namespacedName, ackov1alpha1.AerospikePhaseCompleted, "Cluster is healthy and stable", statusOpts); err != nil {
 		if errors.IsConflict(err) {
 			return ctrl.Result{Requeue: true}, nil
@@ -1092,6 +1101,16 @@ func truncateUTF8(s string, maxBytes int) string {
 		return s
 	}
 	const suffix = "..."
+	// When the budget cannot fit the suffix, appending it would exceed maxBytes
+	// (e.g. maxBytes=2 would still return the 3-byte "..."). Drop the suffix and
+	// truncate s to a valid UTF-8 boundary within maxBytes instead.
+	if maxBytes <= len(suffix) {
+		truncated := s[:max(maxBytes, 0)]
+		for len(truncated) > 0 && !utf8.ValidString(truncated) {
+			truncated = truncated[:len(truncated)-1]
+		}
+		return truncated
+	}
 	limit := max(maxBytes-len(suffix), 0)
 	truncated := s[:limit]
 	for len(truncated) > 0 && !utf8.ValidString(truncated) {

--- a/internal/controller/reconciler_status.go
+++ b/internal/controller/reconciler_status.go
@@ -38,6 +38,15 @@ type StatusUpdateOpts struct {
 	RestartInProgress bool
 	// Paused indicates reconciliation is paused (ReconciliationPaused=True).
 	Paused bool
+	// ValidConfigHashes is the set of acceptable effective per-rack config hashes.
+	// A pod is considered to have the desired config when its ConfigHash is a key
+	// in this set. This is required because each rack receives the effective hash
+	// of (cluster config DeepMerged with rack.AerospikeConfig), so a single
+	// cluster-level hash would never match pods in racks that override config.
+	// When nil, setFineGrainedConditions falls back to comparing every pod against
+	// the single cluster-level hash (used by callers/tests that do not compute
+	// per-rack hashes).
+	ValidConfigHashes map[string]bool
 }
 
 // updateStatusAndPhase re-fetches the latest cluster object from the API server,
@@ -521,13 +530,29 @@ func removeCondition(cluster *ackov1alpha1.AerospikeCluster, condType string) {
 // ConfigApplied, ReconciliationPaused, ACLSynced, MigrationComplete.
 // Called from updateStatusAndPhase after populateStatus.
 func setFineGrainedConditions(cluster *ackov1alpha1.AerospikeCluster, o StatusUpdateOpts) {
-	// ConfigApplied: true when all pods carry the same config hash as the desired config.
-	desiredHash := configHash(cluster.Spec.AerospikeConfig)
+	// ConfigApplied: true when every pod carries an accepted config hash.
+	//
+	// Pods receive the EFFECTIVE per-rack hash — (cluster config DeepMerged with
+	// rack.AerospikeConfig) — so a single cluster-level hash would never match
+	// pods belonging to a rack that overrides config, leaving ConfigApplied=False
+	// forever even after full convergence. When ValidConfigHashes is provided we
+	// accept any pod whose ConfigHash is in that set. Otherwise we fall back to
+	// the legacy single cluster-level hash comparison.
 	allConfigApplied := len(cluster.Status.Pods) > 0
-	for _, ps := range cluster.Status.Pods {
-		if ps.ConfigHash != desiredHash {
-			allConfigApplied = false
-			break
+	if o.ValidConfigHashes != nil {
+		for _, ps := range cluster.Status.Pods {
+			if !o.ValidConfigHashes[ps.ConfigHash] {
+				allConfigApplied = false
+				break
+			}
+		}
+	} else {
+		desiredHash := configHash(cluster.Spec.AerospikeConfig)
+		for _, ps := range cluster.Status.Pods {
+			if ps.ConfigHash != desiredHash {
+				allConfigApplied = false
+				break
+			}
 		}
 	}
 	if allConfigApplied {

--- a/internal/controller/reconciler_status_test.go
+++ b/internal/controller/reconciler_status_test.go
@@ -474,6 +474,80 @@ func TestSetFineGrainedConditions(t *testing.T) {
 			t.Errorf("MigrationComplete = %q, want True", cond.Status)
 		}
 	})
+
+	t.Run("ValidConfigHashes accepts per-rack override hashes: ConfigApplied=True", func(t *testing.T) {
+		// 2-rack cluster: rack 0 uses cluster config, rack 1 overrides config.
+		// Their effective hashes differ. Pods carry their rack's effective hash.
+		clusterCfg := &ackov1alpha1.AerospikeConfigSpec{
+			Value: map[string]any{"service": map[string]any{"proto-fd-max": 15000}},
+		}
+		rack1Cfg := &ackov1alpha1.AerospikeConfigSpec{
+			Value: map[string]any{"service": map[string]any{"proto-fd-max": 30000}},
+		}
+		rack0Hash := configHash(clusterCfg)
+		rack1Hash := configHash(rack1Cfg)
+		if rack0Hash == rack1Hash {
+			t.Fatal("test precondition failed: rack hashes should differ")
+		}
+
+		cluster := &ackov1alpha1.AerospikeCluster{}
+		cluster.Spec.AerospikeConfig = clusterCfg
+		cluster.Status.Pods = map[string]ackov1alpha1.AerospikePodStatus{
+			"c-0-0": {ConfigHash: rack0Hash},
+			"c-1-0": {ConfigHash: rack1Hash},
+		}
+
+		setFineGrainedConditions(cluster, StatusUpdateOpts{
+			ValidConfigHashes: map[string]bool{rack0Hash: true, rack1Hash: true},
+		})
+
+		cond := findCondition(cluster, ackov1alpha1.ConditionConfigApplied)
+		if cond == nil {
+			t.Fatal("ConfigApplied condition not found")
+		}
+		if cond.Status != metav1.ConditionTrue {
+			t.Errorf("ConfigApplied = %q, want True (per-rack override hash should be accepted)", cond.Status)
+		}
+	})
+
+	t.Run("ValidConfigHashes: pod with unknown hash keeps ConfigApplied=False", func(t *testing.T) {
+		cluster := &ackov1alpha1.AerospikeCluster{}
+		cluster.Status.Pods = map[string]ackov1alpha1.AerospikePodStatus{
+			"c-0-0": {ConfigHash: "goodhash"},
+			"c-1-0": {ConfigHash: "stalehash"},
+		}
+		setFineGrainedConditions(cluster, StatusUpdateOpts{
+			ValidConfigHashes: map[string]bool{"goodhash": true},
+		})
+
+		cond := findCondition(cluster, ackov1alpha1.ConditionConfigApplied)
+		if cond == nil {
+			t.Fatal("ConfigApplied condition not found")
+		}
+		if cond.Status != metav1.ConditionFalse {
+			t.Errorf("ConfigApplied = %q, want False (stale pod hash)", cond.Status)
+		}
+	})
+
+	t.Run("nil ValidConfigHashes falls back to single cluster-level hash", func(t *testing.T) {
+		clusterCfg := &ackov1alpha1.AerospikeConfigSpec{
+			Value: map[string]any{"service": map[string]any{"proto-fd-max": 15000}},
+		}
+		cluster := &ackov1alpha1.AerospikeCluster{}
+		cluster.Spec.AerospikeConfig = clusterCfg
+		cluster.Status.Pods = map[string]ackov1alpha1.AerospikePodStatus{
+			"c-0-0": {ConfigHash: configHash(clusterCfg)},
+		}
+		setFineGrainedConditions(cluster, StatusUpdateOpts{ValidConfigHashes: nil})
+
+		cond := findCondition(cluster, ackov1alpha1.ConditionConfigApplied)
+		if cond == nil {
+			t.Fatal("ConfigApplied condition not found")
+		}
+		if cond.Status != metav1.ConditionTrue {
+			t.Errorf("ConfigApplied = %q, want True (fallback path)", cond.Status)
+		}
+	})
 }
 
 func TestConditionsSnapshot(t *testing.T) {

--- a/internal/controller/reconciler_test.go
+++ b/internal/controller/reconciler_test.go
@@ -377,6 +377,38 @@ func TestTruncateUTF8(t *testing.T) {
 			maxBytes: 10,
 			want:     strings.Repeat("한", 2) + "...",
 		},
+		// maxBytes smaller than the "..." suffix (3 bytes): the suffix must be
+		// dropped so the result never exceeds maxBytes.
+		{
+			name:     "maxBytes 0 returns empty",
+			input:    "hello",
+			maxBytes: 0,
+			want:     "",
+		},
+		{
+			name:     "maxBytes 1 returns single byte without suffix",
+			input:    "hello",
+			maxBytes: 1,
+			want:     "h",
+		},
+		{
+			name:     "maxBytes 2 returns two bytes without suffix",
+			input:    "hello",
+			maxBytes: 2,
+			want:     "he",
+		},
+		{
+			name:     "maxBytes 3 equals suffix length returns three bytes without suffix",
+			input:    "hello",
+			maxBytes: 3,
+			want:     "hel",
+		},
+		{
+			name:     "maxBytes below suffix does not split multi-byte char",
+			input:    "한글",
+			maxBytes: 2,
+			want:     "", // first rune is 3 bytes; cannot fit 2 bytes, so empty
+		},
 	}
 
 	for _, tc := range tests {
@@ -384,6 +416,9 @@ func TestTruncateUTF8(t *testing.T) {
 			got := truncateUTF8(tc.input, tc.maxBytes)
 			if got != tc.want {
 				t.Errorf("truncateUTF8(%q, %d) = %q, want %q", tc.input, tc.maxBytes, got, tc.want)
+			}
+			if len(got) > tc.maxBytes && tc.maxBytes >= 0 {
+				t.Errorf("truncateUTF8(%q, %d) returned %d bytes, exceeds maxBytes", tc.input, tc.maxBytes, len(got))
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Three controller-side fixes found by a code analysis sweep against `main`. No CRD `apiVersion`/field/webhook-contract changes, no generated code touched — non-breaking.

### 1. (P1, headline) `ConfigApplied` condition is permanently `False` for racks that override config
`setFineGrainedConditions` compared every pod's `ConfigHash` against a single cluster-level hash `configHash(cluster.Spec.AerospikeConfig)`. But each pod carries its rack's **effective** hash — `configHash(getEffectiveConfig(cluster, rack))`, i.e. the cluster config DeepMerged with `rack.AerospikeConfig` (`reconciler.go` → `rackInfo.hash` → StatefulSet template `ConfigHashAnnotation` → pod status `ConfigHash`). So for any rack with a `rack.AerospikeConfig` override, `ConfigApplied` stayed `False` forever even after full convergence — misleading users and automation gating on the condition.

**Fix:** thread the set of accepted effective per-rack hashes through the status path:
- Added `ValidConfigHashes map[string]bool` to `StatusUpdateOpts`.
- `reconcileCluster` populates it from `rackInfos[i].hash` (already in scope at the `updateStatusAndPhase` call).
- `setFineGrainedConditions` accepts any pod whose `ConfigHash` is in the set, and **falls back** to the legacy single cluster-level hash comparison when `ValidConfigHashes == nil` (preserves behavior for other callers/tests).

### 2. (P2) `truncateUTF8` could exceed `maxBytes` for tiny limits
When `maxBytes < len("...")` the function returned the 3-byte `"..."`, exceeding the budget. Added a guard that drops the suffix and truncates to a valid UTF-8 boundary within `maxBytes`. (Not currently reachable — only caller passes 256 — pure hardening.)

### 3. (skipped) `parseMigrateStat` fail-safe — already fixed on `main`
Re-verification showed current `parseMigrateStat` already returns `(int64, bool)` and both callers fail-safe (treat present-but-unparseable as migrating). No change made.

## Tests
- `reconciler_status_test.go`: 2-rack cluster where one rack overrides config → `ConfigApplied=True`; stale-hash pod → `False`; nil-`ValidConfigHashes` fallback path.
- `reconciler_test.go`: `truncateUTF8` table cases for `maxBytes` ∈ {0,1,2,3} + multi-byte, with a "never exceeds maxBytes" assertion.

## Verification
- `go build ./...` ✅  `go vet ./...` ✅  `gofmt -l` (touched files) clean ✅
- `go test ./internal/controller/ -run 'TestSetFineGrainedConditions|TestTruncateUTF8'` ✅ and `go test ./api/...` ✅
- Full envtest/e2e suite not run locally (requires `KUBEBUILDER_ASSETS`); new tests are pure-function. A kind smoke test is being run separately to validate end-to-end reconcile + the per-rack `ConfigApplied` condition.

🤖 Automated improvement sweep (analysis → fix → verify).