### PR TITLE
fix(webhook): validate per-rack aerospikeConfig against CE constraints

### DIFF
--- a/api/v1alpha1/aerospikecluster_webhook.go
+++ b/api/v1alpha1/aerospikecluster_webhook.go
@@ -539,8 +539,9 @@ func (v *AerospikeClusterValidator) validate(cluster *AerospikeCluster) (admissi
 
 	// Validate rack config
 	if cluster.Spec.RackConfig != nil {
-		rackErrors := v.validateRackConfig(cluster.Spec.RackConfig)
+		rackErrors, rackWarnings := v.validateRackConfig(cluster.Spec.RackConfig)
 		allErrors = append(allErrors, rackErrors...)
+		warnings = append(warnings, rackWarnings...)
 
 		// Reject more racks than pods. The reconciler distributes spec.size
 		// evenly across racks (getRackSize); when len(racks) > size at least
@@ -1404,8 +1405,9 @@ func (v *AerospikeClusterValidator) validateMaxUnavailable(cluster *AerospikeClu
 }
 
 // validateRackConfig validates the rack configuration.
-func (v *AerospikeClusterValidator) validateRackConfig(rackConfig *RackConfig) []string {
+func (v *AerospikeClusterValidator) validateRackConfig(rackConfig *RackConfig) ([]string, admission.Warnings) {
 	var errors []string
+	var warnings admission.Warnings
 
 	rackIDs := make(map[int]bool)
 	rackLabels := make(map[string]bool)
@@ -1424,6 +1426,22 @@ func (v *AerospikeClusterValidator) validateRackConfig(rackConfig *RackConfig) [
 				errors = append(errors, fmt.Sprintf("duplicate rackLabel %q in rackConfig; each rack must have a unique rackLabel", rack.RackLabel))
 			}
 			rackLabels[rack.RackLabel] = true
+		}
+
+		// Validate the per-rack aerospikeConfig override against the SAME CE
+		// constraints as the cluster-level config. A rack's aerospikeConfig is
+		// DeepMerged into the effective config and rendered into the rack's
+		// ConfigMap (getEffectiveConfig in reconciler_config.go), so without this
+		// check a user could inject enterprise-only stanzas (xdr/tls/security
+		// audit sub-keys), exceed the CE namespace count, or set multicast
+		// heartbeat through rack.aerospikeConfig and silently bypass the
+		// cluster-spec webhook — the same CE-bypass class fixed for spec.overrides.
+		if rack.AerospikeConfig != nil {
+			cfgErrors, cfgWarnings := v.validateAerospikeConfig(rack.AerospikeConfig.Value)
+			for _, e := range cfgErrors {
+				errors = append(errors, fmt.Sprintf("rackConfig.racks[id=%d].aerospikeConfig: %s", rack.ID, e))
+			}
+			warnings = append(warnings, cfgWarnings...)
 		}
 	}
 
@@ -1448,7 +1466,7 @@ func (v *AerospikeClusterValidator) validateRackConfig(rackConfig *RackConfig) [
 		}
 	}
 
-	return errors
+	return errors, warnings
 }
 
 // validateOperations validates the on-demand operations spec.

--- a/api/v1alpha1/webhook_test.go
+++ b/api/v1alpha1/webhook_test.go
@@ -3100,6 +3100,104 @@ func TestValidate_DuplicateRackLabels(t *testing.T) {
 	}
 }
 
