### PR TITLE
refactor: correct Go module path to org namespace

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ COPY . .
 # Build for the target platform
 ARG VERSION=unknown
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build \
-    -ldflags "-X github.com/ksr/aerospike-ce-kubernetes-operator/internal/version.Version=${VERSION}" \
+    -ldflags "-X github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/version.Version=${VERSION}" \
     -a -o manager cmd/main.go
 
 # Use distroless as minimal base image to package the manager binary

--- a/Makefile
+++ b/Makefile
@@ -227,7 +227,7 @@ lint-config: golangci-lint ## Verify golangci-lint linter configuration
 ##@ Build
 
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "unknown")
-LDFLAGS = -X github.com/ksr/aerospike-ce-kubernetes-operator/internal/version.Version=$(VERSION)
+LDFLAGS = -X github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/version.Version=$(VERSION)
 
 # Cluster Manager image (single image; helm `ui.api` deployment)
 CLUSTER_MANAGER_API_IMG ?= ghcr.io/aerospike-ce-ecosystem/aerospike-cluster-manager-api

--- a/PROJECT
+++ b/PROJECT
@@ -7,7 +7,7 @@ domain: acko.io
 layout:
 - go.kubebuilder.io/v4
 projectName: aerospike-ce-kubernetes-operator
-repo: github.com/ksr/aerospike-ce-kubernetes-operator
+repo: github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator
 resources:
 - api:
     crdVersion: v1
@@ -16,7 +16,7 @@ resources:
   domain: acko.io
   group: acko
   kind: AerospikeCluster
-  path: github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1
+  path: github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1
   version: v1alpha1
 - api:
     crdVersion: v1
@@ -25,7 +25,7 @@ resources:
   domain: acko.io
   group: acko
   kind: AerospikeClusterTemplate
-  path: github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1
+  path: github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1
   version: v1alpha1
   webhooks:
     defaulting: true

--- a/api/v1alpha1/webhook_drift_test.go
+++ b/api/v1alpha1/webhook_drift_test.go
@@ -20,8 +20,8 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/utils"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/utils"
 )
 
 // TestServiceMonitorNameMatchesUtilsHelper pins the webhook-side

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -40,9 +40,9 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/controller"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/telemetry"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/controller"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/telemetry"
 	// +kubebuilder:scaffold:imports
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ksr/aerospike-ce-kubernetes-operator
+module github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator
 
 go 1.25.3
 

--- a/internal/configgen/network.go
+++ b/internal/configgen/network.go
@@ -4,7 +4,7 @@ import (
 	"strconv"
 	"strings"
 
-	v1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	v1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
 )
 
 // generateNetworkSection generates the network stanza with mesh seeds injected

--- a/internal/configgen/network_test.go
+++ b/internal/configgen/network_test.go
@@ -3,7 +3,7 @@ package configgen
 import (
 	"testing"
 
-	v1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	v1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
 )
 
 const (

--- a/internal/controller/aero_client.go
+++ b/internal/controller/aero_client.go
@@ -17,10 +17,10 @@ import (
 
 	aero "github.com/aerospike/aerospike-client-go/v8"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
-	ackoerrors "github.com/ksr/aerospike-ce-kubernetes-operator/internal/errors"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/podutil"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/utils"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	ackoerrors "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/errors"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/podutil"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/utils"
 )
 
 const (

--- a/internal/controller/aero_client_test.go
+++ b/internal/controller/aero_client_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
-	ackoerrors "github.com/ksr/aerospike-ce-kubernetes-operator/internal/errors"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	ackoerrors "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"

--- a/internal/controller/pause_handler.go
+++ b/internal/controller/pause_handler.go
@@ -10,8 +10,8 @@ import (
 	"k8s.io/client-go/util/retry"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/metrics"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/metrics"
 )
 
 const pausePhaseReason = "Reconciliation paused by user"

--- a/internal/controller/pause_handler_test.go
+++ b/internal/controller/pause_handler_test.go
@@ -11,7 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
 )
 
 func newTestReconciler(scheme *runtime.Scheme, objs ...client.Object) (*AerospikeClusterReconciler, *record.FakeRecorder) {

--- a/internal/controller/reconciler.go
+++ b/internal/controller/reconciler.go
@@ -35,18 +35,18 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
-	ackoerrors "github.com/ksr/aerospike-ce-kubernetes-operator/internal/errors"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/metrics"
-	aerotmpl "github.com/ksr/aerospike-ce-kubernetes-operator/internal/template"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/utils"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	ackoerrors "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/errors"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/metrics"
+	aerotmpl "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/template"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/utils"
 )
 
 // tracer is the OpenTelemetry tracer for the controller. It is bound to the
 // global (delegating) tracer provider, so its spans become real once
 // telemetry.Setup installs the SDK provider and stay NoOp — at near-zero
 // cost — when telemetry is disabled.
-var tracer = otel.Tracer("github.com/ksr/aerospike-ce-kubernetes-operator/internal/controller")
+var tracer = otel.Tracer("github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/controller")
 
 // endSpan records err on span when it is non-nil, then ends the span. It is
 // designed for `defer endSpan(span, &retErr)` with a named error return so the

--- a/internal/controller/reconciler_acl.go
+++ b/internal/controller/reconciler_acl.go
@@ -9,10 +9,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
-	ackoerrors "github.com/ksr/aerospike-ce-kubernetes-operator/internal/errors"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/metrics"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/utils"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	ackoerrors "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/errors"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/metrics"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/utils"
 )
 
 // builtinRoles are Aerospike predefined roles that must not be dropped.

