### PR TITLE
fix(controller): mark on-demand operation as Error on unknown Kind

### DIFF
--- a/internal/controller/reconciler_operations.go
+++ b/internal/controller/reconciler_operations.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -144,6 +145,15 @@ func (r *AerospikeClusterReconciler) reconcileOperations(
 		case ackov1alpha1.OperationPodRestart:
 			opErr = r.coldRestartPod(ctx, cluster, pod)
 			restartReason = ackov1alpha1.RestartReasonManualRestart
+		default:
+			// An unrecognized operation kind must never be reported as a silent
+			// success. Today the CRD enum guards op.Kind at the API server, so
+			// this is defense-in-depth: if validation is ever bypassed (older
+			// CRD, direct status writer, future kind added without a handler),
+			// route the pod into the FailedPods path so finalizeOperationPhase
+			// drives the operation to the terminal Error phase instead of
+			// appending it to CompletedPods having restarted nothing.
+			opErr = fmt.Errorf("unsupported operation kind %q", op.Kind)
 		}
 
 		if opErr == nil && restartReason != "" {

--- a/internal/controller/reconciler_operations_test.go
+++ b/internal/controller/reconciler_operations_test.go
@@ -110,6 +110,86 @@ func TestReconcileOperations_ExplicitPodListNoMatch_GoesToError(t *testing.T) {
 	}
 }
 
