### PR TITLE
fix(webhook): reject namespace/set scope on global-only ACL privileges

### DIFF
--- a/api/v1alpha1/aerospikecluster_webhook.go
+++ b/api/v1alpha1/aerospikecluster_webhook.go
@@ -970,6 +970,20 @@ var aerospikeCEBuiltinRoles = map[string]bool{
 	"truncate":       true,
 }
 
+// aerospikeGlobalOnlyPrivileges lists the privilege codes that Aerospike treats
+// as global-only: they apply to the whole cluster and cannot be scoped to a
+// namespace or set. Attaching a scope (e.g. "sys-admin.myns") is accepted by the
+// Kubernetes API server but rejected by the Aerospike server when the operator
+// syncs the role, leaving the cluster in ACLSyncError. The data-plane privileges
+// (read, write, read-write, read-write-udf, truncate) are intentionally absent
+// here because they are scopable.
+// Reference: https://aerospike.com/docs/server/operations/configure/security/access-control/index.html
+var aerospikeGlobalOnlyPrivileges = map[string]bool{
+	"sys-admin":  true,
+	"user-admin": true,
+	"data-admin": true,
+}
+
 // validateAccessControl validates the ACL configuration.
 func (v *AerospikeClusterValidator) validateAccessControl(acl *AerospikeAccessControlSpec) []string {
 	var errors []string
@@ -1053,9 +1067,19 @@ func (v *AerospikeClusterValidator) validateAccessControl(acl *AerospikeAccessCo
 				continue
 			}
 			// Format: "<code>" or "<code>.<namespace>" or "<code>.<namespace>.<set>"
-			code := strings.SplitN(privStr, ".", 2)[0]
+			code, scope, scoped := strings.Cut(privStr, ".")
 			if !aerospikeCEBuiltinRoles[code] {
 				errors = append(errors, fmt.Sprintf("role %q has invalid privilege code %q; valid codes: read, write, read-write, read-write-udf, sys-admin, user-admin, data-admin, truncate", role.Name, code))
+				continue
+			}
+			// Admin-level privileges are global-only: Aerospike rejects a
+			// namespace/set scope on them at runtime ("privilege ... cannot be
+			// scoped"), leaving the operator stuck in ACLSyncError. Catch the
+			// mistake at admission time with an actionable message instead.
+			if scoped && aerospikeGlobalOnlyPrivileges[code] {
+				errors = append(errors, fmt.Sprintf(
+					"role %q privilege %q: %q is a global-only privilege and cannot be scoped to a namespace or set (%q)",
+					role.Name, privStr, code, scope))
 			}
 		}
 	}

--- a/api/v1alpha1/webhook_test.go
+++ b/api/v1alpha1/webhook_test.go
@@ -4100,6 +4100,86 @@ func TestValidate_ACLScopedPrivilegeAccepted(t *testing.T) {
 	}
 }
 
