### PR TITLE
feat(chart): first-class ui.web.copilot config for the ACKO Agent

### DIFF
--- a/charts/aerospike-ce-kubernetes-operator/README.md
+++ b/charts/aerospike-ce-kubernetes-operator/README.md
@@ -494,27 +494,49 @@ ui:
 ### ACKO Agent (embedded AI copilot)
 
 The web UI ships an optional, off-by-default AI assistant ("ACKO Agent",
-cluster-manager >= 0.31). Enable it by giving ONLY the web container an LLM
-model and the matching provider API key — use the web-scoped values so the
-key never reaches the api container:
+cluster-manager >= 0.31). Enable it from `ui.web.copilot` — set the model, an
+optional gateway base URL, and a key, and the chart wires the web container's
+`COPILOT_*` env and a Secret for the key automatically. The key only ever
+reaches the web container, never the api.
+
+#### Quickest — inline key (dev/test)
+
+```yaml
+ui:
+  web:
+    copilot:
+      enabled: true
+      model: openai/<model>                 # or anthropic/<model>
+      baseUrl: https://llm-gateway.example.com   # omit for the public OpenAI/Anthropic API
+      apiKey: <gateway API key>             # rendered into a chart-managed Secret
+```
+
+#### Production — bring your own Secret
+
+Avoid putting the key in values; reference a pre-created Secret instead. It is
+loaded with `envFrom`, so its keys must be env var names — at minimum the
+provider key (`OPENAI_API_KEY` or `ANTHROPIC_API_KEY`):
 
 ```bash
 kubectl -n aerospike-operator create secret generic acko-agent-secrets \
-  --from-literal=COPILOT_MODEL=anthropic/claude-sonnet-4-5 \
-  --from-literal=ANTHROPIC_API_KEY=<your-key>
+  --from-literal=OPENAI_API_KEY=<gateway API key>
 ```
 
 ```yaml
 ui:
   web:
-    extraEnvFrom:
-      - secretRef:
-          name: acko-agent-secrets
+    copilot:
+      enabled: true
+      model: openai/<model>
+      baseUrl: https://llm-gateway.example.com
+      existingSecret: acko-agent-secrets
 ```
 
-Without the secret the UI renders unchanged and the agent stays disabled.
-See the cluster-manager README for the full COPILOT_* variable reference
-(COPILOT_REQUIRE_AUTH, COPILOT_OIDC_ISSUER_URL, ...).
+Pick a model that supports function/tool calling so the agent's tools work.
+With `enabled: false` (default) the UI renders unchanged and the agent stays
+disabled. For advanced cases you can still inject `COPILOT_*` yourself via
+`ui.web.extraEnv` / `ui.web.extraEnvFrom`. Full variable reference
+(`COPILOT_REQUIRE_AUTH`, ...) is in the cluster-manager README.
 
 ### Full example
 

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/configmap.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/configmap.yaml
@@ -36,6 +36,17 @@ data:
   {{- end }}
   DEFAULT_AEROSPIKE_IMAGE: {{ .Values.aerospikeImages.aerospike | quote }}
   DEFAULT_EXPORTER_IMAGE: {{ .Values.aerospikeImages.exporter | quote }}