--- a/internal/controller/reconciler_acl_phase_test.go
+++ b/internal/controller/reconciler_acl_phase_test.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
 )
 
 // TestTerminalPhaseForACL verifies the phase/reason decision made at the end of

--- a/internal/controller/reconciler_acl_test.go
+++ b/internal/controller/reconciler_acl_test.go
@@ -7,7 +7,7 @@ import (
 
 	aero "github.com/aerospike/aerospike-client-go/v8"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
 )
 
 const (

--- a/internal/controller/reconciler_circuit_breaker_test.go
+++ b/internal/controller/reconciler_circuit_breaker_test.go
@@ -13,9 +13,9 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/metrics"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/utils"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/metrics"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/utils"
 )
 
 func TestCalculateBackoff(t *testing.T) {

--- a/internal/controller/reconciler_cleanup.go
+++ b/internal/controller/reconciler_cleanup.go
@@ -12,9 +12,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/storage"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/utils"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/storage"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/utils"
 )
 
 func (r *AerospikeClusterReconciler) handleDeletion(

--- a/internal/controller/reconciler_config.go
+++ b/internal/controller/reconciler_config.go
@@ -11,12 +11,12 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/configgen"
-	ackoerrors "github.com/ksr/aerospike-ce-kubernetes-operator/internal/errors"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/initcontainer"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/podutil"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/utils"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/configgen"
+	ackoerrors "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/errors"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/initcontainer"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/podutil"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/utils"
 )
 
 func (r *AerospikeClusterReconciler) reconcileConfigMap(

--- a/internal/controller/reconciler_config_test.go
+++ b/internal/controller/reconciler_config_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/utils"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/utils"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/internal/controller/reconciler_dynamic_config.go
+++ b/internal/controller/reconciler_dynamic_config.go
@@ -15,9 +15,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/configdiff"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/metrics"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/configdiff"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/metrics"
 )
 
 const (

--- a/internal/controller/reconciler_dynamic_config_test.go
+++ b/internal/controller/reconciler_dynamic_config_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/configdiff"
 	"github.com/go-logr/logr"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/configdiff"
 )
 
 // --- buildSetConfigCommand tests ---

--- a/internal/controller/reconciler_helpers.go
+++ b/internal/controller/reconciler_helpers.go
@@ -10,8 +10,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/utils"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/utils"
 )
 
 // listClusterPods returns all pods matching the cluster's selector labels.