+func TestValidate_ACLGlobalPrivilegeScopedRejected(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+	for _, code := range []string{"sys-admin", "user-admin", "data-admin"} {
+		t.Run(code, func(t *testing.T) {
+			cluster := &AerospikeCluster{
+				Spec: AerospikeClusterSpec{
+					Size:  3,
+					Image: "aerospike:ce-8.1.1.1",
+					AerospikeAccessControl: &AerospikeAccessControlSpec{
+						Roles: []AerospikeRoleSpec{
+							{Name: "bad-role", Privileges: []string{code + ".myns"}},
+						},
+						Users: []AerospikeUserSpec{
+							{Name: "admin", SecretName: "admin-secret", Roles: []string{"sys-admin", "user-admin"}},
+						},
+					},
+				},
+			}
+
+			_, err := v.validate(cluster)
+			if err == nil {
+				t.Fatalf("expected error for scoped global-only privilege %q", code+".myns")
+			}
+			if !strings.Contains(err.Error(), "global-only privilege") {
+				t.Errorf("error should mention 'global-only privilege', got: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidate_ACLGlobalPrivilegeSetScopedRejected(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+	cluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:  3,
+			Image: "aerospike:ce-8.1.1.1",
+			AerospikeAccessControl: &AerospikeAccessControlSpec{
+				Roles: []AerospikeRoleSpec{
+					{Name: "bad-role", Privileges: []string{"sys-admin.myns.myset"}},
+				},
+				Users: []AerospikeUserSpec{
+					{Name: "admin", SecretName: "admin-secret", Roles: []string{"sys-admin", "user-admin"}},
+				},
+			},
+		},
+	}
+
+	_, err := v.validate(cluster)
+	if err == nil {
+		t.Fatal("expected error for set-scoped global-only privilege 'sys-admin.myns.myset'")
+	}
+	if !strings.Contains(err.Error(), "global-only privilege") {
+		t.Errorf("error should mention 'global-only privilege', got: %v", err)
+	}
+}
+
+func TestValidate_ACLGlobalPrivilegeUnscopedAccepted(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+	cluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:  3,
+			Image: "aerospike:ce-8.1.1.1",
+			AerospikeAccessControl: &AerospikeAccessControlSpec{
+				Roles: []AerospikeRoleSpec{
+					// Unscoped admin privileges are valid; truncate is scopable.
+					{Name: "ops", Privileges: []string{"sys-admin", "user-admin", "data-admin", "truncate.myns"}},
+				},
+				Users: []AerospikeUserSpec{
+					{Name: "admin", SecretName: "admin-secret", Roles: []string{"sys-admin", "user-admin"}},
+				},
+			},
+		},
+	}
+
+	_, err := v.validate(cluster)
+	if err != nil {
+		t.Fatalf("expected unscoped admin privileges and scoped truncate to be accepted, got: %v", err)
+	}
+}
+
 // --- Defaulting idempotency test ---
 
 func TestDefault_IsIdempotent(t *testing.T) {


### PR DESCRIPTION
## Problem

Aerospike treats `sys-admin`, `user-admin`, and `data-admin` as **global-only** privileges — they apply to the entire cluster and cannot be scoped to a namespace or set. The access-control validator previously checked only the privilege *code* (the part before the first `.`) and accepted any scope:

```go
code := strings.SplitN(privStr, ".", 2)[0]
if !aerospikeCEBuiltinRoles[code] { ... }
```

So a CR with a role privilege like `sys-admin.myns` (or `data-admin.myns.myset`) passed admission. The mistake only surfaced later, when the operator tried to sync the role: the Aerospike server rejected the scoped admin privilege and the cluster was left stuck in **`ACLSyncError`** with no actionable signal on the CR — exactly the kind of "valid YAML, runtime crash" gap the rest of this webhook already fails fast on (map/scalar shape checks, enterprise-only keys, etc.).

## Fix

`validateAccessControl` now rejects a namespace/set scope on the three global-only admin privileges at admission time, with a message that names the offending privilege and code. Scopable data-plane privileges (`read`, `write`, `read-write`, `read-write-udf`, `truncate`) are unaffected — `truncate.myns` and `read.myns.myset` still validate.

Implementation:
- New `aerospikeGlobalOnlyPrivileges` set (`sys-admin`, `user-admin`, `data-admin`), documented with a reference to the Aerospike access-control docs.
- Switched the existing `strings.SplitN(privStr, ".", 2)[0]` to `strings.Cut`, which also tells us whether a scope is present.
- Unknown-code path now `continue`s so a single bad privilege does not produce two overlapping errors.

## Tests

Added to `api/v1alpha1/webhook_test.go`:
- `TestValidate_ACLGlobalPrivilegeScopedRejected` — table over `sys-admin`/`user-admin`/`data-admin` with a namespace scope, expects rejection.
- `TestValidate_ACLGlobalPrivilegeSetScopedRejected` — set-scoped `sys-admin.myns.myset` rejected.
- `TestValidate_ACLGlobalPrivilegeUnscopedAccepted` — regression guard: unscoped admin privileges + scoped `truncate.myns` stay accepted.

The new rejection tests fail before the source change and pass after; the existing `TestValidate_ACLScopedPrivilegeAccepted` (read/write scoping) still passes.

## Scope / compatibility

- Pure validation logic — no CRD fields added/removed/renamed, no `apiVersion` bump, no generated code affected (`make manifests`/`make generate` unchanged). No version/Chart.yaml edits.
- 2 files, ~105 lines net.

## Local verification

- `gofmt -l` on changed files: clean
- `go vet ./api/...`: clean
- `go build ./...`: ok
- `go test ./api/v1alpha1/`: ok (full package)
- before/after check: new tests FAIL on `origin/main`, PASS with the fix