### PR TITLE
fix(webhook): catch rack-config drop in simultaneous add/remove guard

### DIFF
--- a/api/v1alpha1/aerospikecluster_webhook.go
+++ b/api/v1alpha1/aerospikecluster_webhook.go
@@ -293,32 +293,36 @@ func (v *AerospikeClusterValidator) ValidateUpdate(ctx context.Context, oldClust
 
 	// Prevent simultaneous addition and removal of rack IDs (which risks data loss
 	// from a rename-like operation). Pure additions or pure removals are fine.
-	if oldCluster.Spec.RackConfig != nil && cluster.Spec.RackConfig != nil {
-		oldIDs := make(map[int]bool, len(oldCluster.Spec.RackConfig.Racks))
-		for _, rack := range oldCluster.Spec.RackConfig.Racks {
-			oldIDs[rack.ID] = true
-		}
-		newIDs := make(map[int]bool, len(cluster.Spec.RackConfig.Racks))
-		for _, rack := range cluster.Spec.RackConfig.Racks {
-			newIDs[rack.ID] = true
-		}
+	//
+	// effectiveRackIDs resolves both specs the same way the reconciler's getRacks
+	// does: when rackConfig is nil or has no racks, the cluster runs a single
+	// default rack with ID 0. Without that fallback the guard only fired when both
+	// specs carried an explicit rackConfig, so dropping rackConfig entirely
+	// (explicit racks -> default rack 0) — which tears down every explicit-rack
+	// StatefulSet and creates a fresh rack-0 one — slipped through unchecked even
+	// though it is exactly the rename-like, data-loss-risky operation the guard
+	// exists to block.
+	oldIDs := effectiveRackIDs(oldCluster.Spec.RackConfig)
+	newIDs := effectiveRackIDs(cluster.Spec.RackConfig)
 
-		// Collect IDs removed (in old but not new) and IDs added (in new but not old).
-		var removedIDs []int
-		for id := range oldIDs {
-			if !newIDs[id] {
-				removedIDs = append(removedIDs, id)
-			}
+	// Collect IDs removed (in old but not new) and IDs added (in new but not old).
+	var removedIDs []int
+	for id := range oldIDs {
+		if !newIDs[id] {
+			removedIDs = append(removedIDs, id)
 		}
-		var addedIDs []int
-		for id := range newIDs {
-			if !oldIDs[id] {
-				addedIDs = append(addedIDs, id)
-			}
+	}
+	var addedIDs []int
+	for id := range newIDs {
+		if !oldIDs[id] {
+			addedIDs = append(addedIDs, id)
 		}
-		if len(removedIDs) > 0 && len(addedIDs) > 0 {
-			return nil, fmt.Errorf("cannot add new rack IDs %v and remove existing rack IDs %v in the same update; please do this in two separate steps (first add, then remove, or vice versa)", addedIDs, removedIDs)
-		}
+	}
+	if len(removedIDs) > 0 && len(addedIDs) > 0 {
+		// Sort for a deterministic error message (map iteration order is random).
+		slices.Sort(addedIDs)
+		slices.Sort(removedIDs)
+		return nil, fmt.Errorf("cannot add new rack IDs %v and remove existing rack IDs %v in the same update; please do this in two separate steps (first add, then remove, or vice versa)", addedIDs, removedIDs)
 	}
 
 	return v.validateWithCtx(ctx, cluster)
@@ -327,6 +331,23 @@ func (v *AerospikeClusterValidator) ValidateUpdate(ctx context.Context, oldClust
 // ValidateDelete implements admission.Validator[*AerospikeCluster].
 func (v *AerospikeClusterValidator) ValidateDelete(ctx context.Context, cluster *AerospikeCluster) (admission.Warnings, error) {
 	return nil, nil
+}
+
+// effectiveRackIDs returns the set of rack IDs the cluster will actually run,
+// mirroring the controller's getRacks fallback: an absent or empty rackConfig
+// means a single default rack with ID 0. Keeping this in sync with getRacks lets
+// ValidateUpdate's add/remove guard reason about the real rack topology rather
+// than the raw spec, so the "drop rackConfig entirely" transition is treated as
+// the simultaneous remove+add it really is.
+func effectiveRackIDs(rackConfig *RackConfig) map[int]bool {
+	if rackConfig == nil || len(rackConfig.Racks) == 0 {
+		return map[int]bool{0: true}
+	}
+	ids := make(map[int]bool, len(rackConfig.Racks))
+	for _, rack := range rackConfig.Racks {
+		ids[rack.ID] = true
+	}
+	return ids
 }
 
 // serviceMonitorName returns the ServiceMonitor name produced by the

--- a/api/v1alpha1/aerospikecluster_webhook.go
+++ b/api/v1alpha1/aerospikecluster_webhook.go
@@ -322,6 +322,14 @@ func (v *AerospikeClusterValidator) ValidateUpdate(ctx context.Context, oldClust
 		// Sort for a deterministic error message (map iteration order is random).
 		slices.Sort(addedIDs)
 		slices.Sort(removedIDs)
+		// Rack ID 0 is the implicit default rack and can never be named explicitly
+		// (validateRackConfig reserves it), so a transition that adds or removes it —
+		// i.e. introducing or dropping rack-awareness on an existing cluster — has no
+		// valid two-step path. Steer the user to the only safe route instead of
+		// suggesting an impossible "add then remove".
+		if slices.Contains(addedIDs, 0) || slices.Contains(removedIDs, 0) {
+			return nil, fmt.Errorf("cannot add new rack IDs %v and remove existing rack IDs %v in the same update: this switches the cluster between the implicit default rack (ID 0) and explicit racks, which recreates StatefulSets and risks data loss; introduce or remove rack-awareness by creating a new cluster and migrating data instead", addedIDs, removedIDs)
+		}
 		return nil, fmt.Errorf("cannot add new rack IDs %v and remove existing rack IDs %v in the same update; please do this in two separate steps (first add, then remove, or vice versa)", addedIDs, removedIDs)
 	}
 

--- a/api/v1alpha1/webhook_test.go
+++ b/api/v1alpha1/webhook_test.go
@@ -4852,6 +4852,139 @@ func TestValidateUpdate_RackOnlyRemoveOK(t *testing.T) {
 	}
 }
 
+// Dropping rackConfig entirely from a cluster that had explicit racks is a
+// rename-like operation: the controller falls back to the default rack (ID 0),
+// tearing down every explicit-rack StatefulSet and creating a fresh rack-0 one.
+// It must be rejected just like an in-spec simultaneous add+remove.
+func TestValidateUpdate_RackConfigDroppedRejected(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+	oldCluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:  4,
+			Image: "aerospike:ce-8.1.1.1",
+			RackConfig: &RackConfig{
+				Racks: []Rack{
+					{ID: 1},
+					{ID: 2},
+				},
+			},
+		},
+	}
+	// rackConfig removed entirely -> effective rack set becomes {0}.
+	newCluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:  4,
+			Image: "aerospike:ce-8.1.1.1",
+		},
+	}
+
+	_, err := v.ValidateUpdate(context.Background(), oldCluster, newCluster)
+	if err == nil {
+		t.Fatal("expected error when dropping rackConfig from a cluster with explicit racks")
+	}
+	if !strings.Contains(err.Error(), "cannot add new rack IDs") {
+		t.Errorf("error should mention 'cannot add new rack IDs', got: %v", err)
+	}
+	// The implicit default rack 0 is the added ID; explicit racks are removed.
+	if !strings.Contains(err.Error(), "[0]") {
+		t.Errorf("error should name the implicit default rack ID 0, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "[1 2]") {
+		t.Errorf("error should name the removed rack IDs [1 2] in sorted order, got: %v", err)
+	}
+}
+
+// An empty Racks slice resolves to the same default rack (ID 0) as a nil
+// rackConfig, so it must be rejected on the same data-loss grounds.
+func TestValidateUpdate_RackConfigEmptiedRejected(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+	oldCluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:  4,
+			Image: "aerospike:ce-8.1.1.1",
+			RackConfig: &RackConfig{
+				Racks: []Rack{{ID: 5}},
+			},
+		},
+	}
+	newCluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:       4,
+			Image:      "aerospike:ce-8.1.1.1",
+			RackConfig: &RackConfig{Racks: []Rack{}},
+		},
+	}
+
+	_, err := v.ValidateUpdate(context.Background(), oldCluster, newCluster)
+	if err == nil {
+		t.Fatal("expected error when emptying rackConfig.racks for a cluster with explicit racks")
+	}
+	if !strings.Contains(err.Error(), "cannot add new rack IDs") {
+		t.Errorf("error should mention 'cannot add new rack IDs', got: %v", err)
+	}
+}
+
+// Adding a first explicit rack to a default-rack (no rackConfig) cluster swaps
+// the implicit rack 0 for the new explicit rack — a rename-like transition that
+// must be rejected.
+func TestValidateUpdate_RackConfigAddedToDefaultRejected(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+	oldCluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:  4,
+			Image: "aerospike:ce-8.1.1.1",
+		},
+	}
+	newCluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:  4,
+			Image: "aerospike:ce-8.1.1.1",
+			RackConfig: &RackConfig{
+				Racks: []Rack{{ID: 1}},
+			},
+		},
+	}
+
+	_, err := v.ValidateUpdate(context.Background(), oldCluster, newCluster)
+	if err == nil {
+		t.Fatal("expected error when adding the first explicit rack to a default-rack cluster")
+	}
+	if !strings.Contains(err.Error(), "cannot add new rack IDs") {
+		t.Errorf("error should mention 'cannot add new rack IDs', got: %v", err)
+	}
+}
+
+// Keeping the effective rack set unchanged across the nil<->empty default-rack
+// forms is a no-op for topology and must be allowed. (Rack ID 0 cannot be
+// specified explicitly — validateRackConfig reserves it — so only nil and the
+// empty slice are valid spellings of the default rack.)
+func TestValidateUpdate_RackConfigDefaultEquivalentForms_OK(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+	base := AerospikeClusterSpec{Size: 4, Image: "aerospike:ce-8.1.1.1"}
+
+	cases := []struct {
+		name         string
+		oldRC, newRC *RackConfig
+	}{
+		{"nil to nil", nil, nil},
+		{"nil to empty", nil, &RackConfig{Racks: []Rack{}}},
+		{"empty to nil", &RackConfig{Racks: []Rack{}}, nil},
+		{"empty to empty", &RackConfig{Racks: []Rack{}}, &RackConfig{Racks: []Rack{}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			oldCluster := &AerospikeCluster{Spec: base}
+			oldCluster.Spec.RackConfig = tc.oldRC
+			newCluster := &AerospikeCluster{Spec: base}
+			newCluster.Spec.RackConfig = tc.newRC
+
+			if _, err := v.ValidateUpdate(context.Background(), oldCluster, newCluster); err != nil {
+				t.Errorf("unexpected error for topology-preserving update: %v", err)
+			}
+		})
+	}
+}
+
 func TestValidate_CE8ImageAccepted(t *testing.T) {
 	v := &AerospikeClusterValidator{}
 	cluster := &AerospikeCluster{

--- a/api/v1alpha1/webhook_test.go
+++ b/api/v1alpha1/webhook_test.go
@@ -4892,6 +4892,11 @@ func TestValidateUpdate_RackConfigDroppedRejected(t *testing.T) {
 	if !strings.Contains(err.Error(), "[1 2]") {
 		t.Errorf("error should name the removed rack IDs [1 2] in sorted order, got: %v", err)
 	}
+	// When the default rack (ID 0) is involved there is no valid two-step path, so
+	// the message must steer toward data migration rather than an impossible add/remove.
+	if !strings.Contains(err.Error(), "migrating data") {
+		t.Errorf("error should guide the user to create a new cluster and migrate data, got: %v", err)
+	}
 }
 
 // An empty Racks slice resolves to the same default rack (ID 0) as a nil


### PR DESCRIPTION
## What

`ValidateUpdate`'s rack-ID guard rejects updates that add **and** remove rack IDs in the same step — a rename-like operation that tears down and recreates StatefulSets and risks data loss. The guard previously only ran when **both** the old and new specs carried an explicit `rackConfig`, so two real transitions slipped through unchecked:

1. **Dropping `rackConfig` entirely** (explicit racks → no `rackConfig`).
2. **Emptying `rackConfig.racks`** (explicit racks → `racks: []`).

In both cases the controller's `getRacks` falls back to a single **default rack (ID 0)**, so the transition is exactly the simultaneous *remove* (of every explicit rack) + *add* (of rack 0) the guard exists to block — every explicit-rack StatefulSet is torn down and a fresh rack-0 one is created.

## Fix

Resolve both old and new specs through a new `effectiveRackIDs` helper that mirrors `getRacks`' default-rack fallback (nil/empty → `{0}`), then always run the add/remove comparison instead of gating it on both specs being non-nil. As a symmetric consequence this also rejects **adding a first explicit rack to a default-rack cluster** (rack 0 → rack N), which is the same rename-like operation in the other direction. The error message now sorts the IDs for deterministic output.

Users who genuinely want to change rack topology are guided by the existing actionable message to do it in two steps (add, then remove, or vice versa).

## Scope / safety

- No CRD `apiVersion` or API type changes; no `make manifests generate` needed.
- No version/appVersion edits.
- Net +154 LOC across 2 files (1 production, 1 test).

## Tests

Added unit tests:
- `TestValidateUpdate_RackConfigDroppedRejected`
- `TestValidateUpdate_RackConfigEmptiedRejected`
- `TestValidateUpdate_RackConfigAddedToDefaultRejected`
- `TestValidateUpdate_RackConfigDefaultEquivalentForms_OK` (nil↔empty default-rack forms remain allowed)

Verified locally: `go build ./...`, `go vet ./api/...`, `gofmt -l` (clean), and `go test ./...` (all packages pass; controller tests ran as plain unit tests without envtest).