### PR TITLE
fix(controller): gate on-demand operation batches on readiness/migration; validate maxUnavailable

### DIFF
--- a/api/v1alpha1/aerospikecluster_webhook.go
+++ b/api/v1alpha1/aerospikecluster_webhook.go
@@ -593,6 +593,17 @@ func (v *AerospikeClusterValidator) validate(cluster *AerospikeCluster) (admissi
 	warnings = append(warnings, v.validateWorkDirectory(cluster)...)
 	warnings = append(warnings, v.validateBatchSize(cluster)...)
 	warnings = append(warnings, v.validateRackBatchSize(cluster)...)
+	// Structurally reject malformed maxUnavailable (negative int, non-percentage
+	// string, out-of-range percentage) at admission time. The raw value flows
+	// straight into PodDisruptionBudgetSpec.MaxUnavailable (reconciler_pdb.go), so
+	// without this fail-fast check K8s only rejects it at PDB apply time, surfacing
+	// as an opaque reconcilePDB error that can trip the circuit breaker. Reuse the
+	// same helper the rackConfig batch-size fields use; minValue 0 because zero
+	// unavailable pods is a valid (if strict) PDB. The existing warning-level
+	// checks for >=size / >=100% stay below and remain intact.
+	if muErr := validateIntOrString(cluster.Spec.MaxUnavailable, "maxUnavailable", 0); muErr != "" {
+		allErrors = append(allErrors, muErr)
+	}
 	warnings = append(warnings, v.validateMaxUnavailable(cluster)...)
 	if len(cluster.Spec.Operations) > 0 {
 		allErrors = append(allErrors, v.validateOperations(cluster.Spec.Operations)...)

--- a/api/v1alpha1/webhook_test.go
+++ b/api/v1alpha1/webhook_test.go
@@ -3977,6 +3977,58 @@ func TestValidate_MaxUnavailableDeferredToTemplate(t *testing.T) {
 	}
 }
 
+// TestValidate_MaxUnavailableStructural locks in the fail-fast structural
+// validation for spec.maxUnavailable. Before this check the webhook only WARNED
+// (for >=size / >=100%) and let negative ints, non-percentage strings, and
+// out-of-range percentages through, so K8s rejected them only at PDB apply time
+// as an opaque reconcilePDB error (which can trip the circuit breaker). These
+// must now be hard ERROR-level admission failures, while structurally-valid
+// values still admit cleanly.
+func TestValidate_MaxUnavailableStructural(t *testing.T) {
+	negative := intstr.FromInt(-1)
+	overPercent := intstr.FromString("150%")
+	nonNumeric := intstr.FromString("abc")
+	validPercent := intstr.FromString("25%")
+	validInt := intstr.FromInt(1)
+
+	tests := []struct {
+		name    string
+		mu      *intstr.IntOrString
+		wantErr bool
+	}{
+		{"negative int rejected", &negative, true},
+		{"percentage over 100 rejected", &overPercent, true},
+		{"non-percentage string rejected", &nonNumeric, true},
+		{"valid percentage admitted", &validPercent, false},
+		{"valid int admitted", &validInt, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := &AerospikeClusterValidator{}
+			cluster := &AerospikeCluster{
+				Spec: AerospikeClusterSpec{
+					Size:           8,
+					Image:          "aerospike:ce-8.1.1.1",
+					MaxUnavailable: tt.mu,
+				},
+			}
+
+			_, err := v.validate(cluster)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected validation error for maxUnavailable=%v, got nil", *tt.mu)
+				}
+				if !strings.Contains(err.Error(), "maxUnavailable") {
+					t.Errorf("error should mention maxUnavailable, got: %v", err)
+				}
+			} else if err != nil {
+				t.Fatalf("expected no error for maxUnavailable=%v, got: %v", *tt.mu, err)
+			}
+		})
+	}
+}
+
 // --- ServiceMonitor / Monitoring consistency tests ---
 
 func TestValidate_ServiceMonitorEnabledWithoutMonitoring(t *testing.T) {

--- a/internal/controller/reconciler_operations.go
+++ b/internal/controller/reconciler_operations.go
@@ -107,6 +107,22 @@ func (r *AerospikeClusterReconciler) reconcileOperations(
 		opStatus.FailedPods = cluster.Status.OperationStatus.FailedPods
 	}
 
+	// Before restarting any more pods, honor the same readiness/migration guard
+	// the rolling-restart path uses (reconciler_restart.go isBatchBlocked). The
+	// operations path only fires SIGUSR1 (warm) or issues a Delete (cold) and
+	// marks the pod "completed" immediately — neither waits for the node to
+	// rejoin the mesh or for migrations to drain. Without this guard, a batched
+	// PodRestart on a replication-factor-2 cluster can take a second node down
+	// while the first is still cold/migrating, risking data unavailability. If
+	// the batch is blocked we requeue (inProgress=true) WITHOUT advancing to the
+	// next pod or persisting further "completed" pods. We only gate when work
+	// actually remains, so a finished operation can still reach its terminal
+	// phase below. rackID 0 is logging-only in isBatchBlocked; the migration
+	// check is cluster-wide and the readiness-gate check inspects these pods.
+	if r.operationBatchBlocked(ctx, cluster, pods, completedSet, failedSet) {
+		return true, nil
+	}
+
 	processed := int32(0)
 
 	for _, pod := range pods {
@@ -235,6 +251,50 @@ func finalizeOperationPhase(
 		opStatus.Phase = ackov1alpha1.AerospikePhaseError
 	}
 	return true
+}
+
+// operationBatchBlocked reports whether reconcileOperations should hold the
+// current batch and requeue without restarting any further pod. It reuses the
+// rolling-restart path's isBatchBlocked guard (readiness gate when enabled,
+// otherwise a cluster-wide migration check) so an on-demand PodRestart cannot
+// take a node down while a previously restarted node is still cold/migrating —
+// the same data-availability protection the rolling-restart path already has.
+//
+// The guard is only consulted when work actually remains (some target pod is
+// neither completed nor failed); a finished operation can therefore still reach
+// its terminal phase instead of being held behind a blocked-batch requeue.
+// rackID 0 is logging-only inside isBatchBlocked; the migration probe is
+// cluster-wide and the readiness-gate check inspects the supplied pods.
+func (r *AerospikeClusterReconciler) operationBatchBlocked(
+	ctx context.Context,
+	cluster *ackov1alpha1.AerospikeCluster,
+	pods []*corev1.Pod,
+	completedSet, failedSet map[string]bool,
+) bool {
+	outstanding := false
+	for _, pod := range pods {
+		if !completedSet[pod.Name] && !failedSet[pod.Name] {
+			outstanding = true
+			break
+		}
+	}
+	if !outstanding {
+		return false
+	}
+	return r.isBatchBlocked(ctx, cluster, 0, derefPods(pods))
+}
+
+// derefPods converts a slice of pod pointers into a slice of pod values, as
+// required by isBatchBlocked (which the rolling-restart path calls with the
+// []corev1.Pod returned by listRackPods). nil pointers are skipped defensively.
+func derefPods(pods []*corev1.Pod) []corev1.Pod {
+	out := make([]corev1.Pod, 0, len(pods))
+	for _, p := range pods {
+		if p != nil {
+			out = append(out, *p)
+		}
+	}
+	return out
 }
 
 // filterPodsByNames returns pointers to the pods matching the given names.

--- a/internal/controller/reconciler_operations_test.go
+++ b/internal/controller/reconciler_operations_test.go
@@ -12,6 +12,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/podutil"
 	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/utils"
 )
 
