### PR TITLE
fix(webhook): reject duplicate Aerospike namespace names

### DIFF
--- a/api/v1alpha1/aerospikecluster_webhook.go
+++ b/api/v1alpha1/aerospikecluster_webhook.go
@@ -668,6 +668,15 @@ func (v *AerospikeClusterValidator) validateAerospikeConfig(config map[string]an
 			if len(ns) > maxCENamespaces {
 				errors = append(errors, fmt.Sprintf("aerospikeConfig.namespaces count %d exceeds CE maximum of %d", len(ns), maxCENamespaces))
 			}
+			// Track namespace names to reject duplicates. configgen
+			// (generateNamespaceSections) emits one `namespace <name> { ... }`
+			// block per entry without de-duplicating, so two entries that share a
+			// name produce two identical-named blocks. aerospikd rejects a
+			// duplicate namespace definition at startup, leaving the pod in a
+			// permanent CrashLoopBackOff. Reject it here so the user gets an
+			// actionable admission error instead of a runtime crash — same
+			// fail-fast philosophy as the map/scalar shape checks below.
+			seenNsNames := make(map[string]bool, len(ns))
 			// Validate each namespace's config
 			for i, nsEntry := range ns {
 				nsMap, ok := nsEntry.(map[string]any)
@@ -675,8 +684,14 @@ func (v *AerospikeClusterValidator) validateAerospikeConfig(config map[string]an
 					errors = append(errors, fmt.Sprintf("aerospikeConfig.namespaces[%d] must be a map, got %T", i, nsEntry))
 					continue
 				}
-				if _, hasName := nsMap["name"]; !hasName {
+				if nameVal, hasName := nsMap["name"]; !hasName {
 					errors = append(errors, fmt.Sprintf("aerospikeConfig.namespaces[%d] is missing required 'name' key", i))
+				} else if name, ok := nameVal.(string); ok && name != "" {
+					if seenNsNames[name] {
+						errors = append(errors, fmt.Sprintf(
+							"aerospikeConfig.namespaces[%d]: duplicate namespace name %q; each namespace must have a unique name", i, name))
+					}
+					seenNsNames[name] = true
 				}
 				nsErrors, nsWarnings := v.validateNamespaceConfig(nsMap, i)
 				errors = append(errors, nsErrors...)

--- a/api/v1alpha1/webhook_test.go
+++ b/api/v1alpha1/webhook_test.go
@@ -419,6 +419,54 @@ func TestValidate_MaxNamespaces(t *testing.T) {
 	}
 }
 
+func TestValidate_DuplicateNamespaceNamesRejected(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+	cluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:  3,
+			Image: "aerospike:ce-8.1.1.1",
+			AerospikeConfig: &AerospikeConfigSpec{
+				Value: map[string]any{
+					"namespaces": []any{
+						map[string]any{"name": "test"},
+						map[string]any{"name": "test"},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := v.validate(cluster)
+	if err == nil {
+		t.Fatal("expected error for duplicate namespace names")
+	}
+	if !strings.Contains(err.Error(), "duplicate namespace name") {
+		t.Errorf("expected duplicate namespace name error, got: %v", err)
+	}
+}
+
+func TestValidate_DistinctNamespaceNamesAccepted(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+	cluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:  3,
+			Image: "aerospike:ce-8.1.1.1",
+			AerospikeConfig: &AerospikeConfigSpec{
+				Value: map[string]any{
+					"namespaces": []any{
+						map[string]any{"name": "ns1"},
+						map[string]any{"name": "ns2"},
+					},
+				},
+			},
+		},
+	}
+
+	if _, err := v.validate(cluster); err != nil {
+		t.Errorf("expected no error for distinct namespace names, got: %v", err)
+	}
+}
+
 func TestValidate_DuplicateRackIDs(t *testing.T) {
 	v := &AerospikeClusterValidator{}
 	cluster := &AerospikeCluster{


### PR DESCRIPTION
## Bug

The `AerospikeCluster` validating webhook (`api/v1alpha1/aerospikecluster_webhook.go`, `validateAerospikeConfig`) enforced several CE namespace constraints — count ≤ 2, each entry must be a map, each must have a `name`, no enterprise-only keys, RF bounds — but it **did not reject two namespace entries that share the same name**.

`internal/configgen/namespace.go` (`generateNamespaceSections`) emits one `namespace <name> { ... }` block per list entry **without de-duplicating**. So a CR like:

```yaml
aerospikeConfig:
  namespaces:
    - name: test
      storage-engine: { ... }
    - name: test          # duplicate
      storage-engine: { ... }
```

renders two `namespace test { ... }` blocks into `aerospike.conf`. `aerospikd` rejects a duplicate namespace definition at startup, so every pod lands in a **permanent CrashLoopBackOff** — a runtime failure the operator never surfaces as an admission error.

## Fix

Add duplicate-name detection in the `[]any` branch of the namespaces type switch. The first occurrence of a name is recorded; any later entry with the same non-empty string name produces an admission error:

```
aerospikeConfig.namespaces[1]: duplicate namespace name "test"; each namespace must have a unique name
```

This mirrors the existing fail-fast philosophy already documented for the map/scalar namespaces-shape checks ("Reject it here so the user gets an actionable admission error instead of [configgen] failing permanently at reconcile time"). Entries missing/with a blank/non-string name are left to the existing `name`-required check and are not counted as duplicates.

## Scope

- 1 cohesive change, 2 files, ~25 LOC.
- No CRD apiVersion bump, no field rename, no chart/version edits.
- Pure in-memory webhook validation; no behavior change for valid configs (distinct names still accepted).

## Verification (run locally on darwin/arm64)

| Command | Result |
|---|---|
| `go build ./...` | pass |
| `go vet ./api/... ./internal/...` | pass |
| `gofmt -l` on the 2 changed files | clean (empty) |
| `make test` (unit **+** integration/envtest, K8s 1.35 assets) | **all packages pass** |
| New test without fix | `TestValidate_DuplicateNamespaceNamesRejected` **FAILs** (confirms it catches the bug) |
| New test with fix | passes; `TestValidate_DistinctNamespaceNamesAccepted` passes (no false positives) |

New unit tests in `api/v1alpha1/webhook_test.go`:
- `TestValidate_DuplicateNamespaceNamesRejected`
- `TestValidate_DistinctNamespaceNamesAccepted`

This should pass CI including the envtest integration suite and Helm lint (no chart/CRD schema changes). Deploy-relevant: a kind smoke test applying a CR with two same-named namespaces would now get an admission rejection instead of a CrashLoopBackOff.