### PR TITLE
fix(webhook): enforce CE-8 minimum for single-segment image tags

### DIFF
--- a/api/v1alpha1/aerospikecluster_webhook.go
+++ b/api/v1alpha1/aerospikecluster_webhook.go
@@ -1103,10 +1103,12 @@ func parseMajorVersion(image string) (int, error) {
 			break
 		}
 	}
-	before, _, ok := strings.Cut(tag, ".")
-	if !ok {
-		return 0, fmt.Errorf("tag %q does not contain a version", tag)
-	}
+	// strings.Cut returns the full string as the first value when there is no
+	// separator, so this handles both multi-segment ("8.1.0.1") and
+	// single-segment ("8") tags. A genuinely unparseable tag (e.g. "latest" or
+	// an empty tag) still fails strconv.Atoi below and returns an error, so the
+	// caller keeps skipping such tags gracefully instead of false-rejecting.
+	before, _, _ := strings.Cut(tag, ".")
 	// Strip leading 'v' to handle tags like "v8.1.1" in addition to "8.1.1".
 	before = strings.TrimPrefix(before, "v")
 	return strconv.Atoi(before)

--- a/api/v1alpha1/webhook_test.go
+++ b/api/v1alpha1/webhook_test.go
@@ -6181,3 +6181,97 @@ func TestValidate_SecuritySectionMalformedNoPanic(t *testing.T) {
 		})
 	}
 }
