### PR TITLE
fix(controller): don't report Completed phase when ACL sync failed

### DIFF
--- a/internal/controller/reconciler.go
+++ b/internal/controller/reconciler.go
@@ -678,18 +678,40 @@ func (r *AerospikeClusterReconciler) reconcileCluster(
 	// cluster-level hash.
 	validConfigHashes := buildValidConfigHashes(rackInfos)
 
-	// Decide the terminal phase for this reconcile. ACL sync failures are
-	// deliberately not routed through handleReconcileError/the circuit breaker
-	// (they are usually recoverable: a wrong password Secret or a node briefly
-	// unavailable mid-restart). But the cluster must NOT be reported as
-	// Completed/"healthy and stable" when ACL never synced — that would mislead
-	// operators and any consumer keying on phase=Completed, and it would stamp
-	// the unsynced spec into Status.AppliedSpec (drift baseline) as if it had
-	// been fully applied. Surface the ACLSync phase with the failure reason and
-	// requeue so the next reconcile retries; the ACLSynced=False condition still
-	// carries the detailed error.
-	phase, phaseReason := terminalPhaseForACL(aclErr)
+	// Publish the terminal status and decide whether to requeue. Split into a
+	// helper so the end-of-reconcile status/requeue handling lives in one place
+	// and reconcileCluster stays under the cyclomatic-complexity budget.
+	return r.finalizeReconcile(ctx, namespacedName, cluster, aclErr, aclSynced, validConfigHashes)
+}
 