+// TestReconcileOperations_UnknownKind_GoesToError is the defense-in-depth
+// regression for the silent-no-op bug in the per-pod switch: an operation whose
+// Kind is neither WarmRestart nor PodRestart previously fell through the switch
+// with opErr=nil and restartReason="", so the pod was appended to CompletedPods
+// and the operation reported Completed having restarted nothing. The CRD enum
+// normally guards op.Kind at the API server, but if that validation is ever
+// bypassed the operator must surface the Error phase with the pod in FailedPods.
+func TestReconcileOperations_UnknownKind_GoesToError(t *testing.T) {
+	scheme := operationsScheme(t)
+	gateEnabled := true
+
+	cluster := &ackov1alpha1.AerospikeCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "default"},
+		Spec: ackov1alpha1.AerospikeClusterSpec{
+			Size: 1,
+			// Enable the readiness gate so operationBatchBlocked stays on the
+			// in-memory gate path (anyPodGateUnsatisfied) instead of the
+			// network-bound migration probe; the Pending target pod is skipped
+			// by the gate check, so the batch is not blocked and the per-pod
+			// switch — the code under test — actually runs.
+			PodSpec: &ackov1alpha1.AerospikePodSpec{ReadinessGateEnabled: &gateEnabled},
+			Operations: []ackov1alpha1.OperationSpec{
+				{
+					ID:      "op-bogus",
+					Kind:    ackov1alpha1.OperationKind("Bogus"),
+					PodList: []string{"demo-0"},
+				},
+			},
+		},
+	}
+
+	target := clusterPod("demo", "demo-0", corev1.PodPending)
+
+	reconciler := &AerospikeClusterReconciler{
+		Client: fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithStatusSubresource(&ackov1alpha1.AerospikeCluster{}).
+			WithObjects(cluster, target).
+			Build(),
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(16),
+	}
+
+	inProgress, err := reconciler.reconcileOperations(context.Background(), cluster)
+	if err != nil {
+		t.Fatalf("reconcileOperations() error = %v", err)
+	}
+	if inProgress {
+		t.Fatal("expected inProgress=false: an unsupported-kind operation is terminal, not requeued")
+	}
+
+	// The pod must NOT have been touched (no warm/cold restart happened).
+	if err := reconciler.Get(context.Background(),
+		types.NamespacedName{Name: "demo-0", Namespace: "default"}, &corev1.Pod{}); err != nil {
+		t.Fatalf("demo-0 should NOT have been restarted for an unsupported kind, Get err = %v", err)
+	}
+
+	updated := &ackov1alpha1.AerospikeCluster{}
+	if err := reconciler.Get(context.Background(),
+		types.NamespacedName{Name: "demo", Namespace: "default"}, updated); err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if updated.Status.OperationStatus == nil {
+		t.Fatal("expected OperationStatus to be set")
+	}
+	if updated.Status.OperationStatus.Phase != ackov1alpha1.AerospikePhaseError {
+		t.Errorf("phase = %q, want %q (an unsupported kind must not be reported as Completed)",
+			updated.Status.OperationStatus.Phase, ackov1alpha1.AerospikePhaseError)
+	}
+	if len(updated.Status.OperationStatus.CompletedPods) != 0 {
+		t.Errorf("CompletedPods = %v, want empty (nothing was actually restarted)",
+			updated.Status.OperationStatus.CompletedPods)
+	}
+	if len(updated.Status.OperationStatus.FailedPods) != 1 ||
+		updated.Status.OperationStatus.FailedPods[0] != "demo-0" {
+		t.Errorf("FailedPods = %v, want [demo-0] (the unsupported-kind pod must fail)",
+			updated.Status.OperationStatus.FailedPods)
+	}
+}
+
 func TestFilterPodsByNames_EmptyNames_ReturnsAll(t *testing.T) {
 	pods := []corev1.Pod{
 		{ObjectMeta: metav1.ObjectMeta{Name: "pod-0"}},

--- a/internal/controller/reconciler_operations_test.go
+++ b/internal/controller/reconciler_operations_test.go
@@ -141,7 +141,7 @@ func TestReconcileOperations_UnknownKind_GoesToError(t *testing.T) {
 		},
 	}
 
-	target := clusterPod("demo", "demo-0", corev1.PodPending)
+	target := clusterPod("demo-0", corev1.PodPending)
 
 	reconciler := &AerospikeClusterReconciler{
 		Client: fake.NewClientBuilder().
@@ -462,14 +462,15 @@ func operationsScheme(t *testing.T) *runtime.Scheme {
 	return scheme
 }
 
-// clusterPod builds a pod carrying the cluster selector labels so listClusterPods
-// (and thus getOperationTargetPods) resolves it as an operation target.
-func clusterPod(clusterName, name string, phase corev1.PodPhase) *corev1.Pod {
+// clusterPod builds a pod carrying the selector labels of the "demo" cluster
+// used throughout these tests so listClusterPods (and thus
+// getOperationTargetPods) resolves it as an operation target.
+func clusterPod(name string, phase corev1.PodPhase) *corev1.Pod {
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: "default",
-			Labels:    utils.SelectorLabelsForCluster(clusterName),
+			Labels:    utils.SelectorLabelsForCluster("demo"),
 		},
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
@@ -513,7 +514,7 @@ func TestReconcileOperations_BlockedByReadinessGate_DoesNotAdvance(t *testing.T)
 
 	// demo-0: already restarted, but its readiness gate is NOT yet satisfied
 	// (Running + gate condition False) → isBatchBlocked must hold the batch.
-	blockedPod := clusterPod("demo", "demo-0", corev1.PodRunning)
+	blockedPod := clusterPod("demo-0", corev1.PodRunning)
 	blockedPod.Spec.ReadinessGates = []corev1.PodReadinessGate{
 		{ConditionType: podutil.AerospikeReadinessGateConditionType},
 	}
@@ -521,7 +522,7 @@ func TestReconcileOperations_BlockedByReadinessGate_DoesNotAdvance(t *testing.T)
 		{Type: podutil.AerospikeReadinessGateConditionType, Status: corev1.ConditionFalse},
 	}
 	// demo-1: the next pod the operation would restart if the guard were absent.
-	nextPod := clusterPod("demo", "demo-1", corev1.PodRunning)
+	nextPod := clusterPod("demo-1", corev1.PodRunning)
 
 	reconciler := &AerospikeClusterReconciler{
 		Client: fake.NewClientBuilder().
@@ -587,7 +588,7 @@ func TestReconcileOperations_NotBlocked_AdvancesOneBatch(t *testing.T) {
 		},
 	}
 
-	target := clusterPod("demo", "demo-0", corev1.PodPending)
+	target := clusterPod("demo-0", corev1.PodPending)
 
 	reconciler := &AerospikeClusterReconciler{
 		Client: fake.NewClientBuilder().


### PR DESCRIPTION
## Problem

The per-pod `switch op.Kind` in `reconcileOperations` (`internal/controller/reconciler_operations.go`) handled only `WarmRestart` and `PodRestart` and had **no `default` arm**. If `op.Kind` is any other value, `opErr` stays `nil` and `restartReason` stays empty, so the pod is appended to `CompletedPods` and the operation is reported **Completed while performing no restart** — a silent no-op success.

The CRD enum guards `op.Kind` at the API server today, so this is defense-in-depth rather than a user-reachable bug. It matches the project's established "no silent no-op success" pattern from prior fixes (#312/#313, and the unresolved-named-pods guard in #320).

## Fix

Add a `default:` arm that sets:

```go
opErr = fmt.Errorf("unsupported operation kind %q", op.Kind)
```

This routes the pod into the existing `FailedPods` path, and `finalizeOperationPhase` then drives the operation to the terminal `Error` phase instead of `Completed`. (`fmt` added to imports.)

## Test plan

Added `TestReconcileOperations_UnknownKind_GoesToError` (mirrors the existing operations tests, using `operationsScheme`/`clusterPod`): a fake-client reconciler with `Spec.Operations[0].Kind = "Bogus"` and one pod. Asserts the operation ends in `AerospikePhaseError` with the pod in `FailedPods` (not `CompletedPods`), `inProgress=false`, and the pod untouched. Readiness gate is enabled with a `Pending` target pod so the batch guard stays on the in-memory path (no network-bound migration probe) — same technique as `TestReconcileOperations_NotBlocked_AdvancesOneBatch`.

Verification (all pass locally, Go 1.26):
- `go build ./...`
- `go vet ./internal/controller/`
- `gofmt -l` on both changed files → empty
- `go test ./internal/controller/` → ok

## Compatibility

No CRD `apiVersion` bump, no field rename/removal. Purely additive defensive handling — non-breaking.