### PR TITLE
docs(chart): document COPILOT_BASE_URL for NAMC Open Models in ACKO Agent

### DIFF
--- a/charts/aerospike-ce-kubernetes-operator/README.md
+++ b/charts/aerospike-ce-kubernetes-operator/README.md
@@ -512,6 +512,23 @@ ui:
           name: acko-agent-secrets
 ```
 
+#### OpenAI-compatible gateway (e.g. NAVER MODEL CONNECT Open Models)
+
+To route the agent through an OpenAI-compatible gateway instead of the public
+OpenAI API, add `COPILOT_BASE_URL` and use an `openai/*` model id with
+`OPENAI_API_KEY`. For NAMC Open Models API (issue the key from the project's
+Open Models API tab in the MODEL CONNECT console):
+
+```bash
+kubectl -n aerospike-operator create secret generic acko-agent-secrets \
+  --from-literal=COPILOT_MODEL=openai/gpt-oss-120b \
+  --from-literal=COPILOT_BASE_URL=https://namc-aigw.io.naver.com \
+  --from-literal=OPENAI_API_KEY=<MODEL CONNECT Open Models API key>
+```
+
+Pick a model that supports function/tool calling so the agent's read tools
+work. The `ui.web.extraEnvFrom` snippet above is unchanged.
+
 Without the secret the UI renders unchanged and the agent stays disabled.
 See the cluster-manager README for the full COPILOT_* variable reference
 (COPILOT_REQUIRE_AUTH, COPILOT_OIDC_ISSUER_URL, ...).

--- a/charts/aerospike-ce-kubernetes-operator/values.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/values.yaml
@@ -818,6 +818,19 @@ ui:
     #         secretKeyRef:
     #           name: acko-agent-secrets
     #           key: ANTHROPIC_API_KEY
+    # To route the agent through an OpenAI-compatible gateway such as NAVER
+    # MODEL CONNECT Open Models API, set COPILOT_BASE_URL and use an
+    # openai/* model id with OPENAI_API_KEY:
+    #   extraEnv:
+    #     - name: COPILOT_MODEL
+    #       value: "openai/gpt-oss-120b"
+    #     - name: COPILOT_BASE_URL
+    #       value: "https://namc-aigw.io.naver.com"
+    #     - name: OPENAI_API_KEY
+    #       valueFrom:
+    #         secretKeyRef:
+    #           name: acko-agent-secrets
+    #           key: OPENAI_API_KEY
     extraEnv: []
     # -- envFrom entries (configMapRef / secretRef) for the web container —
     # bulk injection of an ACKO Agent secret holding COPILOT_MODEL +


### PR DESCRIPTION
## Summary

Document how to point the **ACKO Agent** (web copilot) at an OpenAI-compatible **gateway**
via `COPILOT_BASE_URL` — specifically **NAVER MODEL CONNECT (NAMC) Open Models API**.

Depends on the cluster-manager change that adds `COPILOT_BASE_URL`
(aerospike-ce-ecosystem/aerospike-cluster-manager `feat/copilot-openai-compatible-base-url`).
**Docs only — no template changes** (the web `extraEnv`/`extraEnvFrom` already supports it).

## What changed

- **`charts/.../values.yaml`** — add a NAMC Open Models example to the `ui.web.extraEnv`
  comment (`COPILOT_MODEL=openai/<model>`, `COPILOT_BASE_URL=https://namc-aigw.io.naver.com`,
  `OPENAI_API_KEY` via secretKeyRef).
- **`charts/.../README.md`** — new "OpenAI-compatible gateway (e.g. NAVER MODEL CONNECT
  Open Models)" subsection under *ACKO Agent* with a ready-to-use `acko-agent-secrets` example.

## Verification

Deployed this chart to a kind cluster with the secret above; the cluster-manager web pod
reached NAMC and the ACKO Agent answered through it (see the cluster-manager PR for the
end-to-end browser verification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