+// finalizeReconcile publishes the terminal status for a fully-reconciled cluster
+// and decides whether to requeue. It is split out of reconcileCluster to keep
+// that function's cyclomatic complexity in check and to group the
+// end-of-reconcile status/requeue decision in one place.
+//
+// ACL sync failures are deliberately not routed through
+// handleReconcileError/the circuit breaker (they are usually recoverable: a
+// wrong password Secret or a node briefly unavailable mid-restart). But the
+// cluster must NOT be reported as Completed/"healthy and stable" when ACL never
+// synced — that would mislead operators and any consumer keying on
+// phase=Completed, and it would stamp the unsynced spec into
+// Status.AppliedSpec (drift baseline) as if it had been fully applied. So on an
+// ACL failure terminalPhaseForACL publishes the ACLSync phase with the failure
+// reason and we requeue after aclRetryInterval to retry — a Secret change does
+// not bump the CR generation, so an explicit requeue is the only prompt retry.
+// On success we use a shorter fallback requeue while not all pods are Ready yet,
+// as a safety net for missed pod-Ready watch events.
+func (r *AerospikeClusterReconciler) finalizeReconcile(
+	ctx context.Context,
+	namespacedName types.NamespacedName,
+	cluster *ackov1alpha1.AerospikeCluster,
+	aclErr error,
+	aclSynced bool,
+	validConfigHashes map[string]bool,
+) (ctrl.Result, error) {
+	log := logf.FromContext(ctx)
+
+	phase, phaseReason := terminalPhaseForACL(aclErr)
 	statusOpts := StatusUpdateOpts{ACLErr: aclErr, ACLSynced: aclSynced, ValidConfigHashes: validConfigHashes}
 	if err := r.updateStatusAndPhase(ctx, namespacedName, phase, phaseReason, statusOpts); err != nil {
 		if errors.IsConflict(err) {

--- a/internal/controller/reconciler.go
+++ b/internal/controller/reconciler.go
@@ -78,6 +78,15 @@ const (
 	// longer interval serves only as a safety net for missed watch events.
 	podReadyPollInterval = 60 * time.Second
 
+	// aclRetryInterval is the requeue interval used when ACL sync failed. ACL
+	// failures (wrong password secret, a node briefly unavailable mid-restart)
+	// are treated as recoverable and are NOT routed through the circuit breaker,
+	// but they must still be retried promptly — and the cluster must not be
+	// reported as Completed/healthy in the meantime. Secret changes don't bump
+	// the CR generation, so without an explicit requeue an ACL failure would not
+	// be re-attempted until the next watch event or full resync.
+	aclRetryInterval = 30 * time.Second
+
 	// reconcileTimeout is the maximum duration for a single reconciliation loop.
 	// If the context deadline is exceeded, the reconcile will be retried with backoff.
 	reconcileTimeout = 5 * time.Minute
@@ -669,14 +678,31 @@ func (r *AerospikeClusterReconciler) reconcileCluster(
 	// cluster-level hash.
 	validConfigHashes := buildValidConfigHashes(rackInfos)
 
-	// Update status and set phase to Completed.
+	// Decide the terminal phase for this reconcile. ACL sync failures are
+	// deliberately not routed through handleReconcileError/the circuit breaker
+	// (they are usually recoverable: a wrong password Secret or a node briefly
+	// unavailable mid-restart). But the cluster must NOT be reported as
+	// Completed/"healthy and stable" when ACL never synced — that would mislead
+	// operators and any consumer keying on phase=Completed, and it would stamp
+	// the unsynced spec into Status.AppliedSpec (drift baseline) as if it had
+	// been fully applied. Surface the ACLSync phase with the failure reason and
+	// requeue so the next reconcile retries; the ACLSynced=False condition still
+	// carries the detailed error.
+	phase, phaseReason := terminalPhaseForACL(aclErr)
+
 	statusOpts := StatusUpdateOpts{ACLErr: aclErr, ACLSynced: aclSynced, ValidConfigHashes: validConfigHashes}
-	if err := r.updateStatusAndPhase(ctx, namespacedName, ackov1alpha1.AerospikePhaseCompleted, "Cluster is healthy and stable", statusOpts); err != nil {
+	if err := r.updateStatusAndPhase(ctx, namespacedName, phase, phaseReason, statusOpts); err != nil {
 		if errors.IsConflict(err) {
 			return ctrl.Result{Requeue: true}, nil
 		}
 		metrics.ReconcileErrorsTotal.WithLabelValues(cluster.Namespace, cluster.Name, metrics.ReasonStatus).Inc()
 		return ctrl.Result{}, err
+	}
+
+	// Requeue to retry a failed ACL sync without tripping the circuit breaker.
+	if aclErr != nil {
+		log.Info("Reconciliation completed but ACL sync failed; requeuing to retry", "retryAfter", aclRetryInterval)
+		return ctrl.Result{RequeueAfter: aclRetryInterval}, nil
 	}
 
 	log.Info("Reconciliation completed successfully")
@@ -692,6 +718,25 @@ func (r *AerospikeClusterReconciler) reconcileCluster(
 	}
 
 	return ctrl.Result{}, nil
+}
+
+// terminalPhaseForACL returns the phase and human-readable reason a reconcile
+// should publish at the end of reconcileCluster, given the (possibly nil) ACL
+// sync error.
+//
+// When ACL sync succeeded (or no ACL was configured), the cluster reaches the
+// healthy Completed phase. When ACL sync failed, the cluster must instead stay
+// in the ACLSync phase with the failure reason: reporting Completed/"healthy and
+// stable" on an ACL failure would both mislead consumers keying on
+// phase=Completed and (via updateStatusAndPhase) stamp the unsynced spec into
+// Status.AppliedSpec as if it had been applied. Extracted as a pure function so
+// the phase decision is unit-testable without a live ACL/Aerospike connection.
+func terminalPhaseForACL(aclErr error) (ackov1alpha1.AerospikePhase, string) {
+	if aclErr != nil {
+		return ackov1alpha1.AerospikePhaseACLSync,
+			fmt.Sprintf("ACL synchronization failed; will retry: %v", aclErr)
+	}
+	return ackov1alpha1.AerospikePhaseCompleted, "Cluster is healthy and stable"
 }
 
 // buildValidConfigHashes returns the set of acceptable effective per-rack

--- a/internal/controller/reconciler_acl_phase_test.go
+++ b/internal/controller/reconciler_acl_phase_test.go
@@ -1,0 +1,143 @@
+package controller
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
+)
+
+// TestTerminalPhaseForACL verifies the phase/reason decision made at the end of
+// reconcileCluster. The regression this guards: an ACL sync failure used to be
+// recorded only as the ACLSynced=False condition while the cluster phase was
+// still hard-coded to Completed/"healthy and stable" — a silent failure that
+// misled any consumer keying on phase=Completed.
+func TestTerminalPhaseForACL(t *testing.T) {
+	tests := []struct {
+		name       string
+		aclErr     error
+		wantPhase  ackov1alpha1.AerospikePhase
+		wantReason string
+	}{
+		{
+			name:       "acl synced -> Completed/healthy",
+			aclErr:     nil,
+			wantPhase:  ackov1alpha1.AerospikePhaseCompleted,
+			wantReason: "Cluster is healthy and stable",
+		},
+		{
+			name:       "acl failed -> ACLSync phase, not Completed",
+			aclErr:     errors.New("granting roles to user admin: connection reset"),
+			wantPhase:  ackov1alpha1.AerospikePhaseACLSync,
+			wantReason: "ACL synchronization failed; will retry: granting roles to user admin: connection reset",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotPhase, gotReason := terminalPhaseForACL(tt.aclErr)
+			if gotPhase != tt.wantPhase {
+				t.Errorf("phase = %q, want %q", gotPhase, tt.wantPhase)
+			}
+			if gotReason != tt.wantReason {
+				t.Errorf("reason = %q, want %q", gotReason, tt.wantReason)
+			}
+			// A failed ACL sync must never be reported as the healthy Completed
+			// phase — that is the precise bug being fixed.
+			if tt.aclErr != nil && gotPhase == ackov1alpha1.AerospikePhaseCompleted {
+				t.Errorf("ACL failure must not map to Completed phase")
+			}
+		})
+	}
+}
+
+// TestUpdateStatusAndPhaseACLFailureDoesNotStampAppliedSpec is the integration
+// half of the fix: when reconcileCluster publishes the ACLSync phase (because
+// ACL failed), updateStatusAndPhase must NOT record Status.AppliedSpec — doing
+// so would treat the unsynced spec as the drift-detection baseline. AppliedSpec
+// is only stamped on the Completed phase, so driving the cluster through the
+// ACLSync phase must leave AppliedSpec nil.
+func TestUpdateStatusAndPhaseACLFailureDoesNotStampAppliedSpec(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := ackov1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme() error = %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("corev1 AddToScheme() error = %v", err)
+	}
+
+	stored := &ackov1alpha1.AerospikeCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "default",
+		},
+		Spec: ackov1alpha1.AerospikeClusterSpec{
+			Size:  2,
+			Image: "aerospike:ce-8.1.1.1",
+			AerospikeAccessControl: &ackov1alpha1.AerospikeAccessControlSpec{
+				Users: []ackov1alpha1.AerospikeUserSpec{
+					{Name: "admin", SecretName: "admin-secret", Roles: []string{"sys-admin", "user-admin"}},
+				},
+			},
+		},
+		Status: ackov1alpha1.AerospikeClusterStatus{
+			Phase:       ackov1alpha1.AerospikePhaseACLSync,
+			PhaseReason: "Synchronizing ACL roles and users",
+		},
+	}
+
+	reconciler := &AerospikeClusterReconciler{
+		Client: fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithStatusSubresource(&ackov1alpha1.AerospikeCluster{}).
+			WithObjects(stored).
+			Build(),
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+	}
+
+	aclErr := errors.New("changing password for user admin: timeout")
+	phase, phaseReason := terminalPhaseForACL(aclErr)
+
+	nn := types.NamespacedName{Name: stored.Name, Namespace: stored.Namespace}
+	opts := StatusUpdateOpts{ACLErr: aclErr, ACLSynced: false}
+	if err := reconciler.updateStatusAndPhase(context.Background(), nn, phase, phaseReason, opts); err != nil {
+		t.Fatalf("updateStatusAndPhase() error = %v", err)
+	}
+
+	updated := &ackov1alpha1.AerospikeCluster{}
+	if err := reconciler.Get(context.Background(), nn, updated); err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+
+	if updated.Status.Phase != ackov1alpha1.AerospikePhaseACLSync {
+		t.Errorf("Phase = %q, want %q (ACL failure must not be reported as Completed)",
+			updated.Status.Phase, ackov1alpha1.AerospikePhaseACLSync)
+	}
+	if updated.Status.AppliedSpec != nil {
+		t.Errorf("AppliedSpec must remain nil on ACL failure; got %+v", updated.Status.AppliedSpec)
+	}
+
+	// The ACLSynced condition must carry the detailed failure.
+	var aclCond *metav1.Condition
+	for i := range updated.Status.Conditions {
+		if updated.Status.Conditions[i].Type == ackov1alpha1.ConditionACLSynced {
+			aclCond = &updated.Status.Conditions[i]
+			break
+		}
+	}
+	if aclCond == nil {
+		t.Fatal("expected ACLSynced condition to be set")
+	}
+	if aclCond.Status != metav1.ConditionFalse {
+		t.Errorf("ACLSynced condition status = %q, want False", aclCond.Status)
+	}
+}