--- a/internal/controller/reconciler_monitoring.go
+++ b/internal/controller/reconciler_monitoring.go
@@ -17,8 +17,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/utils"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/utils"
 )
 
 var serviceMonitorGVK = schema.GroupVersionKind{

--- a/internal/controller/reconciler_monitoring_test.go
+++ b/internal/controller/reconciler_monitoring_test.go
@@ -15,8 +15,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/utils"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/utils"
 )
 
 var _ = Describe("reconcileMonitoring", func() {

--- a/internal/controller/reconciler_monitoring_unit_test.go
+++ b/internal/controller/reconciler_monitoring_unit_test.go
@@ -15,7 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
 )
 
 // errMonitoringGetFailure is a sentinel non-NotFound error used to simulate an

--- a/internal/controller/reconciler_networkpolicy.go
+++ b/internal/controller/reconciler_networkpolicy.go
@@ -17,9 +17,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/podutil"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/utils"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/podutil"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/utils"
 )
 
 var ciliumNetworkPolicyGVK = schema.GroupVersionKind{

--- a/internal/controller/reconciler_networkpolicy_test.go
+++ b/internal/controller/reconciler_networkpolicy_test.go
@@ -3,8 +3,8 @@ package controller
 import (
 	"testing"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/podutil"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/podutil"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/internal/controller/reconciler_operations.go
+++ b/internal/controller/reconciler_operations.go
@@ -10,7 +10,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
 )
 
 // reconcileOperations handles on-demand operations (WarmRestart, PodRestart).

--- a/internal/controller/reconciler_operations_test.go
+++ b/internal/controller/reconciler_operations_test.go
@@ -11,9 +11,9 @@ import (
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/podutil"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/utils"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/podutil"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/utils"
 )
 
 // TestReconcileOperations_ExplicitPodListNoMatch_GoesToError is the regression

--- a/internal/controller/reconciler_pdb.go
+++ b/internal/controller/reconciler_pdb.go
@@ -14,8 +14,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/utils"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/utils"
 )
 
 func (r *AerospikeClusterReconciler) reconcilePDB(

--- a/internal/controller/reconciler_pdb_test.go
+++ b/internal/controller/reconciler_pdb_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/utils"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/utils"
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/internal/controller/reconciler_pod_rbac.go
+++ b/internal/controller/reconciler_pod_rbac.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
 )
 
 const (

--- a/internal/controller/reconciler_pod_service.go
+++ b/internal/controller/reconciler_pod_service.go
@@ -13,9 +13,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/podutil"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/utils"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/podutil"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/utils"
 )
 
 const podServiceLabel = "acko.io/pod-service"

--- a/internal/controller/reconciler_pod_service_test.go
+++ b/internal/controller/reconciler_pod_service_test.go
@@ -13,9 +13,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/podutil"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/utils"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/podutil"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/utils"
 )
 
 var _ = Describe("reconcilePodServices", func() {

--- a/internal/controller/reconciler_readiness_gate.go
+++ b/internal/controller/reconciler_readiness_gate.go
@@ -26,8 +26,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/podutil"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/podutil"
 )
 
 // syncAllPodsReadinessGates syncs the "acko.io/aerospike-ready" pod condition

--- a/internal/controller/reconciler_readiness_gate_test.go
+++ b/internal/controller/reconciler_readiness_gate_test.go
@@ -7,8 +7,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/podutil"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/podutil"
 )
 
 // ---------- findPodReadinessCondition ----------

--- a/internal/controller/reconciler_restart.go
+++ b/internal/controller/reconciler_restart.go
@@ -18,11 +18,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/metrics"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/podutil"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/storage"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/utils"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/metrics"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/podutil"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/storage"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/utils"
 )
 
 // maxPodUnstableDuration is the threshold after which a pod stuck in a non-ready

--- a/internal/controller/reconciler_restart_dirty_volumes_test.go
+++ b/internal/controller/reconciler_restart_dirty_volumes_test.go
@@ -10,7 +10,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
 )
 
 // Shared fixtures for the code-quality follow-up regression tests. The values

--- a/internal/controller/reconciler_restart_rolling_test.go
+++ b/internal/controller/reconciler_restart_rolling_test.go
@@ -15,9 +15,9 @@ import (
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/podutil"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/utils"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/podutil"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/utils"
 )
 
 // rollingRestartScheme builds a scheme with both the acko CRD types and the

--- a/internal/controller/reconciler_restart_test.go
+++ b/internal/controller/reconciler_restart_test.go
@@ -13,9 +13,9 @@ import (
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/podutil"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/utils"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/podutil"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/utils"
 )
 
 func TestGetDirtyVolumes_NilStorage(t *testing.T) {

--- a/internal/controller/reconciler_scaledown.go
+++ b/internal/controller/reconciler_scaledown.go
@@ -5,7 +5,7 @@ import (
 
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
 )
 
 // isMigrationInProgress connects to the Aerospike cluster and checks whether

--- a/internal/controller/reconciler_scaledown_test.go
+++ b/internal/controller/reconciler_scaledown_test.go
@@ -5,7 +5,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
 )
 
 // getScaleDownBatchSize is a method on AerospikeClusterReconciler but does not