+
+// --- CE minimum image-version validation tests ---
+
+// TestParseMajorVersion covers direct major-version extraction, including the
+// single-segment (dotless) tag case that previously returned an error and so
+// silently bypassed the CE-version gate.
+func TestParseMajorVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		image   string
+		want    int
+		wantErr bool
+	}{
+		{name: "ce-prefixed full", image: "aerospike:ce-8.1.0.1", want: 8, wantErr: false},
+		{name: "plain full", image: "aerospike:8.1.0.1", want: 8, wantErr: false},
+		{name: "v-prefixed", image: "aerospike:v8.1", want: 8, wantErr: false},
+		{name: "old ce-7 full", image: "aerospike:ce-7.0.0.0", want: 7, wantErr: false},
+		// dotless single-segment tags must still yield the major version.
+		{name: "ce-prefixed dotless 7", image: "aerospike:ce-7", want: 7, wantErr: false},
+		{name: "plain dotless 7", image: "aerospike:7", want: 7, wantErr: false},
+		{name: "ce-prefixed dotless 8", image: "aerospike:ce-8", want: 8, wantErr: false},
+		{name: "v-prefixed dotless 8", image: "aerospike:v8", want: 8, wantErr: false},
+		// genuinely unparseable tags must still error so the caller skips gracefully.
+		{name: "unparseable latest", image: "aerospike:latest", want: 0, wantErr: true},
+		{name: "unparseable empty tag", image: "aerospike:", want: 0, wantErr: true},
+		{name: "no tag at all", image: "aerospike", want: 0, wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseMajorVersion(tc.image)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("parseMajorVersion(%q) = %d, want error", tc.image, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseMajorVersion(%q) unexpected error: %v", tc.image, err)
+			}
+			if got != tc.want {
+				t.Errorf("parseMajorVersion(%q) = %d, want %d", tc.image, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestValidate_CEImageVersionEnforcement verifies the end-to-end webhook
+// behavior: CE images below the minimum major version are rejected (including
+// single-segment tags, which used to slip through), CE-8+ images are accepted,
+// and unparseable tags are skipped rather than false-rejected.
+func TestValidate_CEImageVersionEnforcement(t *testing.T) {
+	tests := []struct {
+		name    string
+		image   string
+		wantErr bool
+	}{
+		{name: "ce-8 full ok", image: "aerospike:ce-8.1.0.1", wantErr: false},
+		{name: "ce-8 four-segment ok", image: "aerospike:ce-8.1.1.1", wantErr: false},
+		{name: "ce-7 full rejected", image: "aerospike:ce-7.0.0.0", wantErr: true},
+		{name: "latest skipped", image: "aerospike:latest", wantErr: false},
+		{name: "no tag skipped", image: "aerospike", wantErr: false},
+		// dotless single-segment tags must enforce the CE-8 minimum too.
+		{name: "ce-7 dotless rejected", image: "aerospike:ce-7", wantErr: true},
+		{name: "plain 7 dotless rejected", image: "aerospike:7", wantErr: true},
+		{name: "ce-8 dotless ok", image: "aerospike:ce-8", wantErr: false},
+		{name: "v8 dotless ok", image: "aerospike:v8", wantErr: false},
+	}
+
+	v := &AerospikeClusterValidator{}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cluster := &AerospikeCluster{
+				Spec: AerospikeClusterSpec{
+					Size:  3,
+					Image: tc.image,
+				},
+			}
+			_, err := v.validate(cluster)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("validate() with image %q: expected error, got none", tc.image)
+				}
+				if !strings.Contains(err.Error(), "below the minimum supported version") {
+					t.Errorf("validate() with image %q: expected CE-minimum error, got: %v", tc.image, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("validate() with image %q: unexpected error: %v", tc.image, err)
+			}
+		})
+	}
+}

--- a/api/v1alpha1/webhook_test.go
+++ b/api/v1alpha1/webhook_test.go
@@ -6264,7 +6264,7 @@ func TestValidate_CEImageVersionEnforcement(t *testing.T) {
 				if err == nil {
 					t.Fatalf("validate() with image %q: expected error, got none", tc.image)
 				}
-				if !strings.Contains(err.Error(), "below the minimum supported version") {
+				if !strings.Contains(err.Error(), "requires Aerospike CE") {
 					t.Errorf("validate() with image %q: expected CE-minimum error, got: %v", tc.image, err)
 				}
 				return


### PR DESCRIPTION
## Problem — CE constraint enforcement gap

`validateCEImageVersion()` in `api/v1alpha1/aerospikecluster_webhook.go` rejects CE images below the minimum major version (`minCEMajorVersion = 8`), so that `aerospike:ce-7.x.y` trips the "CE 7.x and earlier are no longer supported" gate.

However, **single-segment (dotless) tags bypassed the gate entirely**. An image like `aerospike:ce-7` or `aerospike:7` was accepted even though `aerospike:ce-7.0.0.0` was correctly rejected.

## Root cause — error treated as "skip"

`parseMajorVersion` used `strings.Cut(tag, ".")` and returned an error when the (already prefix-/`v`-stripped) tag had no dot:

```go
before, _, ok := strings.Cut(tag, ".")
if !ok {
    return 0, fmt.Errorf("no dot in tag %q", tag)
}
return strconv.Atoi(before)
```

The caller treats **any** error as "can't confidently parse — skip the CE-version check":

```go
if major, err := parseMajorVersion(cluster.Spec.Image); err == nil && major < minCEMajorVersion {
    // reject
}
```

So a dotless `ce-7` produced an error → check skipped → image accepted. The CE constraint was silently bypassed.

## Fix

`parseMajorVersion` now treats a dotless tag as the major segment and parses it with `strconv.Atoi` instead of erroring:

```go
major, _, _ := strings.Cut(tag, ".")
return strconv.Atoi(major)
```

`strings.Cut` already returns the full string as its first return value when there is no separator, so the same line handles both `8.1.0.1` and `8`. All existing normalization is preserved unchanged (tag extracted after `:`, then `ce-` and leading `v` prefixes stripped). Genuinely unparseable tags (`latest`, empty, no tag) still fail `strconv.Atoi`/the tag check and return an error, so the caller keeps skipping them gracefully — `latest` is **not** newly rejected.

## Tests (`api/v1alpha1/webhook_test.go`)

`TestParseMajorVersion` (direct unit test):
- `ce-8.1.0.1`→8, `8.1.0.1`→8, `v8.1`→8, `ce-7.0.0.0`→7
- dotless: `ce-7`→7, `7`→7, `ce-8`→8, `v8`→8
- unparseable still error: `latest`, empty tag, no tag

`TestValidate_CEImageVersionEnforcement` (end-to-end through the validator webhook):
- `ce-7` → rejected, `7` → rejected (the fixed bypass)
- `ce-8` → accepted, `v8` → accepted
- `ce-8.1.1.1` → accepted, `ce-7.0.0.0` → rejected, `latest` / no-tag → skipped (no false reject)

## Verification

- `go build ./...` — pass
- `go vet ./...` — pass
- `gofmt -l api/v1alpha1/` — clean (no output)
- `go test ./api/v1alpha1/...` — pass (new tests: 20 subtests green)

Envtest-based integration tests under `internal/controller/` were not run: `KUBEBUILDER_ASSETS` is unset and the control-plane binaries (kube-apiserver/etcd) are not installed in this environment. The change is confined to `api/v1alpha1` webhook validation and is fully covered by the unit tests above.

Non-breaking: this tightens enforcement to match the documented CE constraints (CE-only, no longer-supported majors). No version or CRD `apiVersion` changes.