### PR TITLE
fix(webhook): reject malformed namespace/set scope on ACL privileges

### DIFF
--- a/api/v1alpha1/aerospikecluster_webhook.go
+++ b/api/v1alpha1/aerospikecluster_webhook.go
@@ -1094,11 +1094,48 @@ func (v *AerospikeClusterValidator) validateAccessControl(acl *AerospikeAccessCo
 				errors = append(errors, fmt.Sprintf(
 					"role %q privilege %q: %q is a global-only privilege and cannot be scoped to a namespace or set (%q)",
 					role.Name, privStr, code, scope))
+				continue
+			}
+			// Validate the scope structure for scopable privileges. A scope is
+			// "<namespace>" or "<namespace>.<set>"; an empty component (e.g.
+			// "read.", "read..set") or a third component ("read.ns.set.extra")
+			// is accepted by the Kubernetes API server but rejected by Aerospike
+			// when the operator syncs the role, leaving the cluster in
+			// ACLSyncError. Catch the malformed scope at admission time with an
+			// actionable message instead — same fail-fast rationale as the
+			// global-only check above.
+			if scoped {
+				errors = append(errors, validatePrivilegeScope(role.Name, privStr, scope)...)
 			}
 		}
 	}
 
 	return errors
+}
+
+// validatePrivilegeScope checks the namespace/set scope of a scopable privilege.
+// scope is the substring after the first "." in the privilege string, i.e.
+// "<namespace>" or "<namespace>.<set>". An empty namespace or set component, or
+// more than two components, is rejected because Aerospike refuses such a
+// privilege at role-sync time and the cluster ends up in ACLSyncError. privStr
+// is the original full privilege string, included verbatim in the error message
+// so the user can locate the offending entry.
+func validatePrivilegeScope(roleName, privStr, scope string) []string {
+	parts := strings.Split(scope, ".")
+	if len(parts) > 2 {
+		return []string{fmt.Sprintf(
+			"role %q privilege %q: scope must be \"<namespace>\" or \"<namespace>.<set>\", got %d components",
+			roleName, privStr, len(parts))}
+	}
+	if parts[0] == "" {
+		return []string{fmt.Sprintf(
+			"role %q privilege %q: namespace scope must not be empty", roleName, privStr)}
+	}
+	if len(parts) == 2 && parts[1] == "" {
+		return []string{fmt.Sprintf(
+			"role %q privilege %q: set scope must not be empty", roleName, privStr)}
+	}
+	return nil
 }
 
 // validateSizeAndImage validates spec.size and spec.image, accounting for the fact that

--- a/api/v1alpha1/webhook_test.go
+++ b/api/v1alpha1/webhook_test.go
@@ -4379,6 +4379,75 @@ func TestValidate_ACLGlobalPrivilegeUnscopedAccepted(t *testing.T) {
 	}
 }
 
