### PR TITLE
fix(webhook): reject invalid Prometheus duration in serviceMonitor.interval

### DIFF
--- a/api/v1alpha1/aerospikecluster_webhook.go
+++ b/api/v1alpha1/aerospikecluster_webhook.go
@@ -42,6 +42,19 @@ var aerospikeclusterlog = logf.Log.WithName("aerospikecluster-resource")
 
 var tomlBareKeyRe = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
 
+// prometheusDurationRe mirrors the validation pattern the Prometheus Operator
+// applies to its Duration type (used by ServiceMonitor endpoints[].interval).
+// The reconciler writes monitoring.serviceMonitor.interval verbatim into the
+// ServiceMonitor's scrape interval (reconciler_monitoring.go), so an interval
+// that does not match this pattern is accepted by the Kubernetes API server but
+// rejected by the Prometheus Operator's own CRD schema when the ServiceMonitor
+// is applied — surfacing as an opaque reconcile-time failure instead of a clear
+// admission error. We replicate the pattern locally (like serviceMonitorGVK)
+// rather than importing prometheus-operator, which is not a module dependency.
+// Reference: monitoring.coreos.com/v1 Duration validation.
+var prometheusDurationRe = regexp.MustCompile(
+	`^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$`)
+
 const (
 	maxCEClusterSize     = 8
 	maxCENamespaces      = 2
@@ -1709,6 +1722,25 @@ func (v *AerospikeClusterValidator) validateMonitoring(m *AerospikeMonitoringSpe
 		}
 	} else if m.ExporterImage != "" {
 		warnings = append(warnings, fmt.Sprintf("monitoring.exporterImage %q has no tag; use an explicit version tag for reproducible deployments", m.ExporterImage))
+	}
+
+	// Validate the ServiceMonitor scrape interval. The reconciler writes this
+	// string verbatim into the ServiceMonitor's endpoints[].interval, where the
+	// Prometheus Operator enforces its Duration pattern. An invalid value (e.g.
+	// "30" with no unit, "5 seconds", or the matched-but-degenerate empty string
+	// from a stray whitespace-only value) passes the Kubernetes API server but is
+	// rejected by the Prometheus Operator CRD at apply time, leaving monitoring
+	// silently un-reconciled. Reject it at admission with an actionable message.
+	// The empty interval is allowed here because the defaulter fills it with the
+	// 30s default before reconcile; only an explicitly set, invalid value fails.
+	if m.ServiceMonitor != nil && m.ServiceMonitor.Enabled && m.ServiceMonitor.Interval != "" {
+		if !prometheusDurationRe.MatchString(m.ServiceMonitor.Interval) {
+			errors = append(errors, fmt.Sprintf(
+				"monitoring.serviceMonitor.interval %q is not a valid Prometheus duration "+
+					"(expected values like \"30s\", \"1m\", \"500ms\", \"2h30m\"); "+
+					"the Prometheus Operator rejects other formats when the ServiceMonitor is applied",
+				m.ServiceMonitor.Interval))
+		}
 	}
 
 	// Validate MetricLabels keys and values for TOML compatibility.

--- a/api/v1alpha1/webhook_test.go
+++ b/api/v1alpha1/webhook_test.go
@@ -2402,6 +2402,106 @@ func TestValidate_MonitoringValidConfig(t *testing.T) {
 	}
 }
 