@@ -364,5 +365,182 @@ func TestOperationFailedPodsDedup(t *testing.T) {
 
 	if len(opStatus.FailedPods) != 1 {
 		t.Fatalf("FailedPods = %v, want exactly one entry (no duplicates across reconciles)", opStatus.FailedPods)
+	}
+}
+
+// operationsScheme builds a scheme with both acko and core/v1 types registered,
+// as the controller-level operations tests need.
+func operationsScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := ackov1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme(acko) error = %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("corev1 AddToScheme() error = %v", err)
+	}
+	return scheme
+}
+
+// clusterPod builds a pod carrying the cluster selector labels so listClusterPods
+// (and thus getOperationTargetPods) resolves it as an operation target.
+func clusterPod(clusterName, name string, phase corev1.PodPhase) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			Labels:    utils.SelectorLabelsForCluster(clusterName),
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: podutil.AerospikeContainerName, Image: "aerospike:ce-8.1.1.1"},
+			},
+		},
+		Status: corev1.PodStatus{Phase: phase},
+	}
+}
+
+// TestReconcileOperations_BlockedByReadinessGate_DoesNotAdvance is the core
+// data-availability regression for Issue 1: on-demand operations must honor the
+// same readiness/migration guard the rolling-restart path uses (isBatchBlocked),
+// so a batched PodRestart cannot take a second node down while a previously
+// restarted node is still cold/migrating. Here a previously restarted pod has an
+// unsatisfied readiness gate. reconcileOperations must requeue (inProgress=true)
+// WITHOUT restarting any further pod or advancing CompletedPods.
+//
+// The readiness-gate path is the in-memory test seam (isReadinessGateEnabled +
+// anyPodGateUnsatisfied); it keeps isBatchBlocked off the network-bound
+// migration probe, mirroring how reconciler_restart_rolling_test.go exercises
+// the same guard.
+func TestReconcileOperations_BlockedByReadinessGate_DoesNotAdvance(t *testing.T) {
+	scheme := operationsScheme(t)
+	gateEnabled := true
+
+	cluster := &ackov1alpha1.AerospikeCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "default"},
+		Spec: ackov1alpha1.AerospikeClusterSpec{
+			Size:    2,
+			PodSpec: &ackov1alpha1.AerospikePodSpec{ReadinessGateEnabled: &gateEnabled},
+			Operations: []ackov1alpha1.OperationSpec{
+				{
+					ID:   "op-rolling",
+					Kind: ackov1alpha1.OperationPodRestart,
+					// Empty PodList → operation targets every cluster pod.
+				},
+			},
+		},
+	}
+
+	// demo-0: already restarted, but its readiness gate is NOT yet satisfied
+	// (Running + gate condition False) → isBatchBlocked must hold the batch.
+	blockedPod := clusterPod("demo", "demo-0", corev1.PodRunning)
+	blockedPod.Spec.ReadinessGates = []corev1.PodReadinessGate{
+		{ConditionType: podutil.AerospikeReadinessGateConditionType},
+	}
+	blockedPod.Status.Conditions = []corev1.PodCondition{
+		{Type: podutil.AerospikeReadinessGateConditionType, Status: corev1.ConditionFalse},
+	}
+	// demo-1: the next pod the operation would restart if the guard were absent.
+	nextPod := clusterPod("demo", "demo-1", corev1.PodRunning)
+
+	reconciler := &AerospikeClusterReconciler{
+		Client: fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithStatusSubresource(&ackov1alpha1.AerospikeCluster{}).
+			WithObjects(cluster, blockedPod, nextPod).
+			Build(),
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(16),
+	}
+
+	inProgress, err := reconciler.reconcileOperations(context.Background(), cluster)
+	if err != nil {
+		t.Fatalf("reconcileOperations() error = %v", err)
+	}
+	if !inProgress {
+		t.Fatal("expected inProgress=true: a blocked batch must requeue, not complete")
+	}
+
+	// No pod should have been restarted: demo-1 must still exist.
+	if err := reconciler.Get(context.Background(),
+		types.NamespacedName{Name: "demo-1", Namespace: "default"}, &corev1.Pod{}); err != nil {
+		t.Fatalf("demo-1 should NOT have been restarted while the batch is blocked, Get err = %v", err)
+	}
+
+	// CompletedPods must not have advanced while blocked.
+	updated := &ackov1alpha1.AerospikeCluster{}
+	if err := reconciler.Get(context.Background(),
+		types.NamespacedName{Name: "demo", Namespace: "default"}, updated); err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if updated.Status.OperationStatus != nil && len(updated.Status.OperationStatus.CompletedPods) != 0 {
+		t.Errorf("CompletedPods = %v, want empty while batch is blocked",
+			updated.Status.OperationStatus.CompletedPods)
+	}
+}
+
+// TestReconcileOperations_NotBlocked_AdvancesOneBatch is the companion
+// regression: with nothing blocking (readiness gate enabled, no pod
+// gate-unsatisfied), reconcileOperations advances exactly one batch (batchSize
+// defaults to 1) — the targeted pod is cold-restarted (deleted) and marked
+// completed. This proves the new guard does not over-block the happy path.
+//
+// The target pod is Pending (not ready) so coldRestartPod skips the best-effort
+// quiesce network call, and a Pending pod is skipped by anyPodGateUnsatisfied so
+// it does not block itself.
+func TestReconcileOperations_NotBlocked_AdvancesOneBatch(t *testing.T) {
+	scheme := operationsScheme(t)
+	gateEnabled := true
+
+	cluster := &ackov1alpha1.AerospikeCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "default"},
+		Spec: ackov1alpha1.AerospikeClusterSpec{
+			Size:    1,
+			PodSpec: &ackov1alpha1.AerospikePodSpec{ReadinessGateEnabled: &gateEnabled},
+			Operations: []ackov1alpha1.OperationSpec{
+				{
+					ID:      "op-single",
+					Kind:    ackov1alpha1.OperationPodRestart,
+					PodList: []string{"demo-0"},
+				},
+			},
+		},
+	}
+
+	target := clusterPod("demo", "demo-0", corev1.PodPending)
+
+	reconciler := &AerospikeClusterReconciler{
+		Client: fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithStatusSubresource(&ackov1alpha1.AerospikeCluster{}).
+			WithObjects(cluster, target).
+			Build(),
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(16),
+	}
+
+	_, err := reconciler.reconcileOperations(context.Background(), cluster)
+	if err != nil {
+		t.Fatalf("reconcileOperations() error = %v", err)
+	}
+
+	// Cold restart deletes the pod.
+	if err := reconciler.Get(context.Background(),
+		types.NamespacedName{Name: "demo-0", Namespace: "default"}, &corev1.Pod{}); err == nil {
+		t.Fatal("expected demo-0 to be deleted (cold restart) when the batch is not blocked")
+	}
+
+	updated := &ackov1alpha1.AerospikeCluster{}
+	if err := reconciler.Get(context.Background(),
+		types.NamespacedName{Name: "demo", Namespace: "default"}, updated); err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if updated.Status.OperationStatus == nil {
+		t.Fatal("expected OperationStatus to be set")
+	}
+	if len(updated.Status.OperationStatus.CompletedPods) != 1 ||
+		updated.Status.OperationStatus.CompletedPods[0] != "demo-0" {
+		t.Errorf("CompletedPods = %v, want [demo-0] (one batch advanced)",
+			updated.Status.OperationStatus.CompletedPods)
 	}
 }