--- a/internal/controller/reconciler_seeds_finder.go
+++ b/internal/controller/reconciler_seeds_finder.go
@@ -12,8 +12,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/utils"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/utils"
 )
 
 // seedsFinderServiceName returns the name of the seeds finder LoadBalancer service.

--- a/internal/controller/reconciler_services.go
+++ b/internal/controller/reconciler_services.go
@@ -13,9 +13,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/podutil"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/utils"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/podutil"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/utils"
 )
 
 // reconcileHeadlessService creates or updates the headless service for the cluster.

--- a/internal/controller/reconciler_services_test.go
+++ b/internal/controller/reconciler_services_test.go
@@ -4,7 +4,7 @@ import (
 	"maps"
 	"testing"
 
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/utils"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/utils"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"

--- a/internal/controller/reconciler_statefulset.go
+++ b/internal/controller/reconciler_statefulset.go
@@ -16,11 +16,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/metrics"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/podutil"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/storage"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/utils"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/metrics"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/podutil"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/storage"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/utils"
 )
 
 // reconcileStatefulSet creates or updates the StatefulSet for a rack.

--- a/internal/controller/reconciler_statefulset_test.go
+++ b/internal/controller/reconciler_statefulset_test.go
@@ -4,7 +4,7 @@ import (
 	"maps"
 	"testing"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
 )
 
 // --- computePodSpecHash tests ---

--- a/internal/controller/reconciler_status.go
+++ b/internal/controller/reconciler_status.go
@@ -19,11 +19,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/metrics"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/podutil"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/utils"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/version"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/metrics"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/podutil"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/utils"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/version"
 )
 
 // StatusUpdateOpts carries optional annotations for updateStatusAndPhase.

--- a/internal/controller/reconciler_status_conflict_test.go
+++ b/internal/controller/reconciler_status_conflict_test.go
@@ -13,8 +13,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/utils"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/utils"
 )
 
 // statusConflictPod builds a cluster pod with the given readiness state.

--- a/internal/controller/reconciler_status_test.go
+++ b/internal/controller/reconciler_status_test.go
@@ -9,8 +9,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/podutil"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/podutil"
 )
 
 func TestIsPodReady(t *testing.T) {

--- a/internal/controller/reconciler_test.go
+++ b/internal/controller/reconciler_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/internal/controller/reconciler_warm_restart.go
+++ b/internal/controller/reconciler_warm_restart.go
@@ -12,9 +12,9 @@ import (
 	"k8s.io/client-go/tools/remotecommand"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/podutil"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/utils"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/podutil"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/utils"
 )
 
 // shouldWarmRestart decides whether a pod can be warm-restarted.

--- a/internal/controller/reconciler_warm_restart_test.go
+++ b/internal/controller/reconciler_warm_restart_test.go
@@ -8,9 +8,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/podutil"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/utils"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/podutil"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/utils"
 )
 
 const testImage = "aerospike:ce-8.1.1.1"

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -35,7 +35,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
 	// +kubebuilder:scaffold:imports
 )
 

--- a/internal/podutil/container.go
+++ b/internal/podutil/container.go
@@ -7,8 +7,8 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
-	v1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/storage"
+	v1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/storage"
 )
 
 const (

--- a/internal/podutil/container_test.go
+++ b/internal/podutil/container_test.go
@@ -8,7 +8,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
-	v1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	v1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
 )
 
 const (

--- a/internal/podutil/pod.go
+++ b/internal/podutil/pod.go
@@ -10,9 +10,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	v1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/storage"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/utils"
+	v1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/storage"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/utils"
 )
 
 const (

--- a/internal/podutil/pod_test.go
+++ b/internal/podutil/pod_test.go
@@ -8,8 +8,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	v1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/utils"
+	v1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/utils"
 )
 
 const (

--- a/internal/storage/local.go
+++ b/internal/storage/local.go
@@ -10,7 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	v1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	v1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
 )
 
 // IsLocalStorageClass returns true if the given storage class name is in the list of local storage classes.

--- a/internal/storage/policy.go
+++ b/internal/storage/policy.go
@@ -3,7 +3,7 @@ package storage
 import (
 	corev1 "k8s.io/api/core/v1"
 
-	v1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	v1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
 )
 
 // ResolveInitMethod returns the effective init method for a volume.

