### PR TITLE
fix(controller): mark on-demand operation as Error when named pods do not exist

### DIFF
--- a/internal/controller/reconciler_operations.go
+++ b/internal/controller/reconciler_operations.go
@@ -48,6 +48,35 @@ func (r *AerospikeClusterReconciler) reconcileOperations(
 		return false, err
 	}
 
+	// Guard against an operation that explicitly targets pods by name but
+	// resolves to none of them (typo, stale name, or pods deleted/renamed).
+	// Without this, finalizeOperationPhase would see zero outstanding pods and
+	// spuriously mark the operation Completed having done nothing — a silent
+	// no-op that misleads the operator. An explicit-but-empty target set is a
+	// terminal error: surface it as the Error phase plus a Warning event so the
+	// next reconcile short-circuits instead of re-reporting a false success.
+	if len(op.PodList) > 0 && len(pods) == 0 {
+		log.Info("Operation targets named pods but none matched; marking operation as failed",
+			"id", op.ID, "kind", op.Kind, "podList", op.PodList)
+		errStatus := &ackov1alpha1.OperationStatus{
+			ID:    op.ID,
+			Kind:  op.Kind,
+			Phase: ackov1alpha1.AerospikePhaseError,
+		}
+		r.Recorder.Eventf(cluster, corev1.EventTypeWarning, EventOperation,
+			"Operation %s (%s): none of the targeted pods %v exist in this cluster",
+			op.ID, op.Kind, op.PodList)
+		if err := r.persistOperationStatus(ctx, cluster, errStatus); err != nil {
+			// A conflict means a concurrent writer updated status first; requeue
+			// to retry. Other errors propagate to the caller.
+			if errors.IsConflict(err) {
+				return true, nil
+			}
+			return false, err
+		}
+		return false, nil
+	}
+
 	// Initialize or update operation status
 	opStatus := &ackov1alpha1.OperationStatus{
 		ID:    op.ID,
@@ -126,13 +155,7 @@ func (r *AerospikeClusterReconciler) reconcileOperations(
 	allDone := finalizeOperationPhase(opStatus, pods, completedSet, failedSet)
 
 	// Update operation status using Patch to avoid overwriting concurrent status changes.
-	latest, err := r.refetchCluster(ctx, types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace})
-	if err != nil {
-		return !allDone, err
-	}
-	base := latest.DeepCopy()
-	latest.Status.OperationStatus = opStatus
-	if err := r.Status().Patch(ctx, latest, client.MergeFrom(base)); err != nil {
+	if err := r.persistOperationStatus(ctx, cluster, opStatus); err != nil {
 		if errors.IsConflict(err) {
 			log.V(1).Info("Conflict patching operation status, will requeue", "operation", op.ID)
 			return true, nil
@@ -144,6 +167,24 @@ func (r *AerospikeClusterReconciler) reconcileOperations(
 		"Operation %s (%s): %d/%d pods processed", op.ID, op.Kind, len(opStatus.CompletedPods), len(pods))
 
 	return !allDone, nil
+}
+
+// persistOperationStatus writes opStatus to cluster.Status.OperationStatus via a
+// MergeFrom patch against a freshly-refetched object, so a concurrent status
+// writer is not clobbered. A conflict error is returned to the caller, which
+// decides whether to requeue.
+func (r *AerospikeClusterReconciler) persistOperationStatus(
+	ctx context.Context,
+	cluster *ackov1alpha1.AerospikeCluster,
+	opStatus *ackov1alpha1.OperationStatus,
+) error {
+	latest, err := r.refetchCluster(ctx, types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace})
+	if err != nil {
+		return err
+	}
+	base := latest.DeepCopy()
+	latest.Status.OperationStatus = opStatus
+	return r.Status().Patch(ctx, latest, client.MergeFrom(base))
 }
 
 // getOperationTargetPods returns the pods targeted by an operation.

--- a/internal/controller/reconciler_operations_test.go
+++ b/internal/controller/reconciler_operations_test.go
@@ -1,13 +1,113 @@
 package controller
 
 import (
+	"context"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/utils"
 )
+
+// TestReconcileOperations_ExplicitPodListNoMatch_GoesToError is the regression
+// guard for the silent-no-op bug: an operation that names pods in podList which
+// do not exist (typo / stale / deleted) previously resolved to an empty target
+// set, and finalizeOperationPhase then marked it Completed having restarted
+// nothing. The operator should instead see the Error phase plus a Warning event.
+func TestReconcileOperations_ExplicitPodListNoMatch_GoesToError(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := ackov1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme() error = %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("corev1 AddToScheme() error = %v", err)
+	}
+
+	cluster := &ackov1alpha1.AerospikeCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "default"},
+		Spec: ackov1alpha1.AerospikeClusterSpec{
+			Size: 1,
+			Operations: []ackov1alpha1.OperationSpec{
+				{
+					ID:      "op-typo",
+					Kind:    ackov1alpha1.OperationWarmRestart,
+					PodList: []string{"demo-does-not-exist"},
+				},
+			},
+		},
+	}
+
+	// A real pod exists in the cluster, but it is NOT the one named in podList.
+	// This proves the guard keys on "named pods unresolved", not "cluster empty".
+	existingPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo-0",
+			Namespace: "default",
+			Labels:    utils.SelectorLabelsForCluster("demo"),
+		},
+	}
+
+	recorder := record.NewFakeRecorder(8)
+	reconciler := &AerospikeClusterReconciler{
+		Client: fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithStatusSubresource(&ackov1alpha1.AerospikeCluster{}).
+			WithObjects(cluster, existingPod).
+			Build(),
+		Scheme:   scheme,
+		Recorder: recorder,
+	}
+
+	inProgress, err := reconciler.reconcileOperations(context.Background(), cluster)
+	if err != nil {
+		t.Fatalf("reconcileOperations() error = %v", err)
+	}
+	if inProgress {
+		t.Fatal("expected inProgress=false: an unresolved-target operation is terminal, not requeued")
+	}
+
+	updated := &ackov1alpha1.AerospikeCluster{}
+	if err := reconciler.Get(context.Background(), types.NamespacedName{Name: "demo", Namespace: "default"}, updated); err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if updated.Status.OperationStatus == nil {
+		t.Fatal("expected OperationStatus to be set")
+	}
+	if updated.Status.OperationStatus.Phase != ackov1alpha1.AerospikePhaseError {
+		t.Errorf("phase = %q, want %q (unresolved named pods must not be reported as Completed)",
+			updated.Status.OperationStatus.Phase, ackov1alpha1.AerospikePhaseError)
+	}
+	if len(updated.Status.OperationStatus.CompletedPods) != 0 {
+		t.Errorf("CompletedPods = %v, want empty (nothing was actually restarted)",
+			updated.Status.OperationStatus.CompletedPods)
+	}
+
+	// A Warning event must have been emitted to make the misconfiguration visible.
+	select {
+	case ev := <-recorder.Events:
+		if ev == "" {
+			t.Error("expected a non-empty Warning event")
+		}
+	default:
+		t.Error("expected a Warning event for the unresolved operation target")
+	}
+
+	// Idempotency: a second reconcile with the same (now Error) status must
+	// short-circuit and not flip the phase or requeue.
+	inProgress2, err := reconciler.reconcileOperations(context.Background(), updated)
+	if err != nil {
+		t.Fatalf("second reconcileOperations() error = %v", err)
+	}
+	if inProgress2 {
+		t.Error("expected inProgress=false on the second reconcile (Error phase is terminal)")
+	}
+}
 
 func TestFilterPodsByNames_EmptyNames_ReturnsAll(t *testing.T) {
 	pods := []corev1.Pod{


### PR DESCRIPTION
## Problem

An on-demand operation (`WarmRestart` / `PodRestart`) that targets specific pods via `spec.operations[].podList` reported **phase=Completed** when *none* of the named pods existed — e.g. a typo, a stale name, or pods that were deleted/renamed since the operation was authored.

The operator looked like it had performed the restart when in fact it did nothing.

## Root cause

`getOperationTargetPods` → `filterPodsByNames` silently drops names that don't match any pod. When every named pod is unmatched, the target set is empty. `finalizeOperationPhase` then counts zero outstanding pods and sets `Phase = Completed` (with empty `CompletedPods`). The empty-target path is legitimately "Completed" when `podList` is omitted (operation applies to all pods, none outstanding), but it is **wrong** when the user explicitly enumerated pods that don't exist.

## Fix

In `reconcileOperations`, after resolving target pods, add a guard:

> if `op.PodList` is non-empty **and** it resolves to zero pods → set `OperationStatus.Phase = Error` and emit a `Warning` event naming the unresolved targets.

The `Error` phase is the documented terminal state; `reconcileOperations` already short-circuits when `OperationStatus.Phase == Error` for the same `op.ID`, so this introduces **no requeue loop** (verified by a second-reconcile idempotency assertion in the test). A conflict on the status patch returns `inProgress=true` to retry, matching the existing pattern.

Also refactored the duplicated refetch+`MergeFrom` status write into a small `persistOperationStatus` helper reused by both the new guard and the existing completion path.

No API type, CRD field, marker, or version change — `OperationStatus.Phase` already supports `Error`. Scope: 2 files, +148/-7.

## Verification (local)

- `go build ./...` — pass
- `go vet ./internal/controller/...` — pass
- `gofmt -l` on both touched files — clean (the pre-existing `test/e2e/e2e_test.go` gofmt flag is untouched and out of scope)
- `go test ./internal/controller/ -count=1` — pass (full package, envtest binaries available locally)
- New test `TestReconcileOperations_ExplicitPodListNoMatch_GoesToError` asserts: terminal `Error` phase, empty `CompletedPods`, a `Warning` event was emitted, and second-reconcile idempotency (no phase flip, no requeue). A real pod exists in the cluster but is *not* the named one, proving the guard keys on "named pods unresolved" rather than "cluster empty".

## kind / e2e testability

Exercisable on a kind cluster: deploy a small `AerospikeCluster`, then patch in an operation whose `podList` names a non-existent pod and observe `Error` + the Warning event (see KIND_SMOKE_HINT in the task report). Otherwise fully covered by the new unit test.