+  {{- if .Values.ui.web.copilot.enabled }}
+  # Embedded ACKO Agent (AI copilot) — non-secret config. The provider API key
+  # is injected separately via a Secret (templates/ui/copilot-secret.yaml) or
+  # the user's existingSecret.
+  COPILOT_ENABLED: "true"
+  COPILOT_MODEL: {{ .Values.ui.web.copilot.model | quote }}
+  {{- with .Values.ui.web.copilot.baseUrl }}
+  COPILOT_BASE_URL: {{ . | quote }}
+  {{- end }}
+  COPILOT_REQUIRE_AUTH: {{ .Values.ui.web.copilot.requireAuth | quote }}
+  {{- end }}
 {{- end }}
 {{- if eq (include "aerospike-ce-kubernetes-operator.multiCluster.enabled" .) "true" }}
 ---

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/copilot-secret.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/copilot-secret.yaml
@@ -1,0 +1,22 @@
+{{- /*
+Chart-managed Secret for the embedded ACKO Agent (AI copilot) provider API key.
+Rendered only when the copilot is enabled with an inline apiKey and no
+existingSecret. The key is stored under the provider's env-var name
+(OPENAI_API_KEY or ANTHROPIC_API_KEY, derived from ui.web.copilot.model) so the
+web Deployment can load it with envFrom. Use ui.web.copilot.existingSecret to
+supply the key from your own Secret instead (never put apiKey in values in
+production).
+*/ -}}
+{{- if and .Values.ui.web.enabled .Values.ui.web.copilot.enabled .Values.ui.web.copilot.apiKey (not .Values.ui.web.copilot.existingSecret) }}
+{{- $keyVar := ternary "ANTHROPIC_API_KEY" "OPENAI_API_KEY" (hasPrefix "anthropic/" .Values.ui.web.copilot.model) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "aerospike-ce-kubernetes-operator.ui.fullname" . }}-copilot
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "aerospike-ce-kubernetes-operator.ui.web.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{ $keyVar }}: {{ .Values.ui.web.copilot.apiKey | quote }}
+{{- end }}

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/deployment-web.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/deployment-web.yaml
@@ -54,6 +54,17 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ include "aerospike-ce-kubernetes-operator.ui.fullname" . }}-config
+            {{- if .Values.ui.web.copilot.enabled }}
+            {{- if .Values.ui.web.copilot.existingSecret }}
+            # ACKO Agent provider API key from a user-supplied Secret.
+            - secretRef:
+                name: {{ .Values.ui.web.copilot.existingSecret }}
+            {{- else if .Values.ui.web.copilot.apiKey }}
+            # ACKO Agent provider API key from the chart-managed Secret.
+            - secretRef:
+                name: {{ include "aerospike-ce-kubernetes-operator.ui.fullname" . }}-copilot
+            {{- end }}
+            {{- end }}
             {{- with .Values.ui.web.extraEnvFrom }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/aerospike-ce-kubernetes-operator/values.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/values.yaml
@@ -818,6 +818,19 @@ ui:
     #         secretKeyRef:
     #           name: acko-agent-secrets
     #           key: ANTHROPIC_API_KEY
+    # To route the agent through a self-hosted or enterprise OpenAI-compatible
+    # LLM gateway, set COPILOT_BASE_URL and use an openai/* model id with
+    # OPENAI_API_KEY:
+    #   extraEnv:
+    #     - name: COPILOT_MODEL
+    #       value: "openai/<model>"
+    #     - name: COPILOT_BASE_URL
+    #       value: "https://llm-gateway.example.com"
+    #     - name: OPENAI_API_KEY
+    #       valueFrom:
+    #         secretKeyRef:
+    #           name: acko-agent-secrets
+    #           key: OPENAI_API_KEY
     extraEnv: []
     # -- envFrom entries (configMapRef / secretRef) for the web container —
     # bulk injection of an ACKO Agent secret holding COPILOT_MODEL +
@@ -826,6 +839,31 @@ ui:
     #     - secretRef:
     #         name: acko-agent-secrets
     extraEnvFrom: []
+    # -- Embedded ACKO Agent (AI copilot) — first-class config. Set enabled +
+    # model + a key here and the chart wires the web container's COPILOT_* env
+    # and a Secret for the key automatically (no manual extraEnv/Secret needed;
+    # extraEnv above still works for advanced cases).
+    copilot:
+      # -- Turn the in-UI AI assistant on. Needs `model` and a key
+      # (`apiKey` or `existingSecret`).
+      enabled: false
+      # -- LLM model as "<provider>/<model>"; provider is `openai` or
+      # `anthropic`. e.g. "openai/gpt-4o", "anthropic/claude-sonnet-4-5".
+      model: ""
+      # -- Optional OpenAI/Anthropic-compatible gateway base URL (sets
+      # COPILOT_BASE_URL). Empty → the provider's public API.
+      # e.g. "https://llm-gateway.example.com".
+      baseUrl: ""
+      # -- API key (inline). Rendered into a chart-managed Secret, never a
+      # ConfigMap. For production prefer `existingSecret`. The chart picks the
+      # env var name from the provider (OPENAI_API_KEY / ANTHROPIC_API_KEY).
+      apiKey: ""
+      # -- Use a pre-created Secret for the key instead of `apiKey` (wins over
+      # it). Loaded with envFrom, so its keys must be env var names — at minimum
+      # the provider key (OPENAI_API_KEY or ANTHROPIC_API_KEY).
+      existingSecret: ""
+      # -- Require a Bearer token on /copilotkit (gates LLM spend).
+      requireAuth: false
     resources:
       requests:
         cpu: 50m


### PR DESCRIPTION
## Summary

Make the embedded **ACKO Agent** (web copilot) configurable from **Helm values
alone** — set base URL + key + model and the chart wires everything. No
hand-built Secret or `extraEnv` plumbing required.

Pairs with the cluster-manager `COPILOT_BASE_URL` support
(aerospike-ce-ecosystem/aerospike-cluster-manager#443).

## New `ui.web.copilot` block

```yaml
ui:
  web:
    copilot:
      enabled: true
      model: openai/<model>          # or anthropic/<model>
      baseUrl: https://llm-gateway.example.com   # optional OpenAI/Anthropic-compatible gateway
      apiKey: <key>                  # inline → chart-managed Secret (dev/test)
      existingSecret: <name>         # OR bring your own (preferred for prod)
      requireAuth: false
```

The chart:
- puts non-secret `COPILOT_*` (ENABLED / MODEL / BASE_URL / REQUIRE_AUTH) in the UI ConfigMap,
- renders a **web-only** Secret for the key under the provider env var
  (`OPENAI_API_KEY` / `ANTHROPIC_API_KEY`, derived from the model prefix), or reads `existingSecret`,
- wires both into the web container via `envFrom` (key never reaches the api container).

Disabled by default — no copilot artifacts rendered. `ui.web.extraEnv` /
`extraEnvFrom` still work for advanced cases.

## Verification

- `helm lint` clean; `helm template` checked for the inline-key, existingSecret,
  anthropic-provider, and disabled paths.
- Live **kind** `helm upgrade` with `--set ui.web.copilot.*`: the web pod came up
  with `COPILOT_ENABLED/MODEL/BASE_URL` + the provider key wired by the chart, and
  `/copilot-config` reported `enabled: true` — agent enabled purely from values,
  no manual Secret/extraEnvFrom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