--- a/internal/storage/policy_test.go
+++ b/internal/storage/policy_test.go
@@ -5,7 +5,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
-	v1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	v1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
 )
 
 func boolPtr(b bool) *bool { return &b }

--- a/internal/storage/pvc.go
+++ b/internal/storage/pvc.go
@@ -11,7 +11,7 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	v1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	v1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
 )
 
 // GetPVCsForStatefulSet lists PVCs belonging to the given StatefulSet of the

--- a/internal/storage/pvc_cascade_test.go
+++ b/internal/storage/pvc_cascade_test.go
@@ -11,7 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	v1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	v1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
 )
 
 const (

--- a/internal/storage/volume.go
+++ b/internal/storage/volume.go
@@ -7,7 +7,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	v1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	v1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
 )
 
 // BuildVolumes converts the AerospikeStorageSpec into Kubernetes Volumes and

--- a/internal/storage/volume_test.go
+++ b/internal/storage/volume_test.go
@@ -6,7 +6,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	v1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	v1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
 )
 
 func TestBuildVolumes_NilSpec(t *testing.T) {

--- a/internal/template/apply_cluster.go
+++ b/internal/template/apply_cluster.go
@@ -17,7 +17,7 @@ limitations under the License.
 package template
 
 import (
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
 )
 
 // applyImage applies the template image default to the cluster.

--- a/internal/template/apply_cluster_test.go
+++ b/internal/template/apply_cluster_test.go
@@ -21,7 +21,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
 )
 
 const (

--- a/internal/template/config.go
+++ b/internal/template/config.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"maps"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
 )
 
 // applyAerospikeConfig merges template aerospikeConfig defaults into the cluster's aerospikeConfig.

--- a/internal/template/merge.go
+++ b/internal/template/merge.go
@@ -19,7 +19,7 @@ package template
 import (
 	corev1 "k8s.io/api/core/v1"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
 )
 
 // MergeTemplateSpec merges base and override AerospikeClusterTemplateSpec.

--- a/internal/template/resolver.go
+++ b/internal/template/resolver.go
@@ -27,8 +27,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
-	ackoerrors "github.com/ksr/aerospike-ce-kubernetes-operator/internal/errors"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	ackoerrors "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/errors"
 )
 
 const (

--- a/internal/template/resolver_test.go
+++ b/internal/template/resolver_test.go
@@ -23,7 +23,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
 )
 
 func TestMergeTemplateSpec_NilInputs(t *testing.T) {

--- a/internal/template/scheduling.go
+++ b/internal/template/scheduling.go
@@ -22,8 +22,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/internal/utils"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/utils"
 )
 
 // TranslatePodAntiAffinity converts a PodAntiAffinityLevel to a Kubernetes PodAntiAffinity struct.

--- a/internal/template/scheduling_test.go
+++ b/internal/template/scheduling_test.go
@@ -21,7 +21,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
 )
 
 func TestTranslatePodAntiAffinity(t *testing.T) {

--- a/internal/template/storage.go
+++ b/internal/template/storage.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
 )
 
 const (

--- a/internal/template/validation.go
+++ b/internal/template/validation.go
@@ -23,7 +23,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
 )
 
 // ValidateResolvedSpec performs cross-field validation on the resolved spec.

--- a/internal/template/validation_test.go
+++ b/internal/template/validation_test.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 	"testing"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
 )
 
 // --- V-T06: Image CE-tag warning ---

--- a/internal/utils/acl.go
+++ b/internal/utils/acl.go
@@ -1,7 +1,7 @@
 package utils
 
 import (
-	v1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	v1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
 )
 
 // FindAdminUser returns the first user that has both "sys-admin" and "user-admin"

--- a/internal/utils/acl_test.go
+++ b/internal/utils/acl_test.go
@@ -3,7 +3,7 @@ package utils
 import (
 	"testing"
 
-	v1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	v1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
 )
 
 func TestFindAdminUser(t *testing.T) {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is injected at build time via ldflags:
 //
-//	go build -ldflags "-X github.com/ksr/aerospike-ce-kubernetes-operator/internal/version.Version=$(VERSION)"
+//	go build -ldflags "-X github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/version.Version=$(VERSION)"
 var Version = "unknown"

--- a/test/client-test/go.mod
+++ b/test/client-test/go.mod
@@ -1,4 +1,4 @@
-module github.com/ksr/aerospike-ce-kubernetes-operator/test/client-test
+module github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/test/client-test
 
 go 1.25
 

--- a/test/e2e/e2e_cluster_test.go
+++ b/test/e2e/e2e_cluster_test.go
@@ -27,8 +27,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/test/utils"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/test/utils"
 )
 
 // aerospikeNS, defaultTimeout, multiNodeTimeout are defined in helpers_test.go

