### PR TITLE
fix(webhook): parse image tag correctly for registry refs with a port

### DIFF
--- a/api/v1alpha1/aerospikecluster_webhook.go
+++ b/api/v1alpha1/aerospikecluster_webhook.go
@@ -1215,7 +1215,17 @@ func (v *AerospikeClusterValidator) validateSizeAndImage(cluster *AerospikeClust
 // pulled through a ported registry. Per the OCI/Docker reference grammar, the tag
 // colon is the LAST colon and must appear after the final '/'; a colon before the
 // last '/' belongs to the registry host:port and means the reference is untagged.
+//
+// A digest-pinned reference may carry an "@<algo>:<hex>" suffix (e.g.
+// "aerospike:ce-8.1.1.1@sha256:abc..."). That digest contains its own colon, so
+// it must be stripped before locating the tag colon; otherwise the digest's
+// colon is misread as the tag separator and parseMajorVersion / isEnterpriseTag
+// silently skip the CE-version / enterprise-image guards for any digest-pinned
+// image. The '@' separator always appears after the final '/'.
 func imageTag(image string) string {
+	if at := strings.LastIndex(image, "@"); at >= 0 && at > strings.LastIndex(image, "/") {
+		image = image[:at]
+	}
 	lastColon := strings.LastIndex(image, ":")
 	if lastColon < 0 {
 		return ""

--- a/api/v1alpha1/aerospikecluster_webhook.go
+++ b/api/v1alpha1/aerospikecluster_webhook.go
@@ -1184,11 +1184,11 @@ func (v *AerospikeClusterValidator) validateSizeAndImage(cluster *AerospikeClust
 				"spec.image %q is an Enterprise Edition image; only Community Edition images are allowed",
 				cluster.Spec.Image))
 		}
-		if !strings.Contains(cluster.Spec.Image, ":") {
+		tag := imageTag(cluster.Spec.Image)
+		if tag == "" {
 			imageWarnings = append(imageWarnings, fmt.Sprintf("spec.image %q has no tag; use an explicit version tag (e.g., aerospike:ce-8.1.1.1) for reproducible deployments", cluster.Spec.Image))
 		} else {
-			parts := strings.SplitN(cluster.Spec.Image, ":", 2)
-			if parts[1] == "latest" {
+			if tag == "latest" {
 				imageWarnings = append(imageWarnings, "spec.image uses 'latest' tag; use an explicit version tag for reproducible deployments")
 			} else {
 				// Enforce minimum CE 8 version.
@@ -1204,15 +1204,37 @@ func (v *AerospikeClusterValidator) validateSizeAndImage(cluster *AerospikeClust
 	return sizeErrors, imageErrors, imageWarnings
 }
 
+// imageTag returns the tag portion of a container image reference, or "" when
+// the reference has no tag.
+//
+// A naive strings.SplitN(image, ":", 2) splits on the FIRST colon, which for a
+// registry that includes a port (e.g. "myregistry.io:5000/aerospike:ce-8.1.1.1"
+// or "localhost:32000/aerospike:ee-8.0.0") is the registry-port separator, not
+// the tag separator. That made parseMajorVersion and isEnterpriseTag misread the
+// tag and silently skip the CE version / enterprise-image guards for any image
+// pulled through a ported registry. Per the OCI/Docker reference grammar, the tag
+// colon is the LAST colon and must appear after the final '/'; a colon before the
+// last '/' belongs to the registry host:port and means the reference is untagged.
+func imageTag(image string) string {
+	lastColon := strings.LastIndex(image, ":")
+	if lastColon < 0 {
+		return ""
+	}
+	// A colon that precedes the last '/' is a registry port, not a tag.
+	if slash := strings.LastIndex(image, "/"); slash > lastColon {
+		return ""
+	}
+	return image[lastColon+1:]
+}
+
 // parseMajorVersion extracts the major version number from a container image tag
 // such as "aerospike:ce-8.1.1.1" or "aerospike:8.1.0". Returns an error if the
 // version cannot be determined.
 func parseMajorVersion(image string) (int, error) {
-	parts := strings.SplitN(image, ":", 2)
-	if len(parts) != 2 {
+	tag := imageTag(image)
+	if tag == "" {
 		return 0, fmt.Errorf("image %q has no tag", image)
 	}
-	tag := parts[1]
 	for _, prefix := range []string{"ce-", "ee-", "ent-"} {
 		if after, found := strings.CutPrefix(tag, prefix); found {
 			tag = after
@@ -1233,12 +1255,7 @@ func parseMajorVersion(image string) (int, error) {
 // isEnterpriseTag returns true if the image tag indicates an Enterprise Edition image
 // (e.g., "aerospike:ee-8.0.0.1_1", "aerospike:ent-8.0.0").
 func isEnterpriseTag(image string) bool {
-	parts := strings.SplitN(image, ":", 2)
-	if len(parts) != 2 {
-		return false
-	}
-
-	tagLower := strings.ToLower(parts[1])
+	tagLower := strings.ToLower(imageTag(image))
 	return strings.HasPrefix(tagLower, "ee-") || strings.HasPrefix(tagLower, "ent-")
 }
 
@@ -1804,9 +1821,8 @@ func (v *AerospikeClusterValidator) validateMonitoring(m *AerospikeMonitoringSpe
 	}
 
 	// Warn about 'latest' tag on exporter image.
-	if strings.Contains(m.ExporterImage, ":") {
-		parts := strings.SplitN(m.ExporterImage, ":", 2)
-		if parts[1] == "latest" {
+	if exporterTag := imageTag(m.ExporterImage); exporterTag != "" {
+		if exporterTag == "latest" {
 			warnings = append(warnings, "monitoring.exporterImage uses 'latest' tag; use an explicit version tag for reproducible deployments")
 		}
 	} else if m.ExporterImage != "" {

--- a/api/v1alpha1/webhook_test.go
+++ b/api/v1alpha1/webhook_test.go
@@ -1887,6 +1887,14 @@ func TestImageTag(t *testing.T) {
 		// reference is untagged.
 		{"myregistry.io:5000/aerospike", ""},
 		{"localhost:32000/aerospike", ""},
+		// Digest-pinned refs: the "@sha256:..." suffix must be stripped before
+		// locating the tag colon, otherwise the digest hex is returned as the tag
+		// and the CE-version / enterprise guards are silently skipped.
+		{"aerospike:ce-8.1.1.1@sha256:abc123", "ce-8.1.1.1"},
+		{"myregistry.io:5000/aerospike:ce-8.1.1.1@sha256:abc123", "ce-8.1.1.1"},
+		// Digest only, no tag: still untagged after stripping the digest.
+		{"aerospike@sha256:abc123", ""},
+		{"myregistry.io:5000/aerospike@sha256:abc123", ""},
 	}
 
 	for _, tc := range tests {
@@ -4710,6 +4718,39 @@ func TestValidate_ImageWithDigestAccepted(t *testing.T) {
 	}
 }
 
+// TestValidate_DigestPinnedGuardsStillFire verifies that the CE-version and
+// enterprise-edition guards are NOT bypassed by a "@sha256:..." digest suffix.
+// Before the digest was stripped in imageTag, the digest's colon was misread as
+// the tag separator, parseMajorVersion/isEnterpriseTag failed, and these images
+// slipped through.
+func TestValidate_DigestPinnedGuardsStillFire(t *testing.T) {
+	tests := []struct {
+		name    string
+		image   string
+		wantSub string // expected substring in the rejection error
+	}{
+		{name: "ce-7 digest-pinned rejected", image: "aerospike:ce-7.0.0.0@sha256:abc123", wantSub: "requires Aerospike CE"},
+		{name: "ee digest-pinned rejected", image: "aerospike:ee-8.0.0.1@sha256:abc123", wantSub: "Enterprise Edition"},
+		{name: "ported registry ce-7 digest rejected", image: "myregistry.io:5000/aerospike:ce-7.0.0.0@sha256:abc123", wantSub: "requires Aerospike CE"},
+	}
+
+	v := &AerospikeClusterValidator{}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cluster := &AerospikeCluster{
+				Spec: AerospikeClusterSpec{Size: 1, Image: tc.image},
+			}
+			_, err := v.validate(cluster)
+			if err == nil {
+				t.Fatalf("validate() with image %q: expected error, got none", tc.image)
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Errorf("validate() with image %q: expected error containing %q, got: %v", tc.image, tc.wantSub, err)
+			}
+		})
+	}
+}
+
 func TestValidate_ImageEnterpriseEETag(t *testing.T) {
 	v := &AerospikeClusterValidator{}
 	cluster := &AerospikeCluster{
@@ -6893,6 +6934,14 @@ func TestParseMajorVersion(t *testing.T) {
 		// gate is silently skipped.
 		{name: "ported registry ce-7", image: "myregistry.io:5000/aerospike:ce-7.0.0.0", want: 7, wantErr: false},
 		{name: "ported registry ce-8", image: "localhost:32000/aerospike:ce-8.1.1.1", want: 8, wantErr: false},
+		// Digest-pinned refs: the digest suffix must be stripped so the real tag's
+		// major version is parsed, not the digest hex (which would error and skip
+		// the CE-version gate).
+		{name: "digest-pinned ce-7", image: "aerospike:ce-7.0.0.0@sha256:abc123", want: 7, wantErr: false},
+		{name: "digest-pinned ce-8", image: "aerospike:ce-8.1.1.1@sha256:abc123", want: 8, wantErr: false},
+		{name: "ported registry digest-pinned ce-8", image: "myregistry.io:5000/aerospike:ce-8.1.1.1@sha256:abc123", want: 8, wantErr: false},
+		// Digest only (no tag) must error so the caller skips it.
+		{name: "digest only untagged", image: "aerospike@sha256:abc123", want: 0, wantErr: true},
 		// Ported registry with no tag must error so the caller skips it.
 		{name: "ported registry untagged", image: "myregistry.io:5000/aerospike", want: 0, wantErr: true},
 		// genuinely unparseable tags must still error so the caller skips gracefully.

--- a/api/v1alpha1/webhook_test.go
+++ b/api/v1alpha1/webhook_test.go
@@ -339,6 +339,11 @@ func TestValidate_EnterpriseImageRejected(t *testing.T) {
 	}{
 		{"aerospike:ee-8.0.0.1_1"},
 		{"aerospike-enterprise:8.0.0"},
+		// Enterprise image pulled through a registry that includes a port: the
+		// host:port colon must not be mistaken for the tag separator, otherwise
+		// the ee-/ent- tag is not detected and the image bypasses the CE guard.
+		{"myregistry.io:5000/aerospike:ee-8.0.0.1_1"},
+		{"localhost:32000/aerospike:ent-8.1.0"},
 	}
 
 	for _, tc := range tests {
@@ -1842,12 +1847,51 @@ func TestIsEnterpriseTag(t *testing.T) {
 		{"myrepo/aerospike:ce-8.1.1.1", false},
 		{"myrepo/aerospike:ee-8.1.1.1", true},
 		{"myrepo/aerospike:ent-8.1.1.1", true},
+		// Registry references with a port: the host:port colon must NOT be read
+		// as the tag separator, otherwise an Enterprise image slips through.
+		{"myregistry.io:5000/aerospike:ce-8.1.1.1", false},
+		{"myregistry.io:5000/aerospike:ee-8.0.0.1_1", true},
+		{"localhost:32000/aerospike:ent-8.1.0", true},
+		// A ported registry reference with no tag is untagged (the only colon is
+		// the registry port), so it is not an enterprise tag.
+		{"myregistry.io:5000/aerospike", false},
 	}
 
 	for _, tc := range tests {
 		got := isEnterpriseTag(tc.image)
 		if got != tc.expected {
 			t.Errorf("isEnterpriseTag(%q) = %v, want %v", tc.image, got, tc.expected)
+		}
+	}
+}
+
+// --- imageTag tests ---
+
+// TestImageTag covers tag extraction including the registry-with-port case that
+// a naive SplitN(image, ":", 2) misparsed (reading the host:port colon as the
+// tag separator), which silently bypassed the CE version / enterprise guards.
+func TestImageTag(t *testing.T) {
+	tests := []struct {
+		image string
+		want  string
+	}{
+		{"aerospike:ce-8.1.1.1", "ce-8.1.1.1"},
+		{"aerospike", ""},
+		{"aerospike:", ""},
+		{"myrepo/aerospike:ce-8.1.1.1", "ce-8.1.1.1"},
+		// Registry with a port: tag is after the last colon, which follows the
+		// last '/'.
+		{"myregistry.io:5000/aerospike:ce-8.1.1.1", "ce-8.1.1.1"},
+		{"localhost:32000/aerospike:ent-8.1.0", "ent-8.1.0"},
+		// Ported registry, no tag: the only colon is the registry port, so the
+		// reference is untagged.
+		{"myregistry.io:5000/aerospike", ""},
+		{"localhost:32000/aerospike", ""},
+	}
+
+	for _, tc := range tests {
+		if got := imageTag(tc.image); got != tc.want {
+			t.Errorf("imageTag(%q) = %q, want %q", tc.image, got, tc.want)
 		}
 	}
 }
@@ -5074,6 +5118,11 @@ func TestValidate_CE7ImageRejected(t *testing.T) {
 	}{
 		{"ce-7 tag", "aerospike:ce-7.2.0.6"},
 		{"ce-7.0 tag", "aerospike:ce-7.0.0.0"},
+		// CE 7.x image pulled through a ported registry: the host:port colon must
+		// not be mistaken for the tag separator, otherwise parseMajorVersion fails
+		// and the minimum-version gate is silently skipped.
+		{"ported registry ce-7", "myregistry.io:5000/aerospike:ce-7.0.0.0"},
+		{"ported registry ce-7 localhost", "localhost:32000/aerospike:ce-7.2.0.6"},
 	}
 
 	for _, tc := range tests {
@@ -6839,6 +6888,13 @@ func TestParseMajorVersion(t *testing.T) {
 		{name: "plain dotless 7", image: "aerospike:7", want: 7, wantErr: false},
 		{name: "ce-prefixed dotless 8", image: "aerospike:ce-8", want: 8, wantErr: false},
 		{name: "v-prefixed dotless 8", image: "aerospike:v8", want: 8, wantErr: false},
+		// Registry with a port: the host:port colon must not be read as the tag
+		// separator, otherwise the major version is misparsed and the CE-version
+		// gate is silently skipped.
+		{name: "ported registry ce-7", image: "myregistry.io:5000/aerospike:ce-7.0.0.0", want: 7, wantErr: false},
+		{name: "ported registry ce-8", image: "localhost:32000/aerospike:ce-8.1.1.1", want: 8, wantErr: false},
+		// Ported registry with no tag must error so the caller skips it.
+		{name: "ported registry untagged", image: "myregistry.io:5000/aerospike", want: 0, wantErr: true},
 		// genuinely unparseable tags must still error so the caller skips gracefully.
 		{name: "unparseable latest", image: "aerospike:latest", want: 0, wantErr: true},
 		{name: "unparseable empty tag", image: "aerospike:", want: 0, wantErr: true},

--- a/internal/template/resolver.go
+++ b/internal/template/resolver.go
@@ -69,16 +69,28 @@ var enterpriseOnlyNamespaceKeysCE = map[string]string{
 	"tomb-raider-period":       "tomb-raider is Enterprise-only",
 }
 
+// imageTag returns the tag portion of a container image reference, or "" when
+// the reference has no tag. A colon before the final '/' belongs to a registry
+// host:port (e.g. "myregistry.io:5000/aerospike:ee-8.0.0"), not the tag, so the
+// tag is taken from the last colon only when it follows the last '/'. Mirrors
+// api/v1alpha1.imageTag — duplicated to avoid an import cycle.
+func imageTag(image string) string {
+	lastColon := strings.LastIndex(image, ":")
+	if lastColon < 0 {
+		return ""
+	}
+	if slash := strings.LastIndex(image, "/"); slash > lastColon {
+		return ""
+	}
+	return image[lastColon+1:]
+}
+
 // isEnterpriseTag returns true for image tags that indicate an Enterprise
 // Edition build (e.g., "aerospike:ee-8.0.0.1_1", "aerospike:ent-8.0.0").
 // Mirrors api/v1alpha1.isEnterpriseTag — duplicated to avoid an import
 // cycle.
 func isEnterpriseTag(image string) bool {
-	parts := strings.SplitN(image, ":", 2)
-	if len(parts) != 2 {
-		return false
-	}
-	tagLower := strings.ToLower(parts[1])
+	tagLower := strings.ToLower(imageTag(image))
 	return strings.HasPrefix(tagLower, "ee-") || strings.HasPrefix(tagLower, "ent-")
 }
 

--- a/internal/template/resolver.go
+++ b/internal/template/resolver.go
@@ -72,9 +72,14 @@ var enterpriseOnlyNamespaceKeysCE = map[string]string{
 // imageTag returns the tag portion of a container image reference, or "" when
 // the reference has no tag. A colon before the final '/' belongs to a registry
 // host:port (e.g. "myregistry.io:5000/aerospike:ee-8.0.0"), not the tag, so the
-// tag is taken from the last colon only when it follows the last '/'. Mirrors
+// tag is taken from the last colon only when it follows the last '/'. A
+// digest-pinned ref's "@<algo>:<hex>" suffix is stripped first so the digest's
+// own colon is not misread as the tag separator. Mirrors
 // api/v1alpha1.imageTag — duplicated to avoid an import cycle.
 func imageTag(image string) string {
+	if at := strings.LastIndex(image, "@"); at >= 0 && at > strings.LastIndex(image, "/") {
+		image = image[:at]
+	}
 	lastColon := strings.LastIndex(image, ":")
 	if lastColon < 0 {
 		return ""

--- a/internal/template/validation_test.go
+++ b/internal/template/validation_test.go
@@ -86,6 +86,11 @@ func TestValidateTemplateSpec_V_T06_RejectsEnterpriseEditionTag(t *testing.T) {
 	for _, img := range []string{
 		"myregistry.io/aerospike:ee-8.0.0.1_1",
 		"myregistry.io/aerospike:ent-8.0.0",
+		// Registry references that include a port previously had their tag
+		// misparsed (the host:port colon was read as the tag separator), so an
+		// Enterprise image slipped through the CE guard. These must be rejected.
+		"myregistry.io:5000/aerospike:ee-8.0.0.1_1",
+		"localhost:32000/aerospike:ent-8.0.0",
 	} {
 		spec := &ackov1alpha1.AerospikeClusterTemplateSpec{Image: img}
 		errs, _ := ValidateTemplateSpec(spec)


### PR DESCRIPTION
## Problem

The CE image guards in the validating webhook extracted the image tag with `strings.SplitN(image, ":", 2)`, which splits on the **first** colon. For any image pulled through a registry that includes a **port** — e.g. `myregistry.io:5000/aerospike:ee-8.0.0` or `localhost:32000/aerospike:ce-7.0.0.0` — that first colon is the registry `host:port` separator, not the tag separator. The "tag" was therefore read as `5000/aerospike:ee-8.0.0`, and two CE constraints were silently bypassed:

- **Enterprise image bypass** — `isEnterpriseTag()` returned `false` for a ported-registry `ee-`/`ent-` image, so it slipped past the CE enterprise-image rejection. The existing `strings.Contains(image, "enterprise")` fallback does **not** catch these, because the repository name contains no `enterprise` substring.
- **CE 7.x version bypass** — `parseMajorVersion()` failed to parse the major version (`strconv.Atoi("5000/aerospike:ce-7")` errors), and the caller skips on parse error, so the "CE 7.x is no longer supported" minimum-version guard never fired for ported-registry images.

Both bypasses also existed in the post-template-merge CE check in `internal/template/resolver.go`, which carries its own duplicated `isEnterpriseTag`.

### Reproduction (before fix)
```
isEnterpriseTag("myregistry.io:5000/aerospike:ee-8.0.0")  => false   (should be true)
parseMajorVersion("myregistry.io:5000/aerospike:ce-7.0.0.0") => err   (version guard skipped)
```

## Root cause

`SplitN(image, ":", 2)` assumes the first colon is always the tag separator. That is false whenever the registry host carries an explicit port.

## Fix

Add an `imageTag()` helper that follows the OCI/Docker reference grammar: the tag colon is the **last** colon and must appear **after** the final `/`; a colon before the last `/` belongs to the registry `host:port`, which means the reference is untagged. Route `parseMajorVersion`, `isEnterpriseTag`, and the `spec.image` / `monitoring.exporterImage` `latest`/no-tag warning paths through it. The template resolver mirrors the helper locally to stay import-cycle free (matching the existing duplicated `isEnterpriseTag` there).

Files: `api/v1alpha1/aerospikecluster_webhook.go`, `internal/template/resolver.go` (+ tests). No CRD/apiVersion change, no public type rename, no version bump.

## Tests

Added unit coverage for ported-registry references:
- new `TestImageTag`
- ported-registry cases added to `TestIsEnterpriseTag`, `TestParseMajorVersion`, `TestValidate_EnterpriseImageRejected`, `TestValidate_CE7ImageRejected`, and the template `TestValidateTemplateSpec_V_T06_RejectsEnterpriseEditionTag`

## Verification

All run locally on darwin/arm64:

| Gate | Result |
|------|--------|
| `go build ./...` | PASS |
| `go vet ./...` | PASS |
| `gofmt -l` on the 4 changed files | clean (the only repo-wide gofmt hit is pre-existing `test/e2e/e2e_test.go`, untouched here) |
| custom `golangci-lint run ./api/... ./internal/template/...` (logcheck plugin built via `golangci-lint custom`) | **0 issues** |
| `go test` for `./api/...` and `./internal/template/...` | PASS |
| `go test` full non-e2e suite | PASS |
| envtest integration (`-tags=integration`, KUBEBUILDER_ASSETS k8s 1.35.0) | PASS — controller suite 32/32 specs green (needed an absolute `KUBEBUILDER_ASSETS` path; relative path resolution failed for an unrelated cwd reason) |

## Risk / scope

Low. Pure validation/parsing logic in the webhook and template resolver; no reconcile, pod, status, or networking behavior changes. Worst case of the helper is that a previously-accepted image is now correctly rejected (ported-registry Enterprise/CE-7 images), which is the intended CE constraint.

## kind / e2e

Slow kind/e2e suite was **deferred to separate validation** per task scope. This change does touch **webhook admission behavior**: a kind smoke test could assert that creating an `AerospikeCluster` with `spec.image: <host>:<port>/aerospike:ee-8.x` (or `:ce-7.x`) is now rejected by the webhook, where previously it was admitted. No reconcile/pod path is affected.