+// TestValidate_RackAerospikeConfigEnterpriseBypass verifies that enterprise-only
+// stanzas and CE-constraint violations injected through a per-rack
+// aerospikeConfig override are rejected by the webhook. A rack's aerospikeConfig
+// is DeepMerged into the effective config and rendered into the rack's ConfigMap
+// (getEffectiveConfig), so without per-rack validation it was a silent CE bypass.
+func TestValidate_RackAerospikeConfigEnterpriseBypass(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+
+	cases := []struct {
+		name      string
+		rackCfg   map[string]any
+		wantInErr string
+	}{
+		{
+			name:      "xdr via rack override",
+			rackCfg:   map[string]any{"xdr": map[string]any{}},
+			wantInErr: "xdr",
+		},
+		{
+			name:      "tls via rack override",
+			rackCfg:   map[string]any{"tls": map[string]any{}},
+			wantInErr: "tls",
+		},
+		{
+			name: "exceeds CE namespace count via rack override",
+			rackCfg: map[string]any{
+				"namespaces": []any{
+					map[string]any{"name": "ns1"},
+					map[string]any{"name": "ns2"},
+					map[string]any{"name": "ns3"},
+				},
+			},
+			wantInErr: "exceeds CE maximum",
+		},
+		{
+			name: "multicast heartbeat via rack override",
+			rackCfg: map[string]any{
+				"network": map[string]any{
+					"heartbeat": map[string]any{"mode": "multicast"},
+				},
+			},
+			wantInErr: "mesh",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cluster := &AerospikeCluster{
+				Spec: AerospikeClusterSpec{
+					Size:  3,
+					Image: "aerospike:ce-8.1.1.1",
+					RackConfig: &RackConfig{
+						Racks: []Rack{
+							{ID: 1, AerospikeConfig: &AerospikeConfigSpec{Value: tc.rackCfg}},
+						},
+					},
+				},
+			}
+
+			_, err := v.validate(cluster)
+			if err == nil {
+				t.Fatalf("expected error for rack aerospikeConfig %q", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.wantInErr) {
+				t.Errorf("error should mention %q, got: %v", tc.wantInErr, err)
+			}
+			if !strings.Contains(err.Error(), "rackConfig.racks[id=1].aerospikeConfig") {
+				t.Errorf("error should be scoped to the rack, got: %v", err)
+			}
+		})
+	}
+}
+
+// TestValidate_RackAerospikeConfigValidCEPasses ensures a legitimate CE rack
+// override is not rejected by the new per-rack validation.
+func TestValidate_RackAerospikeConfigValidCEPasses(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+	cluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:  3,
+			Image: "aerospike:ce-8.1.1.1",
+			RackConfig: &RackConfig{
+				Racks: []Rack{
+					{ID: 1, AerospikeConfig: &AerospikeConfigSpec{Value: map[string]any{
+						"namespaces": []any{
+							map[string]any{"name": "test", "replication-factor": 2},
+						},
+					}}},
+				},
+			},
+		},
+	}
+
+	if _, err := v.validate(cluster); err != nil {
+		t.Fatalf("valid CE rack aerospikeConfig should pass, got: %v", err)
+	}
+}
+
 // --- validateOperations gap tests ---
 
 func TestValidate_MultipleOperationsRejected(t *testing.T) {


### PR DESCRIPTION
## Nil-map claim verification result: CONFIRMED FALSE

The prior analysis claimed \`reconciler_status.go:288\` (now line 337, \`prev := cluster.Status.Pods[pod.Name]\`) panics on first reconcile because \`Status.Pods\` is a nil map. **This is a false positive.** In Go, *reading* from a nil map returns the zero value safely — only *writing* panics. That line is a read and is safe.

I also audited the real panic-risk class nearby:
- All four \`Status.Pods[x] = ...\` **write** sites (\`reconciler_restart.go\`:496/639, \`reconciler_dynamic_config.go\`:475/519) already nil-guard with \`if latest.Status.Pods == nil { make(...) }\`.
- \`enrichStatusWithAerospikeInfo\` / \`applyMigrationStats\` writes run only after \`populateStatus\` assigns a non-nil map (\`Status.Pods = podStatuses\`).
- Pointer derefs (\`Status.MigrationStatus.RemainingPartitions\` at :133, \`Status.AppliedSpec\` in \`reconciler_acl.go\`:247) are nil-guarded.

No panic bug exists in the status path. I did **not** force a fix there.

## Actual defect fixed: CE-constraint validation hole (webhook)

\`Rack.AerospikeConfig\` (per-rack override) is DeepMerged into the effective config and rendered into the rack's ConfigMap (\`getEffectiveConfig\` in \`reconciler_config.go\`). But \`validateRackConfig\` never ran the CE-constraint checks on it. A user could set \`rackConfig.racks[].aerospikeConfig\` to inject enterprise-only stanzas (\`xdr\`, \`tls\`, security audit sub-keys), exceed the CE namespace count (max 2), or set multicast heartbeat — **silently bypassing** the webhook that protects the cluster-level config. This is the same CE-bypass class previously closed for \`spec.overrides\`.

### Fix
\`validateRackConfig\` now validates each rack's \`aerospikeConfig\` via the existing \`validateAerospikeConfig\`, scoping errors to \`rackConfig.racks[id=N].aerospikeConfig\`. Warnings are threaded through to the single caller in \`validate()\`.

## Test
- \`TestValidate_RackAerospikeConfigEnterpriseBypass\` — table test: xdr, tls, namespace-count overflow, multicast heartbeat via rack override. **Fails before the fix** (verified by temporarily reverting the validation block: all 4 subtests reported "expected error"), **passes after.**
- \`TestValidate_RackAerospikeConfigValidCEPasses\` — positive control: a valid CE rack override still passes.

## Local verification
- \`go build ./...\` — OK
- \`go test $(go list ./... | grep -v /e2e)\` — all packages OK
- \`gofmt -l\` on both changed files — clean (the flagged \`test/e2e/e2e_test.go\` is pre-existing on \`origin/main\`, untouched here)
- \`go vet ./...\` — clean

## Scope
2 files, +119 lines. No CRD apiVersion bump, no version bump.