--- a/test/e2e/e2e_features_test.go
+++ b/test/e2e/e2e_features_test.go
@@ -26,8 +26,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/test/utils"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/test/utils"
 )
 
 const featuresNS = "aerospike-features"

--- a/test/e2e/e2e_multirack_test.go
+++ b/test/e2e/e2e_multirack_test.go
@@ -26,8 +26,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/test/utils"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/test/utils"
 )
 
 const multirackNS = "aerospike-multirack"

--- a/test/e2e/e2e_pvc_test.go
+++ b/test/e2e/e2e_pvc_test.go
@@ -25,8 +25,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/test/utils"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/test/utils"
 )
 
 const pvcNS = "aerospike-pvc"

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -38,8 +38,8 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/test/utils"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/test/utils"
 )
 
 var (

--- a/test/e2e/e2e_template_test.go
+++ b/test/e2e/e2e_template_test.go
@@ -27,8 +27,8 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
-	"github.com/ksr/aerospike-ce-kubernetes-operator/test/utils"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/test/utils"
 )
 
 const templateTestNS = "aerospike-template"

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -26,13 +26,13 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	corev1 "k8s.io/api/core/v1"
 	authv1 "k8s.io/api/authentication/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/ksr/aerospike-ce-kubernetes-operator/test/utils"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/test/utils"
 )
 
 // namespace where the project is deployed in

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -25,7 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
 )
 
 // Shared constants used across all e2e test files.

--- a/test/utils/k8s_client_helpers.go
+++ b/test/utils/k8s_client_helpers.go
@@ -29,8 +29,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	ackov1alpha1 "github.com/ksr/aerospike-ce-kubernetes-operator/api/v1alpha1"
-	internalutils "github.com/ksr/aerospike-ce-kubernetes-operator/internal/utils"
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	internalutils "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/utils"
 )
 
 // --- Namespace helpers ---


### PR DESCRIPTION
## Summary

The Go module was declared under a personal namespace, `github.com/ksr/aerospike-ce-kubernetes-operator`, which is inconsistent with the org that owns the repo. This renames the module path to the org namespace:

`github.com/ksr/aerospike-ce-kubernetes-operator` → `github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator`

## Changes

- **`go.mod`** — module directive (via `go mod edit -module`)
- **`test/client-test/go.mod`** — nested module directive (`.../test/client-test`)
- **85 `.go` files** — all import paths of the module rewritten; also the OTel tracer name string in `internal/controller/reconciler.go`
- **`PROJECT`** — kubebuilder `repo:` and API `path:` entries
- **`Makefile` & `Dockerfile`** — `-ldflags -X .../internal/version.Version` linker path
- **`internal/version/version.go`** — doc-comment build example
- Two test files pick up gofmt import re-ordering (the new path sorts before neighbouring imports); `test/e2e/e2e_test.go` also carried a pre-existing gofmt ordering issue, now normalized so the lint job stays green.

## Verification

- `go mod tidy` — no `go.sum` / dependency drift (only the module line changed)
- `gofmt -l .` — clean
- `go vet ./...` — pass
- `go build ./...` (and the nested `test/client-test` module) — pass
- `go test ./api/... ./internal/... ./cmd/...` — all pass
- `make manifests generate` — no codegen drift (no CRD / RBAC / `zz_generated` changes)
- Grep confirms **zero** remaining `github.com/ksr/` references (the only `ksr` substrings left are inside unrelated base64 hashes in `go.sum` and `docs/package-lock.json`)

## Version-labeling note (for maintainer)

This changes the **Go module import path** — a public contract for any Go code that imports this module. In practice ACKO is consumed as a deployable operator (helm chart / OCI image), and there are **no known downstream Go importers**, so the practical impact is internal. It is intentionally committed as `refactor:` (no `!`, no `BREAKING CHANGE` footer) to **avoid triggering a MAJOR auto-release**. Please make the final version-label / release-note call: if you consider the import-path change a breaking public-API change, apply the appropriate label/notes rather than relying on Conventional-Commit auto-bumping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)