+// TestValidate_ACLScopedPrivilegeMalformedRejected covers scopable privileges
+// whose namespace/set scope is structurally invalid. Aerospike rejects these at
+// role-sync time (leaving the cluster in ACLSyncError), so the webhook must
+// reject them at admission with an actionable message instead.
+func TestValidate_ACLScopedPrivilegeMalformedRejected(t *testing.T) {
+	cases := []struct {
+		name    string
+		priv    string
+		wantMsg string
+	}{
+		{"trailing dot empty namespace", "read.", "namespace scope must not be empty"},
+		{"empty namespace before set", "read..myset", "namespace scope must not be empty"},
+		{"trailing dot empty set", "read.myns.", "set scope must not be empty"},
+		{"too many scope components", "read.myns.myset.extra", "scope must be"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			v := &AerospikeClusterValidator{}
+			cluster := &AerospikeCluster{
+				Spec: AerospikeClusterSpec{
+					Size:  3,
+					Image: "aerospike:ce-8.1.1.1",
+					AerospikeAccessControl: &AerospikeAccessControlSpec{
+						Roles: []AerospikeRoleSpec{
+							{Name: "bad-role", Privileges: []string{tc.priv}},
+						},
+						Users: []AerospikeUserSpec{
+							{Name: "admin", SecretName: "admin-secret", Roles: []string{"sys-admin", "user-admin"}},
+						},
+					},
+				},
+			}
+
+			_, err := v.validate(cluster)
+			if err == nil {
+				t.Fatalf("expected error for malformed scoped privilege %q", tc.priv)
+			}
+			if !strings.Contains(err.Error(), tc.wantMsg) {
+				t.Errorf("error should mention %q, got: %v", tc.wantMsg, err)
+			}
+		})
+	}
+}
+
+// TestValidate_ACLScopedSetPrivilegeAccepted confirms a well-formed
+// namespace.set scope on a scopable privilege is still accepted (guards against
+// the new structural check over-rejecting valid input).
+func TestValidate_ACLScopedSetPrivilegeAccepted(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+	cluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:  3,
+			Image: "aerospike:ce-8.1.1.1",
+			AerospikeAccessControl: &AerospikeAccessControlSpec{
+				Roles: []AerospikeRoleSpec{
+					{Name: "set-reader", Privileges: []string{"read-write-udf.myns.myset"}},
+				},
+				Users: []AerospikeUserSpec{
+					{Name: "admin", SecretName: "admin-secret", Roles: []string{"sys-admin", "user-admin"}},
+				},
+			},
+		},
+	}
+
+	if _, err := v.validate(cluster); err != nil {
+		t.Fatalf("expected well-formed namespace.set scope to be accepted, got: %v", err)
+	}
+}
+
 // --- Defaulting idempotency test ---
 
 func TestDefault_IsIdempotent(t *testing.T) {


### PR DESCRIPTION
## Problem

Scopable ACL privileges (`read`, `write`, `read-write`, `read-write-udf`, `truncate`) accept an optional namespace/set scope of the form `<code>.<namespace>` or `<code>.<namespace>.<set>`. The validator in `validateAccessControl` only split the privilege string on the **first** dot (`strings.Cut`) and never validated the scope structure.

As a result, structurally invalid scopes passed admission:

- `read.` — trailing dot, empty namespace
- `read..myset` — empty namespace before set
- `read.myns.` — trailing dot, empty set
- `read.myns.myset.extra` — more than two scope components

The Kubernetes API server accepts all of these, but Aerospike rejects the privilege when the operator syncs the role, leaving the cluster stuck in **ACLSyncError**. This is the same failure class the recent ACL webhook fixes (e.g. #315 global-only scoped privileges) were added to prevent — catch the mistake at admission with an actionable message instead of a runtime sync failure.

## Fix

Add `validatePrivilegeScope(roleName, privStr, scope)` and call it for scopable privileges that carry a scope. It rejects:

- an empty namespace component,
- an empty set component, and
- more than two scope components (`<namespace>.<set>` is the max).

Well-formed scopes (`read.myns`, `read-write-udf.myns.myset`) and unscoped/global-only privileges are unaffected. The check is purely structural (component count + non-empty) — it deliberately does not validate namespace/set character sets, to stay low-risk.

## Verification

All run locally (unit-level, no envtest/cluster needed — these call `validator.validate` directly):

- `gofmt -l api/v1alpha1/aerospikecluster_webhook.go api/v1alpha1/webhook_test.go` — clean
- `go build ./...` — OK
- `go vet ./api/...` — OK
- `go test ./api/v1alpha1/ -run 'TestValidate_ACL' -v` — PASS (incl. new `TestValidate_ACLScopedPrivilegeMalformedRejected` 4 subcases + `TestValidate_ACLScopedSetPrivilegeAccepted`)
- `go test ./api/v1alpha1/` — PASS (full package, no regressions)

No CRD type changes, so no `make manifests`/`make generate` needed.

## Kind e2e (pending — run separately)

A kind e2e should confirm the webhook rejects a CR whose `aerospikeAccessControl.roles[].privileges` contains a malformed scope (e.g. `read.` or `read.ns.set.extra`) at `kubectl apply` time with the new error message, and that a valid scoped privilege (`read.myns.myset`) is still admitted and syncs without ACLSyncError on a running CE cluster.