+func TestValidate_ServiceMonitorIntervalInvalid(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+
+	// Values the Prometheus Operator's Duration schema rejects. ACKO must catch
+	// these at admission instead of letting the ServiceMonitor fail at apply.
+	invalidIntervals := []string{
+		"30",        // missing unit
+		"5 seconds", // not a duration string
+		"thirty",    // non-numeric
+		"30S",       // wrong-case unit
+		"1.5s",      // fractional not allowed
+		"-5s",       // negative
+	}
+
+	for _, interval := range invalidIntervals {
+		cluster := &AerospikeCluster{
+			Spec: AerospikeClusterSpec{
+				Size:  3,
+				Image: "aerospike:ce-8.1.1.1",
+				Monitoring: &AerospikeMonitoringSpec{
+					Enabled:       true,
+					ExporterImage: "aerospike/aerospike-prometheus-exporter:1.16.1",
+					Port:          9145,
+					ServiceMonitor: &ServiceMonitorSpec{
+						Enabled:  true,
+						Interval: interval,
+					},
+				},
+			},
+		}
+
+		_, err := v.validate(cluster)
+		if err == nil {
+			t.Errorf("expected error for invalid serviceMonitor interval %q", interval)
+			continue
+		}
+		if !strings.Contains(err.Error(), "serviceMonitor.interval") {
+			t.Errorf("interval %q: error should mention 'serviceMonitor.interval', got: %v", interval, err)
+		}
+	}
+}
+
+func TestValidate_ServiceMonitorIntervalValid(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+
+	// Values the Prometheus Operator's Duration schema accepts, plus the empty
+	// string (defaulter fills it in before reconcile).
+	validIntervals := []string{"30s", "1m", "500ms", "2h30m", "1y2w3d", "0", ""}
+
+	for _, interval := range validIntervals {
+		cluster := &AerospikeCluster{
+			Spec: AerospikeClusterSpec{
+				Size:  3,
+				Image: "aerospike:ce-8.1.1.1",
+				Monitoring: &AerospikeMonitoringSpec{
+					Enabled:       true,
+					ExporterImage: "aerospike/aerospike-prometheus-exporter:1.16.1",
+					Port:          9145,
+					ServiceMonitor: &ServiceMonitorSpec{
+						Enabled:  true,
+						Interval: interval,
+					},
+				},
+			},
+		}
+
+		_, err := v.validate(cluster)
+		if err != nil {
+			t.Errorf("unexpected error for valid serviceMonitor interval %q: %v", interval, err)
+		}
+	}
+}
+
+func TestValidate_ServiceMonitorIntervalSkippedWhenDisabled(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+
+	// An invalid interval must not be rejected when the ServiceMonitor itself is
+	// disabled — no ServiceMonitor is created, so the interval is never applied.
+	cluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:  3,
+			Image: "aerospike:ce-8.1.1.1",
+			Monitoring: &AerospikeMonitoringSpec{
+				Enabled:       true,
+				ExporterImage: "aerospike/aerospike-prometheus-exporter:1.16.1",
+				Port:          9145,
+				ServiceMonitor: &ServiceMonitorSpec{
+					Enabled:  false,
+					Interval: "not-a-duration",
+				},
+			},
+		},
+	}
+
+	_, err := v.validate(cluster)
+	if err != nil {
+		t.Errorf("unexpected error for invalid interval on a disabled ServiceMonitor: %v", err)
+	}
+}
+
 func TestValidate_MonitoringDisabledSkipsValidation(t *testing.T) {
 	v := &AerospikeClusterValidator{}
 	// Invalid config but disabled — should pass


### PR DESCRIPTION
## Problem

`monitoring.serviceMonitor.interval` is a free-form string (`ServiceMonitorSpec.Interval`, defaults to `30s`). The reconciler writes it **verbatim** into the generated ServiceMonitor's scrape interval:

```go
// internal/controller/reconciler_monitoring.go
interval := monitoring.ServiceMonitor.Interval
...
"endpoints": []any{ map[string]any{ "port": "metrics", "interval": interval, "path": "/metrics" } },
```

The Prometheus Operator's `monitoring.coreos.com/v1` CRD validates `endpoints[].interval` against its `Duration` pattern. An interval that does not match — `"30"` (missing unit), `"5 seconds"`, `"1.5s"`, `"30S"`, `"-5s"` — is **accepted by the Kubernetes API server** (the field has no ACKO-side validation and the ServiceMonitor is built via unstructured), then **rejected by the Prometheus Operator CRD schema when the operator applies the ServiceMonitor**. Result: monitoring is silently un-reconciled and the user sees an opaque apply-time error far from the CR they edited.

## Root cause

No admission-time validation of `serviceMonitor.interval`. Every other "string flows into a downstream system that has stricter rules" case in this webhook fails fast at admission (TOML metric-label keys, network port shapes, logging contexts, namespace shapes); the scrape interval was the gap.

## Fix

Validate the interval in `validateMonitoring` against the **same `Duration` regex the Prometheus Operator enforces**, replicated locally (`prometheusDurationRe`) — consistent with how `serviceMonitorGVK` is kept local to avoid importing prometheus-operator (which is **not** a module dependency).

- Only checked when `monitoring.serviceMonitor.enabled` is true (no SM created otherwise).
- Empty string is allowed: the defaulter fills it with `30s` before reconcile; only an explicitly-set invalid value is rejected.
- Produces an actionable error listing valid example values.

## Tests

Added pure unit tests (no cluster / no envtest needed):
- `TestValidate_ServiceMonitorIntervalInvalid` — `30`, `5 seconds`, `thirty`, `30S`, `1.5s`, `-5s` all rejected with a `serviceMonitor.interval` message.
- `TestValidate_ServiceMonitorIntervalValid` — `30s`, `1m`, `500ms`, `2h30m`, `1y2w3d`, `0`, `""` all accepted.
- `TestValidate_ServiceMonitorIntervalSkippedWhenDisabled` — invalid interval ignored when SM disabled.

```
go build ./...                                  # OK
go vet ./api/...                                # OK
gofmt -l <changed files>                        # clean
go test ./api/v1alpha1/                         # ok (full package, no regressions)
go test ./api/v1alpha1/ -run 'TestValidate_ServiceMonitorInterval|TestValidate_Monitoring|TestDefaultMonitoring' -v   # all PASS
```

## Risk

**Low.** Admission-time validation only. The added regex matches the Prometheus Operator's published `Duration` pattern exactly (verified against representative valid/invalid inputs). The empty-string and SM-disabled guards ensure existing valid CRs (including ones relying on the `30s` default) are unaffected.

## Runtime behavior

Does **not** change any running cluster's reconcile/deploy behavior — it is an admission-time guard that rejects CRs which would otherwise produce a broken ServiceMonitor. No CRD apiVersion bump, no public type rename, no version edit.