### PR DESCRIPTION
## Summary

Two focused safety fixes so unsafe / malformed inputs fail fast instead of degrading into opaque reconcile failures or unsafe parallel restarts.

### Issue 1 — On-demand operations restart batches with no readiness/migration gating (data-availability bug)

`reconcileOperations` (`internal/controller/reconciler_operations.go`) processed a batch and marked pods "completed" the instant `warmRestartPod`/`coldRestartPod` returned. Those calls only send `SIGUSR1` / issue a `Delete` — they do **not** wait for the node to rejoin the mesh or for migrations to drain. It then requeued every `defaultReconcileRetryInterval` and immediately restarted the next batch.

The rolling-restart path (`reconciler_restart.go`) already guards each batch with `r.isBatchBlocked(...)`, so the next pod is not restarted until the previously-restarted pod rejoined the mesh and migrations completed. The operations path had no such guard, so on **replication-factor-2** a batched `PodRestart` could take a second node down while the first was still cold/migrating — risking data unavailability.

**Fix:** before advancing/processing a batch, reuse the existing `isBatchBlocked` guard via a small `operationBatchBlocked` helper. When the batch is blocked we return the function's existing in-progress/requeue signal (`true, nil`) **without** advancing to the next pod or marking further pods completed. The guard is only consulted when work actually remains (some target pod is neither completed nor failed), so a finished operation still reaches its terminal phase. `isBatchBlocked`'s `rackID` arg is logging-only; the migration probe is cluster-wide and the readiness-gate check inspects the operation's target pods (converted to values via `derefPods`). Migration logic and the rolling-restart path itself are untouched.

