### PR TITLE
fix(ci): pin kind install via helm/kind-action in E2E workflow

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -39,11 +39,16 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Install the latest version of kind
-        run: |
-          curl -Lo ./kind https://kind.sigs.k8s.io/dl/latest/kind-linux-$(go env GOARCH)
-          chmod +x ./kind
-          sudo mv ./kind /usr/local/bin/kind
+      - name: Install kind
+        # Pinned install via helm/kind-action. The previous unpinned
+        # `curl https://kind.sigs.k8s.io/dl/latest/...` failed intermittently
+        # with `curl: (6) Could not resolve host: kind.sigs.k8s.io` on GitHub
+        # runners (#257). The action downloads the binary from GitHub
+        # releases, which is always resolvable from GitHub-hosted runners.
+        uses: helm/kind-action@v1
+        with:
+          version: v0.32.0
+          install_only: true
 
       - name: Verify kind installation
         run: kind version


### PR DESCRIPTION
## Summary

Fixes #257 — the `E2E Tests` workflow's `Install the latest version of kind` step failed with:

```
curl: (6) Could not resolve host: kind.sigs.k8s.io
```

## Root cause

The workflow downloaded kind from `https://kind.sigs.k8s.io/dl/latest/kind-linux-<arch>`. DNS resolution of `kind.sigs.k8s.io` fails intermittently on GitHub-hosted runners — it killed the last push-triggered runs on `main` (2026-02-22/23) and the PR runs around 2026-05-05..05-10 (PRs #253/#254/#255), while other periods pass. On top of the flake, `dl/latest` floated the kind version, so runs were not reproducible.

## Change

Replace the manual `curl` with the maintained [`helm/kind-action@v1`](https://github.com/helm/kind-action) using `install_only: true` and an explicit pin to **kind v0.32.0** (current stable release, 2026-06-02 — the same version the last green run on 2026-06-11 resolved via `latest`, so it is proven compatible with this repo's e2e suite). The action downloads the binary from `github.com/kubernetes-sigs/kind/releases`, which is always resolvable from GitHub-hosted runners, removing the `kind.sigs.k8s.io` DNS dependency entirely. Pinning by major action tag matches the repo's existing convention (`actions/checkout@v6`, `azure/setup-helm@v5`, ...).

Sanity-checked the rest of the workflow for adjacent bitrot: `kubectl` comes preinstalled on `ubuntu-latest` (no download URL to rot), and `kind-config.yaml` pins no node image, so kind v0.32.0 uses its bundled default — the downstream pipeline was green as of 2026-06-11.

## CI validation

This workflow triggers on `pull_request` to `main` and `.github/workflows/**` is not in `paths-ignore`, so the **E2E Tests run on this PR exercises the fixed install step pre-merge** (pull_request runs use the workflow file from the PR merge ref). Note the DNS failure was intermittent, so a green run proves the new path works but the real win is removing the flaky host from the critical path. The workflow no longer runs on push to `main` (changed in #232), so there is no post-merge main run to watch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)