### PR TITLE
fix(docs): make navbar wordmark theme-aware via srcDark logo variant

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -56,6 +56,7 @@ const config = {
         logo: {
           alt: 'ACKO — Aerospike CE Kubernetes Operator',
           src: 'img/logo.svg',
+          srcDark: 'img/logo-dark.svg',
         },
         items: [
           {

--- a/docs/static/img/logo-dark.svg
+++ b/docs/static/img/logo-dark.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 256" role="img" aria-labelledby="title">
   <title id="title">ACKO</title>
-  <style>.wordmark{fill:#0B1F33}</style>
+  <style>.wordmark{fill:#FFFFFF}</style>
   <g transform="translate(16 16) scale(.875)">
     <rect x="6" y="6" width="244" height="244" rx="52" fill="#FFC72C"/>
     <path d="M54 190L100 66l46 124M75 135h49" fill="none" stroke="#0B1F33" stroke-width="19" stroke-linecap="square" stroke-linejoin="miter"/>


### PR DESCRIPTION
## Problem
The docs navbar logo colors the **"ACKO" wordmark** via an SVG-embedded `@media(prefers-color-scheme:dark)` rule inside `docs/static/img/logo.svg`. Docusaurus renders the navbar logo as an `<img src>`, so that media query keys off the **OS** color scheme, not the site's **manual** light/dark toggle (`data-theme` on `<html>`, which cannot reach into an img-embedded SVG).

**Failure scenario:** a visitor on OS *light* mode who toggles the site to *dark* gets a navy navbar with a still-navy wordmark (navy-on-navy, invisible); the symmetric OS-dark + site-light case is white-on-white. The yellow mark/glyph stays visible in all cases — only the "ACKO" text disappears. (Found during an ecosystem-wide branding review of #332.)

## Fix
Use the canonical Docusaurus theme-aware logo pattern instead of an SVG-internal media query:
- `logo.svg` — wordmark always navy `#0B1F33` (media query dropped); correct for the light theme.
- **new** `logo-dark.svg` — wordmark white `#FFFFFF`; for the dark theme.
- `docusaurus.config.js` navbar logo gains `srcDark: 'img/logo-dark.svg'`, so Docusaurus swaps on `data-theme` and the wordmark stays legible under both the OS default and any manual toggle.

Mark/glyph, yellow tile, and viewBox are unchanged; both SVGs validated as well-formed XML. `fix:` → PATCH.
