### PR TITLE
feat(chart): web-scoped extraEnv/extraEnvFrom for the ACKO Agent LLM key

### DIFF
--- a/charts/aerospike-ce-kubernetes-operator/README.md
+++ b/charts/aerospike-ce-kubernetes-operator/README.md
@@ -471,7 +471,9 @@ helm install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kuber
 ```
 
 Shared extra environment variables can be passed to both UI containers via
-`ui.extraEnv`; API-only environment can be passed via `ui.api.extraEnv`:
+`ui.extraEnv`; API-only environment via `ui.api.extraEnv` /
+`ui.api.extraEnvFrom`; web-only environment via `ui.web.extraEnv` /
+`ui.web.extraEnvFrom`:
 
 ```yaml
 ui:
@@ -488,6 +490,31 @@ ui:
       - name: API_ONLY_SETTING
         value: enabled
 ```
+
+### ACKO Agent (embedded AI copilot)
+
+The web UI ships an optional, off-by-default AI assistant ("ACKO Agent",
+cluster-manager >= 0.31). Enable it by giving ONLY the web container an LLM
+model and the matching provider API key — use the web-scoped values so the
+key never reaches the api container:
+
+```bash
+kubectl -n aerospike-operator create secret generic acko-agent-secrets \
+  --from-literal=COPILOT_MODEL=anthropic/claude-sonnet-4-5 \
+  --from-literal=ANTHROPIC_API_KEY=<your-key>
+```
+
+```yaml
+ui:
+  web:
+    extraEnvFrom:
+      - secretRef:
+          name: acko-agent-secrets
+```
+
+Without the secret the UI renders unchanged and the agent stays disabled.
+See the cluster-manager README for the full COPILOT_* variable reference
+(COPILOT_REQUIRE_AUTH, COPILOT_OIDC_ISSUER_URL, ...).
 
 ### Full example
 

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/deployment-web.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/deployment-web.yaml
@@ -54,9 +54,17 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ include "aerospike-ce-kubernetes-operator.ui.fullname" . }}-config
-          {{- with .Values.ui.extraEnv }}
-          env:
+            {{- with .Values.ui.web.extraEnvFrom }}
             {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- if or .Values.ui.web.extraEnv .Values.ui.extraEnv }}
+          env:
+            {{- with .Values.ui.web.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .Values.ui.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
           {{- with .Values.ui.securityContext }}
           securityContext:

--- a/charts/aerospike-ce-kubernetes-operator/values.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/values.yaml
@@ -806,6 +806,26 @@ ui:
       # instead of the in-cluster API Service. Required when
       # `ui.api.enabled=false` so the web frontend has somewhere to talk to.
       apiUrl: ""
+    # -- Extra env entries rendered ONLY into the web container (the shared
+    # `ui.extraEnv` renders into both api and web). Use this for the
+    # embedded ACKO Agent (AI copilot) so the LLM API key never reaches the
+    # api container. Example:
+    #   extraEnv:
+    #     - name: COPILOT_MODEL
+    #       value: "anthropic/claude-sonnet-4-5"
+    #     - name: ANTHROPIC_API_KEY
+    #       valueFrom:
+    #         secretKeyRef:
+    #           name: acko-agent-secrets
+    #           key: ANTHROPIC_API_KEY
+    extraEnv: []
+    # -- envFrom entries (configMapRef / secretRef) for the web container —
+    # bulk injection of an ACKO Agent secret holding COPILOT_MODEL +
+    # provider API keys. Example:
+    #   extraEnvFrom:
+    #     - secretRef:
+    #         name: acko-agent-secrets
+    extraEnvFrom: []
     resources:
       requests:
         cpu: 50m


### PR DESCRIPTION
## Summary

The cluster-manager web UI is gaining an optional embedded AI assistant (**ACKO Agent**, aerospike-ce-ecosystem/aerospike-cluster-manager#439). Enabling it requires `COPILOT_MODEL` + `ANTHROPIC_API_KEY`/`OPENAI_API_KEY` on the **web container only** — but the chart had no web-scoped env values: the shared `ui.extraEnv` renders into both api and web containers, which would leak the LLM key into the api pod.

## Changes

- `ui.web.extraEnv` — env entries rendered only into the web container (supports `valueFrom.secretKeyRef`)
- `ui.web.extraEnvFrom` — `configMapRef`/`secretRef` bulk injection for the web container, mirroring the existing `ui.api.extraEnvFrom`
- Chart README: web-scoped env documentation + ACKO Agent secret example (`kubectl create secret generic acko-agent-secrets ...` + `ui.web.extraEnvFrom`)

## Verification

- `helm lint` clean
- `helm template` with `ui.web.extraEnv` + `ui.web.extraEnvFrom` set: the web Deployment renders the `secretRef` under `envFrom` and the env entry; the api Deployment is unchanged
- Backward compatible: both new values default to `[]`; existing `ui.extraEnv` behavior is preserved (web still renders it after web-scoped entries)