### PR DESCRIPTION
## Issue

`reconcileCluster` treats ACL sync errors as **non-fatal** — deliberately, so a recoverable ACL problem (wrong password Secret, a node briefly unavailable mid-restart) doesn't trip the reconcile circuit breaker. But after a failed ACL sync it still called:

```go
updateStatusAndPhase(ctx, nn, ackov1alpha1.AerospikePhaseCompleted, "Cluster is healthy and stable", statusOpts)
```

The `aclErr` was threaded only into the `ACLSynced=False` *condition*; the **phase** was hard-coded to `Completed`. Three consequences:

1. **Silent failure**: a cluster whose ACL never synced is reported as `phase=Completed` / "Cluster is healthy and stable". Any consumer keying on `phase=Completed` (ackoctl, UI, dashboards, scripts) sees a degraded cluster as healthy.
2. **Corrupted drift baseline**: `updateStatusAndPhase` stamps `Status.AppliedSpec = Spec.DeepCopy()` on the `Completed` phase, so the *unsynced* spec became the drift-detection baseline as if it had been fully applied.
3. **No retry**: `reconcileCluster` returned `(ctrl.Result{}, nil)` — no requeue. Since Secret changes don't bump the CR generation, the failed ACL sync wasn't re-attempted until the next watch event or full resync.