The helper extraction also keeps `reconcileOperations` under the repo's gocyclo limit (golangci-lint).

### Issue 2 — `spec.maxUnavailable` accepted structurally invalid values that the PDB later rejects at apply time

`validateMaxUnavailable` (`api/v1alpha1/aerospikecluster_webhook.go`) only **warned** (for `>=size` / `>=100%`); it never **errored** on a negative int, a non-percentage string (`"abc"`), or an out-of-range percentage (`"150%"`). The raw value flows straight into `PodDisruptionBudgetSpec.MaxUnavailable` (`reconciler_pdb.go`), so K8s rejected it only at reconcile time — surfacing as an opaque `reconcilePDB` error that can trip the circuit breaker.

**Fix:** add an ERROR-level structural check in the webhook `validate()` flow, reusing the existing `validateIntOrString` helper (`minValue 0`, the same helper the `rackConfig` batch-size fields use). The existing warning logic (`>=size` / `>=100%`) is kept intact.

## Test coverage

- **Issue 2** (`api/v1alpha1/webhook_test.go`, `TestValidate_MaxUnavailableStructural`): table test mirroring the existing `validateIntOrString` cases — `intstr.FromInt(-1)` → error, `"150%"` → error, `"abc"` → error, `"25%"` → no error, `1` → no error. Existing `TestValidate_MaxUnavailable*` warning tests still pass.
- **Issue 1** (`internal/controller/reconciler_operations_test.go`):
  - `TestReconcileOperations_BlockedByReadinessGate_DoesNotAdvance` — a previously-restarted pod has an unsatisfied readiness gate; `reconcileOperations` returns `inProgress=true`, the next target pod is **not** deleted, and `CompletedPods` does **not** advance.
  - `TestReconcileOperations_NotBlocked_AdvancesOneBatch` — with nothing blocking, exactly one batch advances (target pod cold-restarted/deleted and marked completed), proving the guard does not over-block the happy path.
  - These use the in-memory readiness-gate seam (`ReadinessGateEnabled` + `anyPodGateUnsatisfied`), the same seam the rolling-restart tests use, keeping `isBatchBlocked` off the network-bound migration probe.

## Verification

All gates ran locally (`/tmp/ace-work/aerospike-ce-kubernetes-operator`) and pass clean:
- `gofmt -l` on changed files — empty
- `go build ./...` — OK
- `go vet ./...` — OK
- `make test` — unit **+ envtest integration** (setup-envtest downloaded K8s 1.35 binaries successfully; integration suite ran, not deferred)
- `make lint` (golangci-lint v2.8.0) — 0 issues

No CRD/manifest drift: `make test` ran `controller-gen` but produced no changes to generated files; only the 4 source/test files are modified.
