### PR TITLE
refactor: P2 code-quality follow-ups from 2026-05-10 health check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -267,8 +267,12 @@ build: manifests generate fmt vet ## Build manager binary.
 	go build -ldflags "$(LDFLAGS)" -o bin/manager cmd/main.go
 
 .PHONY: run
+# --leader-elect=false: the binary defaults to leader election ON (in-cluster
+# safety), but out-of-cluster runs have no namespace to host the election
+# Lease, so local dev must opt out. Do not run two local instances against the
+# same cluster — without leader election they will reconcile concurrently.
 run: manifests generate fmt vet ## Run a controller from your host.
-	go run -ldflags "$(LDFLAGS)" ./cmd/main.go
+	go run -ldflags "$(LDFLAGS)" ./cmd/main.go --leader-elect=false
 
 # If you wish to build the manager image targeting other platforms you can use the --platform flag.
 # (i.e. docker build --platform linux/arm64). However, you must enable docker buildKit for it.

--- a/README.md
+++ b/README.md
@@ -315,6 +315,15 @@ make lint           # Run golangci-lint
 make run            # Run controller locally against current kubeconfig
 ```
 
+> **Leader election**: the manager defaults to `--leader-elect=true` so an
+> in-cluster deployment that omits the flag can never end up with two active
+> managers reconciling the same `AerospikeCluster`. `make run` passes
+> `--leader-elect=false` because an out-of-cluster process has no in-cluster
+> namespace to host the election Lease. If you invoke `go run ./cmd/main.go`
+> directly, pass `--leader-elect=false` yourself — and never run two local
+> instances against the same cluster, since without leader election they
+> reconcile (and delete pods) concurrently.
+
 ### Local deployment with Kind
 
 When deploying to a Kind cluster after a local build:

--- a/api/v1alpha1/aerospikecluster_webhook.go
+++ b/api/v1alpha1/aerospikecluster_webhook.go
@@ -951,8 +951,11 @@ func (v *AerospikeClusterValidator) validateNamespaceConfig(nsMap map[string]any
 
 	// Validate replication-factor: single-node clusters should use 1.
 	// Accept every integer type a decoder can plausibly produce (int, int32,
-	// int64, float64, json.Number); an unhandled type would otherwise silently
-	// skip the range check.
+	// int64, float64, json.Number). Any other type — most commonly a string
+	// from YAML quoting, e.g. replication-factor: "2" — is rejected explicitly:
+	// an unhandled type would otherwise silently skip the range check here
+	// while validateReplicationFactor reports the type error, leaving the two
+	// paths inconsistent.
 	if rf, ok := nsMap["replication-factor"]; ok {
 		switch v := rf.(type) {
 		case int:
@@ -972,9 +975,13 @@ func (v *AerospikeClusterValidator) validateNamespaceConfig(nsMap map[string]any
 				errors = append(errors, fmt.Sprintf("namespace[%d] %q: replication-factor must be between 1 and 4 (got %v)", index, nsName, v))
 			}
 		case json.Number:
-			if n, err := v.Int64(); err == nil && (n < 1 || n > 4) {
+			if n, err := v.Int64(); err != nil {
+				errors = append(errors, fmt.Sprintf("namespace[%d] %q: replication-factor must be an integer, got %s", index, nsName, v.String()))
+			} else if n < 1 || n > 4 {
 				errors = append(errors, fmt.Sprintf("namespace[%d] %q: replication-factor must be between 1 and 4 (got %s)", index, nsName, v.String()))
 			}
+		default:
+			errors = append(errors, fmt.Sprintf("namespace[%d] %q: replication-factor must be an integer, got %T (%v)", index, nsName, rf, rf))
 		}
 	}
 

--- a/api/v1alpha1/webhook_test.go
+++ b/api/v1alpha1/webhook_test.go
@@ -2,6 +2,7 @@ package v1alpha1
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"math"
 	"slices"
@@ -3599,6 +3600,86 @@ func TestValidate_ReplicationFactorStringType(t *testing.T) {
 	}
 	if strings.Contains(err.Error(), "got 0") {
 		t.Errorf("error should not report the misleading 'got 0' for a string value, got: %v", err)
+	}
+}
+
+// TestValidateNamespaceConfig_ReplicationFactorStringType verifies the
+// per-namespace CE validation path (validateNamespaceConfig) rejects a
+// string-typed replication-factor explicitly instead of silently skipping the
+// range check, and that the message is consistent with the
+// validateReplicationFactor path ("must be an integer, got string").
+func TestValidateNamespaceConfig_ReplicationFactorStringType(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+	nsMap := map[string]any{
+		"name":               "test",
+		"replication-factor": "2",
+	}
+
+	errs, _ := v.validateNamespaceConfig(nsMap, 0)
+	if len(errs) == 0 {
+		t.Fatal("expected error when replication-factor is a string")
+	}
+	found := false
+	for _, e := range errs {
+		if strings.Contains(e, "replication-factor must be an integer, got string") {
+			found = true
+		}
+		if strings.Contains(e, "got 0") {
+			t.Errorf("error should not report the misleading 'got 0' for a string value, got: %v", e)
+		}
+	}
+	if !found {
+		t.Errorf("expected 'replication-factor must be an integer, got string' error, got: %v", errs)
+	}
+}
+
+// TestValidateNamespaceConfig_ReplicationFactorNonIntegerJSONNumber verifies
+// that a json.Number that cannot be parsed as an integer is rejected instead
+// of silently passing the range check.
+func TestValidateNamespaceConfig_ReplicationFactorNonIntegerJSONNumber(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+	nsMap := map[string]any{
+		"name":               "test",
+		"replication-factor": json.Number("2.5"),
+	}
+
+	errs, _ := v.validateNamespaceConfig(nsMap, 0)
+	if len(errs) == 0 {
+		t.Fatal("expected error when replication-factor is a non-integer json.Number")
+	}
+	if !strings.Contains(errs[0], "replication-factor must be an integer, got 2.5") {
+		t.Errorf("expected 'replication-factor must be an integer, got 2.5' error, got: %v", errs)
+	}
+}
+
+// TestValidateReplicationFactor_StringType exercises the cross-check path
+// (validateReplicationFactor) directly with a string-typed value to pin the
+// "must be an integer, got string" message emitted by its default case.
+func TestValidateReplicationFactor_StringType(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+	cluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:  3,
+			Image: "aerospike:ce-8.1.1.1",
+			AerospikeConfig: &AerospikeConfigSpec{
+				Value: map[string]any{
+					"namespaces": []any{
+						map[string]any{
+							"name":               "test",
+							"replication-factor": "2",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	errs := v.validateReplicationFactor(cluster)
+	if len(errs) == 0 {
+		t.Fatal("expected error when replication-factor is a string")
+	}
+	if !strings.Contains(errs[0], "replication-factor must be an integer, got string") {
+		t.Errorf("expected 'replication-factor must be an integer, got string' error, got: %v", errs)
 	}
 }
 

--- a/charts/aerospike-ce-kubernetes-operator/templates/NOTES.txt
+++ b/charts/aerospike-ce-kubernetes-operator/templates/NOTES.txt
@@ -124,7 +124,9 @@ in project-hub for `acko-realm.json`).
 {{- if not .Values.crds.install }}
 
 NOTE: CRD installation is disabled (crds.install=false).
-Ensure acko-crds is installed separately before creating AerospikeCluster resources:
+Ensure the aerospike-ce-kubernetes-operator-crds chart is installed separately
+(release name "acko-crds" below is just a suggestion) before creating
+AerospikeCluster resources:
   helm install acko-crds oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kubernetes-operator-crds --version {{ .Chart.Version }}
 {{- end }}
 

--- a/charts/aerospike-ce-kubernetes-operator/templates/ui/deployment-web.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/ui/deployment-web.yaml
@@ -89,6 +89,10 @@ spec:
           readinessProbe:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.ui.web.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           lifecycle:
             preStop:
               exec:

--- a/charts/aerospike-ce-kubernetes-operator/values.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/values.yaml
@@ -871,6 +871,15 @@ ui:
       limits:
         cpu: 150m
         memory: 384Mi
+    # -- Web probes hit `/` because the Next.js standalone server exposes no
+    # dedicated health route today. `/` is a weak liveness signal (Next.js can
+    # return 200 for pages whose SSR errored), but it is the best endpoint
+    # available: do NOT point these at `/api/health` — the web container's
+    # proxy (proxy.js) forwards `/api/*` to the API backend, so that probe
+    # would measure API availability and restart healthy web pods whenever the
+    # API is down. A dedicated web health route (e.g. `/healthz` served by
+    # proxy.js itself) belongs in aerospike-cluster-manager; switch these
+    # paths over once it exists.
     livenessProbe:
       httpGet:
         path: /
@@ -885,6 +894,17 @@ ui:
       initialDelaySeconds: 5
       periodSeconds: 10
       timeoutSeconds: 5
+    # -- Gates liveness/readiness until the Next.js standalone server inside
+    # the proxy has come up (mirrors the api pod's startupProbe pattern:
+    # 5s x 30 failures = 150s budget), so slow cold starts are not killed by
+    # the liveness probe.
+    startupProbe:
+      httpGet:
+        path: /
+        port: web
+      periodSeconds: 5
+      timeoutSeconds: 3
+      failureThreshold: 30
 
     # =============================================================================
     # OIDC (web SPA — Authorization Code + PKCE)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -85,9 +85,17 @@ func run() error {
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
-	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
+	// Leader election defaults to true so that a bare in-cluster deployment
+	// (one that omits the flag) can never end up with two active managers
+	// reconciling — and racing pod deletions on — the same AerospikeCluster.
+	// The Helm chart and config/manager/manager.yaml pass --leader-elect
+	// explicitly; local out-of-cluster runs must pass --leader-elect=false
+	// (make run does) because there is no in-cluster namespace to host the
+	// election Lease.
+	flag.BoolVar(&enableLeaderElection, "leader-elect", true,
 		"Enable leader election for controller manager. "+
-			"Enabling this will ensure there is only one active controller manager.")
+			"Enabling this will ensure there is only one active controller manager. "+
+			"Set --leader-elect=false for local out-of-cluster runs (e.g. make run).")
 	flag.BoolVar(&secureMetrics, "metrics-secure", true,
 		"If set, the metrics endpoint is served securely via HTTPS. Use --metrics-secure=false to use HTTP instead.")
 	flag.StringVar(&webhookCertPath, "webhook-cert-path", "", "The directory that contains the webhook certificate.")

--- a/docs/content/reference/helm-values.md
+++ b/docs/content/reference/helm-values.md
@@ -338,7 +338,7 @@ The api and web Deployments have independent resource settings.
 
 ### Probes
 
-The api Deployment has liveness / readiness / startup probes; the web Deployment has liveness / readiness probes.
+Both the api and web Deployments have liveness / readiness / startup probes.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
@@ -357,7 +357,7 @@ The api Deployment has liveness / readiness / startup probes; the web Deployment
 | `ui.api.startupProbe.periodSeconds` | int | `5` | Check period. |
 | `ui.api.startupProbe.timeoutSeconds` | int | `3` | Timeout. |
 | `ui.api.startupProbe.failureThreshold` | int | `30` | Max failures before giving up (allows 150s startup). |
-| `ui.web.livenessProbe.httpGet.path` | string | `/` | Web liveness probe path. |
+| `ui.web.livenessProbe.httpGet.path` | string | `/` | Web liveness probe path. The web app exposes no dedicated health route yet; do not point this at `/api/health` — the web proxy forwards `/api/*` to the API backend, so that would measure the wrong component. |
 | `ui.web.livenessProbe.httpGet.port` | string | `web` | Web liveness probe port. |
 | `ui.web.livenessProbe.initialDelaySeconds` | int | `15` | Initial delay. |
 | `ui.web.livenessProbe.periodSeconds` | int | `20` | Check period. |
@@ -367,6 +367,11 @@ The api Deployment has liveness / readiness / startup probes; the web Deployment
 | `ui.web.readinessProbe.initialDelaySeconds` | int | `5` | Initial delay. |
 | `ui.web.readinessProbe.periodSeconds` | int | `10` | Check period. |
 | `ui.web.readinessProbe.timeoutSeconds` | int | `5` | Timeout. |
+| `ui.web.startupProbe.httpGet.path` | string | `/` | Web startup probe path. |
+| `ui.web.startupProbe.httpGet.port` | string | `web` | Web startup probe port. |
+| `ui.web.startupProbe.periodSeconds` | int | `5` | Check period. |
+| `ui.web.startupProbe.timeoutSeconds` | int | `3` | Timeout. |
+| `ui.web.startupProbe.failureThreshold` | int | `30` | Max failures before giving up (allows 150s startup). |
 
 ### Environment
 

--- a/internal/controller/aero_client.go
+++ b/internal/controller/aero_client.go
@@ -83,7 +83,8 @@ func (r *AerospikeClusterReconciler) getAerospikeClient(
 }
 
 // getAerospikeClientWithRetry wraps getAerospikeClient with retry logic using
-// exponential backoff (2s, 4s, 8s). This is useful during initial deployment
+// exponential backoff (2s, 4s, 8s) — up to 4 attempts in total (the initial
+// attempt plus maxRetries retries). This is useful during initial deployment
 // when DNS may not yet be resolving for the headless service.
 //
 // Permanent validation errors (e.g. a missing admin Secret or a Secret without
@@ -125,7 +126,8 @@ func (r *AerospikeClusterReconciler) getAerospikeClientWithRetry(
 		}
 	}
 
-	return nil, fmt.Errorf("failed after %d retries: %w", maxRetries, lastErr)
+	// maxRetries+1: the loop runs the initial attempt plus maxRetries retries.
+	return nil, fmt.Errorf("failed after %d attempts: %w", maxRetries+1, lastErr)
 }
 
 // closeAerospikeClient safely closes an Aerospike client.

--- a/internal/controller/events.go
+++ b/internal/controller/events.go
@@ -5,6 +5,7 @@ package controller
 const (
 	// Rolling restart lifecycle
 	EventRollingRestartStarted   = "RollingRestartStarted"
+	EventRollingRestartDeferred  = "RollingRestartDeferred"
 	EventRollingRestartCompleted = "RollingRestartCompleted"
 	EventRestartFailed           = "RestartFailed"
 	EventPodWarmRestarted        = "PodWarmRestarted"

--- a/internal/controller/reconciler_events_test.go
+++ b/internal/controller/reconciler_events_test.go
@@ -13,6 +13,7 @@ func TestEventConstants(t *testing.T) {
 	}{
 		// Rolling restart lifecycle
 		{"RollingRestartStarted", EventRollingRestartStarted, "RollingRestartStarted"},
+		{"RollingRestartDeferred", EventRollingRestartDeferred, "RollingRestartDeferred"},
 		{"RollingRestartCompleted", EventRollingRestartCompleted, "RollingRestartCompleted"},
 		{"RestartFailed", EventRestartFailed, "RestartFailed"},
 		{"PodWarmRestarted", EventPodWarmRestarted, "PodWarmRestarted"},

--- a/internal/controller/reconciler_restart.go
+++ b/internal/controller/reconciler_restart.go
@@ -789,7 +789,7 @@ func (r *AerospikeClusterReconciler) isBatchBlocked(
 	}
 	if migrating {
 		log.Info("Data migration in progress, delaying next restart batch", "rack", rackID)
-		r.Recorder.Eventf(cluster, corev1.EventTypeWarning, EventRollingRestartStarted,
+		r.Recorder.Eventf(cluster, corev1.EventTypeWarning, EventRollingRestartDeferred,
 			"Rolling restart paused for rack %d: data migration in progress", rackID)
 		return true
 	}


### PR DESCRIPTION
Fixes #256

P2 code-quality follow-ups from the 2026-05-10 main-branch health check. One commit per concern; no behavioral change beyond the items listed.

## Checklist — issue item → resolution

| # | Item | Resolution |
|---|------|------------|
| 1 | `EventRollingRestartStarted` reused for deferred state (`reconciler_restart.go`) | Added `EventRollingRestartDeferred = "RollingRestartDeferred"` to `internal/controller/events.go` (mirrors `EventScaleDownDeferred`) and emit it in `isBatchBlocked` when a batch is deferred due to in-flight migration. Added the constant to the `TestEventConstants` stability test. |
| 2 | `markDirtyVolumes` uses full `Status().Update` | **Already resolved on main** — `markDirtyVolumes` was converted to `Status().Patch(ctx, latest, client.MergeFrom(base))` by #285/#289 (with an explanatory comment in place). No change needed; verified the file has no remaining `Status().Update` calls. |
| 3 | `--leader-elect` defaults to false (`cmd/main.go`) | **Defaulted to `true`.** Rationale: a bare in-cluster deployment that omits the flag must never end up with two active managers racing pod deletions on the same `AerospikeCluster` (silent data-plane hazard); with the new default the failure mode for a misconfigured install is a loud, debuggable lease-RBAC error instead. Because an out-of-cluster process has no namespace to host the election Lease, defaulting to true would break `make run` — so `make run` now passes `--leader-elect=false` explicitly (with a Makefile comment), and the README Development section documents the default, the local-dev opt-out, and the "never run two local instances" risk. Helm chart and `config/manager/manager.yaml` already pass `--leader-elect` explicitly and are unaffected. |
| 4 | `getAerospikeClientWithRetry` off-by-one message (`aero_client.go`) | Rephrased to `"failed after %d attempts: %w"` using `maxRetries+1` (= 4: initial attempt + 3 retries), per the issue's preferred option. Doc comment updated to state "up to 4 attempts in total". |
| 5 | `replication-factor` string-typed input inconsistency (webhook, both paths) | `validateReplicationFactor` already rejects strings via its `default:` case ("must be an integer, got string (…)", from #289). Added the matching explicit `default:` case to `validateNamespaceConfig` — previously a string silently skipped the 1–4 range check with no error — emitting the same `"replication-factor must be an integer, got string"` style message, and also surfaced non-integer `json.Number` parse failures instead of silently passing. New unit tests pin both paths: `TestValidateNamespaceConfig_ReplicationFactorStringType`, `TestValidateNamespaceConfig_ReplicationFactorNonIntegerJSONNumber`, `TestValidateReplicationFactor_StringType` (plus the pre-existing end-to-end `TestValidate_ReplicationFactorStringType`). |
| 6 | UI web `livenessProbe` hits `/` (helm `values.yaml`) | Checked the cluster-manager web app (Next.js standalone + `proxy.js`): **no dedicated health route exists**, and `/api/health` is NOT usable for the web pod — `proxy.js` forwards `/api/*` to the API backend, so that probe would measure API availability and restart healthy web pods whenever the API is down. Kept `/` for liveness/readiness with a comment documenting exactly this, and added a `startupProbe` on `/` matching the api pod pattern (5s × 30 failures = 150s budget), including the missing `startupProbe` render block in `templates/ui/deployment-web.yaml`. Updated `docs/content/reference/helm-values.md` accordingly. **Follow-up belongs in aerospike-cluster-manager:** a dedicated web health route (e.g. `/healthz` served by `proxy.js` itself); switch the probe paths over once it exists. |
| 7 | NOTES.txt CRD install command name mismatch | The OCI URL itself was already corrected by #296 (`oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kubernetes-operator-crds`). Fixed the remaining prose: NOTES.txt now names the actual chart `aerospike-ce-kubernetes-operator-crds` and clarifies that `acko-crds` in the command is merely a suggested release name. No OCI artifacts renamed. |

## Verification

- `gofmt -l ./api ./cmd ./internal` — clean
- `go vet ./...` — clean
- `go build ./...` — OK
- `go test ./api/... ./internal/... ./cmd/...` — all packages pass
- `make test` (manifests + generate + vet + envtest integration suite, `-tags=integration`) — pass, no generated-file drift
- `helm lint` on both charts — 0 failures
- `helm template --set crds.install=false` — web pod renders the new `startupProbe`; api pod unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