## Root cause

The terminal phase at the end of `reconcileCluster` ignored `aclErr` and always used `AerospikePhaseCompleted`.

## Fix

- Extract the phase decision into a pure helper `terminalPhaseForACL(aclErr)`:
  - `aclErr == nil` → `Completed` / "Cluster is healthy and stable" (unchanged).
  - `aclErr != nil` → `ACLSync` phase with reason `"ACL synchronization failed; will retry: <err>"`.
- Because the phase is no longer `Completed` on failure, `AppliedSpec` is **not** stamped (drift baseline stays correct).
- Requeue after a new `aclRetryInterval` (30s) on ACL failure so the sync is retried **without** routing through `handleReconcileError`/the circuit breaker — preserving the existing "ACL errors are recoverable" design.
- The `ACLSynced=False` condition still carries the detailed error (unchanged).

## Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- `gofmt -l` on changed files — empty
- `go test ./...` — all unit packages pass
- New tests **fail without the fix** (verified by temporarily reintroducing the bug):
  - `TestTerminalPhaseForACL` (table-driven): asserts ACL failure never maps to `Completed`.
  - `TestUpdateStatusAndPhaseACLFailureDoesNotStampAppliedSpec` (fake client): drives the cluster through the ACLSync phase and asserts `Status.AppliedSpec` stays nil and the `ACLSynced` condition is `False`.

`golangci-lint` was not run — this environment's config requires a `logcheck` plugin that isn't installed (pre-existing infra limitation, unrelated to this change).

## Files

- `internal/controller/reconciler.go` (+49/-2)
- `internal/controller/reconciler_acl_phase_test.go` (new, +143)