### PR TITLE
fix(chart): grant prometheusrules; degrade optional-resource 403s instead of failing

### DIFF
--- a/api/v1alpha1/aerospikecluster_webhook.go
+++ b/api/v1alpha1/aerospikecluster_webhook.go
@@ -451,6 +451,20 @@ func (v *AerospikeClusterValidator) validateServiceMonitorUniqueness(
 		// CRD not installed — the reconciler will skip ServiceMonitor reconciliation
 		// with a clearer log message, so don't fail admission here.
 		return nil
+	case apierrors.IsForbidden(err):
+		// Access denied on the uniqueness probe. Failing admission here is worse
+		// than the reconcile-time degradation for the same 403: it rejects every
+		// create and update of the AerospikeCluster, so the user cannot even
+		// write the CR, let alone fix it. That is reachable in exactly the
+		// scenario the chart supports with `--set rbac.create=false` — an
+		// RBAC-only install where the cluster admin trimmed
+		// monitoring.coreos.com out of the operator's role.
+		//
+		// The probe is an optimisation, not a correctness requirement: it turns
+		// a name collision into an admission error instead of a confusing
+		// reconcile failure. Without permission to run it we lose that nicety
+		// and nothing else — the reconciler still degrades the feature safely.
+		return nil
 	default:
 		return fmt.Errorf("getting ServiceMonitor %q in namespace %q: %w", smName, cluster.Namespace, err)
 	}

--- a/api/v1alpha1/webhook_test.go
+++ b/api/v1alpha1/webhook_test.go
@@ -11,13 +11,16 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
 func boolPtr(b bool) *bool { return &b }
@@ -7095,5 +7098,102 @@ func TestValidate_CEImageVersionEnforcement(t *testing.T) {
 				t.Errorf("validate() with image %q: unexpected error: %v", tc.image, err)
 			}
 		})
+	}
+}
+
+// newServiceMonitorGetErrClient builds a ServiceMonitor-aware fake client whose
+// Get always fails with getErr, so the validator's uniqueness probe can be
+// driven through a specific API error.
+func newServiceMonitorGetErrClient(t *testing.T, getErr error) client.Client {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	if err := AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+
+	smListGVK := serviceMonitorGVK
+	smListGVK.Kind = "ServiceMonitorList"
+	scheme.AddKnownTypeWithName(serviceMonitorGVK, &unstructured.Unstructured{})
+	scheme.AddKnownTypeWithName(smListGVK, &unstructured.UnstructuredList{})
+
+	base := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	return interceptor.NewClient(base, interceptor.Funcs{
+		Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey,
+			obj client.Object, opts ...client.GetOption) error {
+			return getErr
+		},
+	})
+}
+
+// TestValidateServiceMonitorUniqueness_ForbiddenDoesNotRejectCR pins that a 403
+// on the ServiceMonitor uniqueness probe does not fail admission.
+//
+// The probe is an optimisation: it turns a name collision into a clear
+// admission error instead of a confusing reconcile failure. Rejecting the CR
+// when the operator merely lacks permission to run it is strictly worse than
+// the reconcile-time degradation for the same 403 — the user cannot create or
+// update the AerospikeCluster at all, so they cannot even edit their way out of
+// it. That is reachable in the scenario the chart supports with
+// `--set rbac.create=false`, where the cluster admin trims
+// monitoring.coreos.com out of the operator's role.
+func TestValidateServiceMonitorUniqueness_ForbiddenDoesNotRejectCR(t *testing.T) {
+	cluster := makeMonitoringEnabledCluster("uid-new")
+
+	forbidden := apierrors.NewForbidden(
+		schema.GroupResource{Group: "monitoring.coreos.com", Resource: "servicemonitors"},
+		serviceMonitorName(cluster),
+		fmt.Errorf(`clusterrole "acko-manager" does not grant get on servicemonitors`),
+	)
+
+	v := &AerospikeClusterValidator{Client: newServiceMonitorGetErrClient(t, forbidden)}
+
+	if err := v.validateServiceMonitorUniqueness(context.Background(), cluster); err != nil {
+		t.Fatalf("validateServiceMonitorUniqueness() = %v, want nil: a 403 on the "+
+			"uniqueness probe must not reject the CR at admission", err)
+	}
+}
+
+// TestValidate_ForbiddenServiceMonitorProbeStillAdmits drives the whole
+// validator, not just the probe, so the 403 has to survive every layer between
+// validate() and the admission response.
+func TestValidate_ForbiddenServiceMonitorProbeStillAdmits(t *testing.T) {
+	cluster := makeMonitoringEnabledCluster("uid-new")
+	cluster.Spec.Monitoring.ExporterImage = "aerospike-prometheus-exporter:v1"
+	cluster.Spec.Monitoring.Port = 9145
+	cluster.Spec.Monitoring.ServiceMonitor.Interval = "30s"
+
+	forbidden := apierrors.NewForbidden(
+		schema.GroupResource{Group: "monitoring.coreos.com", Resource: "servicemonitors"},
+		serviceMonitorName(cluster), fmt.Errorf("access denied"))
+
+	v := &AerospikeClusterValidator{Client: newServiceMonitorGetErrClient(t, forbidden)}
+
+	if _, err := v.ValidateCreate(context.Background(), cluster); err != nil {
+		t.Errorf("ValidateCreate() = %v, want nil", err)
+	}
+	if _, err := v.ValidateUpdate(context.Background(), cluster.DeepCopy(), cluster); err != nil {
+		t.Errorf("ValidateUpdate() = %v, want nil", err)
+	}
+}
+
+// TestValidateServiceMonitorUniqueness_OtherErrorsStillReject guards the other
+// side: only "we are not allowed to look" and "the CRD is absent" may pass. A
+// transient API failure must still fail admission rather than admit a CR whose
+// ServiceMonitor name may collide.
+func TestValidateServiceMonitorUniqueness_OtherErrorsStillReject(t *testing.T) {
+	cluster := makeMonitoringEnabledCluster("uid-new")
+
+	internalErr := apierrors.NewInternalError(fmt.Errorf("etcd unavailable"))
+
+	v := &AerospikeClusterValidator{Client: newServiceMonitorGetErrClient(t, internalErr)}
+
+	err := v.validateServiceMonitorUniqueness(context.Background(), cluster)
+	if err == nil {
+		t.Fatal("validateServiceMonitorUniqueness() = nil, want error for a non-403 API failure")
+	}
+	if !strings.Contains(err.Error(), "getting ServiceMonitor") {
+		t.Errorf("expected the wrapped Get error, got: %v", err)
 	}
 }

--- a/charts/aerospike-ce-kubernetes-operator/templates/clusterrole-manager.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/clusterrole-manager.yaml
@@ -118,6 +118,7 @@ rules:
   - apiGroups:
       - monitoring.coreos.com
     resources:
+      - prometheusrules
       - servicemonitors
     verbs:
       - create

--- a/internal/controller/reconciler_monitoring.go
+++ b/internal/controller/reconciler_monitoring.go
@@ -7,6 +7,7 @@ import (
 	"maps"
 	"reflect"
 
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -71,8 +72,8 @@ func (r *AerospikeClusterReconciler) reconcileMonitoring(
 		case meta.IsNoMatchError(err):
 			log.Info("ServiceMonitor CRD not installed, skipping")
 		case errors.IsForbidden(err):
-			log.Info("ServiceMonitor access denied by RBAC, skipping",
-				"name", utils.ServiceMonitorName(cluster.Name), "error", err.Error())
+			logForbiddenMonitoringResource(
+				log, smEnabled, "ServiceMonitor", utils.ServiceMonitorName(cluster.Name), err)
 		default:
 			return fmt.Errorf("reconciling ServiceMonitor: %w", err)
 		}
@@ -88,14 +89,40 @@ func (r *AerospikeClusterReconciler) reconcileMonitoring(
 		case meta.IsNoMatchError(err):
 			log.Info("PrometheusRule CRD not installed, skipping")
 		case errors.IsForbidden(err):
-			log.Info("PrometheusRule access denied by RBAC, skipping",
-				"name", utils.PrometheusRuleName(cluster.Name), "error", err.Error())
+			logForbiddenMonitoringResource(
+				log, prEnabled, "PrometheusRule", utils.PrometheusRuleName(cluster.Name), err)
 		default:
 			return fmt.Errorf("reconciling PrometheusRule: %w", err)
 		}
 	}
 
 	return nil
+}
+
+// logForbiddenMonitoringResource reports a 403 on an optional monitoring
+// resource at a level that matches what the user loses.
+//
+// A 403 is not only an RBAC gap. The API server returns Forbidden for a
+// ValidatingWebhook or policy-engine (Kyverno / Gatekeeper) denial and for
+// ResourceQuota exhaustion too, so any of those degrades the feature by this
+// same path. Degrading is still the right call — freezing the whole control
+// loop over an optional integration is worse — but when the resource is
+// *enabled* the operator is silently not delivering something the user asked
+// for, and that must not be buried in an Info line. There is no
+// MonitoringReady status condition to read instead, so the log is currently the
+// only signal; publishing a degraded condition is the proper follow-up.
+//
+// When the resource is disabled the 403 only blocks the stale-object cleanup
+// Get. That is worth reporting, but not at Error on every reconcile for a
+// feature nobody asked for.
+func logForbiddenMonitoringResource(log logr.Logger, enabled bool, kind, name string, err error) {
+	if enabled {
+		log.Error(err, "Access denied for an enabled monitoring resource; feature degraded",
+			"kind", kind, "name", name)
+		return
+	}
+	log.Info("Access denied for monitoring resource, skipping stale-object cleanup",
+		"kind", kind, "name", name, "error", err.Error())
 }
 
 func (r *AerospikeClusterReconciler) reconcileMetricsService(

--- a/internal/controller/reconciler_monitoring.go
+++ b/internal/controller/reconciler_monitoring.go
@@ -33,6 +33,18 @@ var prometheusRuleGVK = schema.GroupVersionKind{
 	Kind:    "PrometheusRule",
 }
 
+// reconcileMonitoring reconciles the metrics Service plus the two optional
+// Prometheus-Operator resources.
+//
+// ServiceMonitor and PrometheusRule are best-effort: the CRDs may not be
+// installed, and the operator's ClusterRole may not grant access to them (a
+// chart install that predates the RBAC entry, or an RBAC-only install trimmed
+// by the cluster admin). Both of those conditions must degrade the individual
+// feature, never fail the reconcile — an error returned from here reaches
+// handleReconcileError, and after maxFailedReconciles consecutive failures the
+// circuit breaker freezes scale, rolling restart, config and ACL
+// reconciliation for the whole cluster. Losing the entire control loop over an
+// optional monitoring integration is never the right trade.
 func (r *AerospikeClusterReconciler) reconcileMonitoring(
 	ctx context.Context,
 	cluster *ackov1alpha1.AerospikeCluster,
@@ -53,10 +65,15 @@ func (r *AerospikeClusterReconciler) reconcileMonitoring(
 		cluster.Spec.Monitoring.ServiceMonitor.Enabled
 
 	if err := r.reconcileServiceMonitor(ctx, cluster, smEnabled); err != nil {
-		// Only log and skip if the CRD is not installed; propagate other errors.
-		if meta.IsNoMatchError(err) {
+		// Only log and skip if the CRD is not installed or the operator is not
+		// allowed to touch it; propagate other errors.
+		switch {
+		case meta.IsNoMatchError(err):
 			log.Info("ServiceMonitor CRD not installed, skipping")
-		} else {
+		case errors.IsForbidden(err):
+			log.Info("ServiceMonitor access denied by RBAC, skipping",
+				"name", utils.ServiceMonitorName(cluster.Name), "error", err.Error())
+		default:
 			return fmt.Errorf("reconciling ServiceMonitor: %w", err)
 		}
 	}
@@ -67,9 +84,13 @@ func (r *AerospikeClusterReconciler) reconcileMonitoring(
 		cluster.Spec.Monitoring.PrometheusRule.Enabled
 
 	if err := r.reconcilePrometheusRule(ctx, cluster, prEnabled); err != nil {
-		if meta.IsNoMatchError(err) {
+		switch {
+		case meta.IsNoMatchError(err):
 			log.Info("PrometheusRule CRD not installed, skipping")
-		} else {
+		case errors.IsForbidden(err):
+			log.Info("PrometheusRule access denied by RBAC, skipping",
+				"name", utils.PrometheusRuleName(cluster.Name), "error", err.Error())
+		default:
 			return fmt.Errorf("reconciling PrometheusRule: %w", err)
 		}
 	}

--- a/internal/controller/reconciler_monitoring_unit_test.go
+++ b/internal/controller/reconciler_monitoring_unit_test.go
@@ -24,6 +24,11 @@ import (
 // API failure during monitoring-resource cleanup.
 var errMonitoringGetFailure = errors.New("simulated API server failure")
 
+// monitoringTestCluster is the cluster name shared by the monitoring unit tests.
+// Named rather than repeated inline so goconst does not flag the literal, and so
+// the fixtures and the expected resource names cannot drift apart.
+const monitoringTestCluster = "demo"
+
 func TestToStringMap(t *testing.T) {
 	tests := []struct {
 		name string
@@ -333,7 +338,7 @@ func TestReconcileMetricsService_CleanupGetErrorNotSwallowed(t *testing.T) {
 	scheme := rollingRestartScheme(t)
 
 	cluster := &ackov1alpha1.AerospikeCluster{}
-	cluster.Name = "demo"
+	cluster.Name = monitoringTestCluster
 	cluster.Namespace = ctrlTestNamespace
 
 	base := fake.NewClientBuilder().
@@ -402,7 +407,7 @@ func monitoringGetErrClient(scheme *runtime.Scheme, errFor func(resource string)
 func forbiddenMonitoringErr(resource string) error {
 	return apierrors.NewForbidden(
 		schema.GroupResource{Group: "monitoring.coreos.com", Resource: resource},
-		"demo",
+		monitoringTestCluster,
 		errors.New(`clusterrole "acko-manager" does not grant this resource`),
 	)
 }
@@ -457,7 +462,7 @@ func TestReconcileMonitoring_ForbiddenDegradesFeature(t *testing.T) {
 			scheme := rollingRestartScheme(t)
 
 			cluster := &ackov1alpha1.AerospikeCluster{}
-			cluster.Name = "demo"
+			cluster.Name = monitoringTestCluster
 			cluster.Namespace = ctrlTestNamespace
 			cluster.Spec.Monitoring = tc.monitoring
 
@@ -482,7 +487,7 @@ func TestReconcileMonitoring_UnexpectedErrorStillFailsReconcile(t *testing.T) {
 	scheme := rollingRestartScheme(t)
 
 	cluster := &ackov1alpha1.AerospikeCluster{}
-	cluster.Name = "demo"
+	cluster.Name = monitoringTestCluster
 	cluster.Namespace = ctrlTestNamespace
 
 	r := &AerospikeClusterReconciler{

--- a/internal/controller/reconciler_monitoring_unit_test.go
+++ b/internal/controller/reconciler_monitoring_unit_test.go
@@ -10,6 +10,8 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -356,5 +358,145 @@ func TestReconcileMetricsService_CleanupGetErrorNotSwallowed(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "getting metrics service") {
 		t.Errorf("expected wrapped cleanup Get error, got: %v", err)
+	}
+}
+
+// monitoringResourceFor returns the monitoring.coreos.com resource name for an
+// unstructured object, or "" if the object is not one of the two optional
+// Prometheus-Operator kinds.
+func monitoringResourceFor(obj client.Object) string {
+	u, ok := obj.(*unstructured.Unstructured)
+	if !ok {
+		return ""
+	}
+	gvk := u.GroupVersionKind()
+	if gvk.Group != "monitoring.coreos.com" {
+		return ""
+	}
+	switch gvk.Kind {
+	case "ServiceMonitor":
+		return "servicemonitors"
+	case "PrometheusRule":
+		return "prometheusrules"
+	}
+	return ""
+}
+
+// monitoringGetErrClient builds a fake client whose Get fails for every
+// monitoring.coreos.com object with the error errFor produces for that
+// resource, while serving every other Get normally.
+func monitoringGetErrClient(scheme *runtime.Scheme, errFor func(resource string) error) client.WithWatch {
+	base := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	return interceptor.NewClient(base, interceptor.Funcs{
+		Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey,
+			obj client.Object, opts ...client.GetOption) error {
+			if resource := monitoringResourceFor(obj); resource != "" {
+				return errFor(resource)
+			}
+			return c.Get(ctx, key, obj, opts...)
+		},
+	})
+}
+
+func forbiddenMonitoringErr(resource string) error {
+	return apierrors.NewForbidden(
+		schema.GroupResource{Group: "monitoring.coreos.com", Resource: resource},
+		"demo",
+		errors.New(`clusterrole "acko-manager" does not grant this resource`),
+	)
+}
+
+// TestReconcileMonitoring_ForbiddenDegradesFeature is the regression test for
+// the RBAC-403 cluster freeze. reconcilePrometheusRule issues a Get on *every*
+// reconcile — including when the feature is disabled, where the Get exists only
+// to clean up a stale object. A chart install whose manager ClusterRole omits
+// monitoring.coreos.com/prometheusrules therefore got a 403 on every pass, and
+// the error funnelled into handleReconcileError until the circuit breaker
+// wedged the cluster in BackoffActive: no scale, no rolling restart, no config
+// change, no ACL sync. A 403 on an optional resource must degrade that one
+// feature and leave the reconcile successful, exactly as a missing CRD does.
+func TestReconcileMonitoring_ForbiddenDegradesFeature(t *testing.T) {
+	tests := []struct {
+		name       string
+		monitoring *ackov1alpha1.AerospikeMonitoringSpec
+	}{
+		{
+			// The reported failure mode: the cluster asks for no monitoring at
+			// all, yet the stale-object cleanup Get still 403s.
+			name:       "monitoring not configured",
+			monitoring: nil,
+		},
+		{
+			name: "monitoring enabled, optional resources disabled",
+			monitoring: &ackov1alpha1.AerospikeMonitoringSpec{
+				Enabled:       true,
+				ExporterImage: "exporter:v1",
+				Port:          9145,
+			},
+		},
+		{
+			name: "optional resources explicitly enabled",
+			monitoring: &ackov1alpha1.AerospikeMonitoringSpec{
+				Enabled:       true,
+				ExporterImage: "exporter:v1",
+				Port:          9145,
+				ServiceMonitor: &ackov1alpha1.ServiceMonitorSpec{
+					Enabled:  true,
+					Interval: "30s",
+				},
+				PrometheusRule: &ackov1alpha1.PrometheusRuleSpec{
+					Enabled: true,
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			scheme := rollingRestartScheme(t)
+
+			cluster := &ackov1alpha1.AerospikeCluster{}
+			cluster.Name = "demo"
+			cluster.Namespace = ctrlTestNamespace
+			cluster.Spec.Monitoring = tc.monitoring
+
+			r := &AerospikeClusterReconciler{
+				Client: monitoringGetErrClient(scheme, forbiddenMonitoringErr),
+				Scheme: scheme,
+			}
+
+			if err := r.reconcileMonitoring(context.Background(), cluster); err != nil {
+				t.Fatalf("reconcileMonitoring() = %v, want nil: a 403 on an optional "+
+					"monitoring resource must not fail the reconcile", err)
+			}
+		})
+	}
+}
+
+// TestReconcileMonitoring_UnexpectedErrorStillFailsReconcile guards the other
+// side of the fix: only "this resource is unreachable by design" errors — a
+// missing CRD or a 403 — are allowed to degrade the feature. A transient API
+// failure must still surface, or a real outage would be silently swallowed.
+func TestReconcileMonitoring_UnexpectedErrorStillFailsReconcile(t *testing.T) {
+	scheme := rollingRestartScheme(t)
+
+	cluster := &ackov1alpha1.AerospikeCluster{}
+	cluster.Name = "demo"
+	cluster.Namespace = ctrlTestNamespace
+
+	r := &AerospikeClusterReconciler{
+		Client: monitoringGetErrClient(scheme, func(string) error {
+			return apierrors.NewInternalError(errMonitoringGetFailure)
+		}),
+		Scheme: scheme,
+	}
+
+	err := r.reconcileMonitoring(context.Background(), cluster)
+	if err == nil {
+		t.Fatal("reconcileMonitoring() = nil, want error for a non-403 API failure")
+	}
+	if !strings.Contains(err.Error(), "reconciling ServiceMonitor") {
+		t.Errorf("expected the ServiceMonitor error to propagate, got: %v", err)
 	}
 }

--- a/internal/controller/reconciler_monitoring_unit_test.go
+++ b/internal/controller/reconciler_monitoring_unit_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -16,6 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
 )
@@ -503,5 +505,176 @@ func TestReconcileMonitoring_UnexpectedErrorStillFailsReconcile(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "reconciling ServiceMonitor") {
 		t.Errorf("expected the ServiceMonitor error to propagate, got: %v", err)
+	}
+}
+
+// recordingSink captures which level a log line was emitted at, so the
+// enabled/disabled split in logForbiddenMonitoringResource is asserted rather
+// than assumed. WithValues/WithName intentionally return the same sink: the test
+// only cares about messages and levels.
+type recordingSink struct {
+	errorMsgs []string
+	infoMsgs  []string
+}
+
+func (s *recordingSink) Init(logr.RuntimeInfo)               {}
+func (s *recordingSink) Enabled(int) bool                    { return true }
+func (s *recordingSink) WithValues(...any) logr.LogSink      { return s }
+func (s *recordingSink) WithName(string) logr.LogSink        { return s }
+func (s *recordingSink) Info(_ int, msg string, _ ...any)    { s.infoMsgs = append(s.infoMsgs, msg) }
+func (s *recordingSink) Error(_ error, msg string, _ ...any) { s.errorMsgs = append(s.errorMsgs, msg) }
+
+func (s *recordingSink) logged(msgs []string, want string) bool {
+	for _, m := range msgs {
+		if strings.Contains(m, want) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestReconcileMonitoring_ForbiddenLogLevelMatchesEnabled pins the Error-vs-Info
+// split. A 403 on a resource the user explicitly enabled means the operator is
+// silently not delivering something that was asked for, and with no
+// MonitoringReady condition to read the log is the only signal — so it must be
+// Error. A 403 on a disabled resource only blocks the stale-object cleanup Get,
+// where an Error on every reconcile would train operators to ignore the
+// operator's Error logs.
+func TestReconcileMonitoring_ForbiddenLogLevelMatchesEnabled(t *testing.T) {
+	const (
+		errorMsg = "Access denied for an enabled monitoring resource"
+		infoMsg  = "Access denied for monitoring resource, skipping stale-object cleanup"
+	)
+
+	tests := []struct {
+		name         string
+		monitoring   *ackov1alpha1.AerospikeMonitoringSpec
+		wantErrorLog bool
+	}{
+		{
+			name:         "disabled resource logs at Info",
+			monitoring:   nil,
+			wantErrorLog: false,
+		},
+		{
+			name: "enabled resource logs at Error",
+			monitoring: &ackov1alpha1.AerospikeMonitoringSpec{
+				Enabled:       true,
+				ExporterImage: "exporter:v1",
+				Port:          9145,
+				ServiceMonitor: &ackov1alpha1.ServiceMonitorSpec{
+					Enabled:  true,
+					Interval: "30s",
+				},
+				PrometheusRule: &ackov1alpha1.PrometheusRuleSpec{Enabled: true},
+			},
+			wantErrorLog: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			scheme := rollingRestartScheme(t)
+
+			cluster := &ackov1alpha1.AerospikeCluster{}
+			cluster.Name = monitoringTestCluster
+			cluster.Namespace = ctrlTestNamespace
+			cluster.Spec.Monitoring = tc.monitoring
+
+			r := &AerospikeClusterReconciler{
+				Client: monitoringGetErrClient(scheme, forbiddenMonitoringErr),
+				Scheme: scheme,
+			}
+
+			sink := &recordingSink{}
+			ctx := logf.IntoContext(context.Background(), logr.New(sink))
+
+			if err := r.reconcileMonitoring(ctx, cluster); err != nil {
+				t.Fatalf("reconcileMonitoring() = %v, want nil", err)
+			}
+
+			gotError := sink.logged(sink.errorMsgs, errorMsg)
+			gotInfo := sink.logged(sink.infoMsgs, infoMsg)
+
+			if tc.wantErrorLog {
+				if !gotError {
+					t.Errorf("expected an Error-level log for an enabled resource, got errors=%v infos=%v",
+						sink.errorMsgs, sink.infoMsgs)
+				}
+				if gotInfo {
+					t.Errorf("an enabled resource must not be reported at Info: %v", sink.infoMsgs)
+				}
+				return
+			}
+			if !gotInfo {
+				t.Errorf("expected an Info-level log for a disabled resource, got errors=%v infos=%v",
+					sink.errorMsgs, sink.infoMsgs)
+			}
+			if gotError {
+				t.Errorf("a disabled resource must not be reported at Error: %v", sink.errorMsgs)
+			}
+		})
+	}
+}
+
+// TestMonitoringCleanupForbiddenSurvivesErrorWrap pins the coupling between the
+// cleanup error wrap and the IsForbidden classification.
+//
+// The disabled path wraps the Get failure as
+// "getting <Kind> %s for cleanup: %w", and reconcileMonitoring's
+// errors.IsForbidden case only matches because apierrors.IsForbidden resolves
+// through errors.As. If a refactor drops the %w — switching to %v, or building a
+// fresh error — the 403 silently stops being recognised and the reconcile starts
+// failing again, which is the original cluster-freeze bug. Nothing else in the
+// suite would catch that, because reconcileMonitoring would still return an
+// error for a reason the tests do not distinguish.
+func TestMonitoringCleanupForbiddenSurvivesErrorWrap(t *testing.T) {
+	tests := []struct {
+		name    string
+		call    func(r *AerospikeClusterReconciler, cluster *ackov1alpha1.AerospikeCluster) error
+		wantMsg string
+	}{
+		{
+			name: "ServiceMonitor cleanup",
+			call: func(r *AerospikeClusterReconciler, c *ackov1alpha1.AerospikeCluster) error {
+				return r.reconcileServiceMonitor(context.Background(), c, false)
+			},
+			wantMsg: "getting ServiceMonitor",
+		},
+		{
+			name: "PrometheusRule cleanup",
+			call: func(r *AerospikeClusterReconciler, c *ackov1alpha1.AerospikeCluster) error {
+				return r.reconcilePrometheusRule(context.Background(), c, false)
+			},
+			wantMsg: "getting PrometheusRule",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			scheme := rollingRestartScheme(t)
+
+			cluster := &ackov1alpha1.AerospikeCluster{}
+			cluster.Name = monitoringTestCluster
+			cluster.Namespace = ctrlTestNamespace
+
+			r := &AerospikeClusterReconciler{
+				Client: monitoringGetErrClient(scheme, forbiddenMonitoringErr),
+				Scheme: scheme,
+			}
+
+			err := tc.call(r, cluster)
+			if err == nil {
+				t.Fatal("expected the cleanup Get error to be returned to the caller")
+			}
+			// The wrap must still be there ...
+			if !strings.Contains(err.Error(), tc.wantMsg) || !strings.Contains(err.Error(), "for cleanup") {
+				t.Errorf("expected the wrapped cleanup error, got: %v", err)
+			}
+			// ... and IsForbidden must still see through it.
+			if !apierrors.IsForbidden(err) {
+				t.Errorf("apierrors.IsForbidden must match through the %%w wrap, got: %v", err)
+			}
+		})
 	}
 }

--- a/internal/controller/reconciler_networkpolicy.go
+++ b/internal/controller/reconciler_networkpolicy.go
@@ -185,6 +185,19 @@ func (r *AerospikeClusterReconciler) reconcileCiliumNetworkPolicy(
 		return nil
 	}
 
+	// Access denied — same shape as the CRD-absent case and the same reason to
+	// degrade rather than fail: this error reaches reconcileCluster ->
+	// handleReconcileError -> the circuit breaker, which after
+	// maxFailedReconciles freezes scale, rolling restart, config and ACL
+	// reconciliation for the whole cluster. Losing the control loop over an
+	// optional network-policy integration is never the right trade. Logged at
+	// Error because the policy was explicitly enabled and is not being applied.
+	if err != nil && errors.IsForbidden(err) {
+		log.Error(err, "Access denied for CiliumNetworkPolicy; network policy not applied",
+			"name", npName)
+		return nil
+	}
+
 	selectorLabels := utils.SelectorLabelsForCluster(cluster.Name)
 	labels := utils.LabelsForCluster(cluster.Name)
 

--- a/internal/controller/reconciler_networkpolicy_test.go
+++ b/internal/controller/reconciler_networkpolicy_test.go
@@ -1,12 +1,22 @@
 package controller
 
 import (
+	"context"
+	"errors"
+	"strings"
 	"testing"
 
 	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
 	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/podutil"
 	networkingv1 "k8s.io/api/networking/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
 func TestBuildK8sNetworkPolicy_BasicPorts(t *testing.T) {
@@ -230,5 +240,98 @@ func TestK8sNetworkPolicyChanged_LabelsChanged(t *testing.T) {
 
 	if changed := k8sNetworkPolicyChanged(existing, desired); !changed {
 		t.Fatal("k8sNetworkPolicyChanged() = false, want true when labels differ")
+	}
+}
+
+// TestReconcileNetworkPolicy_CiliumForbiddenDegrades covers the same 403 funnel
+// as the monitoring resources. reconcileNetworkPolicy's error reaches
+// reconcileCluster -> handleReconcileError -> the circuit breaker
+// (reconciler.go:609), so a denied CiliumNetworkPolicy Get would freeze scale,
+// rolling restart, config and ACL reconciliation for the whole cluster over an
+// optional network-policy integration. The chart does grant cilium.io, so the
+// exposure is narrower than the missing prometheusrules grant — but an RBAC-only
+// install, a policy-engine denial or a ResourceQuota all reach it.
+func TestReconcileNetworkPolicy_CiliumForbiddenDegrades(t *testing.T) {
+	scheme := rollingRestartScheme(t)
+
+	cluster := &ackov1alpha1.AerospikeCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: ctrlTestNamespace},
+		Spec: ackov1alpha1.AerospikeClusterSpec{
+			Size:  1,
+			Image: "aerospike:ce-8.1.1.1",
+			NetworkPolicyConfig: &ackov1alpha1.NetworkPolicyConfig{
+				Enabled: true,
+				Type:    ackov1alpha1.NetworkPolicyTypeCilium,
+			},
+		},
+	}
+
+	base := fake.NewClientBuilder().WithScheme(scheme).Build()
+	denying := interceptor.NewClient(base, interceptor.Funcs{
+		Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey,
+			obj client.Object, opts ...client.GetOption) error {
+			if u, ok := obj.(*unstructured.Unstructured); ok &&
+				u.GroupVersionKind() == ciliumNetworkPolicyGVK {
+				return apierrors.NewForbidden(
+					schema.GroupResource{Group: "cilium.io", Resource: "ciliumnetworkpolicies"},
+					key.Name, errors.New("access denied"))
+			}
+			return c.Get(ctx, key, obj, opts...)
+		},
+	})
+
+	r := &AerospikeClusterReconciler{
+		Client:   denying,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(8),
+	}
+
+	if err := r.reconcileNetworkPolicy(context.Background(), cluster); err != nil {
+		t.Fatalf("reconcileNetworkPolicy() = %v, want nil: a 403 on an optional "+
+			"CiliumNetworkPolicy must not fail the reconcile", err)
+	}
+}
+
+// TestReconcileNetworkPolicy_CiliumOtherErrorStillFails guards the other side —
+// only a 403 or an absent CRD may degrade; a transient API failure must surface.
+func TestReconcileNetworkPolicy_CiliumOtherErrorStillFails(t *testing.T) {
+	scheme := rollingRestartScheme(t)
+
+	cluster := &ackov1alpha1.AerospikeCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: ctrlTestNamespace},
+		Spec: ackov1alpha1.AerospikeClusterSpec{
+			Size:  1,
+			Image: "aerospike:ce-8.1.1.1",
+			NetworkPolicyConfig: &ackov1alpha1.NetworkPolicyConfig{
+				Enabled: true,
+				Type:    ackov1alpha1.NetworkPolicyTypeCilium,
+			},
+		},
+	}
+
+	base := fake.NewClientBuilder().WithScheme(scheme).Build()
+	failing := interceptor.NewClient(base, interceptor.Funcs{
+		Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey,
+			obj client.Object, opts ...client.GetOption) error {
+			if u, ok := obj.(*unstructured.Unstructured); ok &&
+				u.GroupVersionKind() == ciliumNetworkPolicyGVK {
+				return apierrors.NewInternalError(errors.New("etcd unavailable"))
+			}
+			return c.Get(ctx, key, obj, opts...)
+		},
+	})
+
+	r := &AerospikeClusterReconciler{
+		Client:   failing,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(8),
+	}
+
+	err := r.reconcileNetworkPolicy(context.Background(), cluster)
+	if err == nil {
+		t.Fatal("reconcileNetworkPolicy() = nil, want error for a non-403 API failure")
+	}
+	if !strings.Contains(err.Error(), "getting CiliumNetworkPolicy") {
+		t.Errorf("expected the wrapped Get error, got: %v", err)
 	}
 }

--- a/internal/controller/reconciler_networkpolicy_test.go
+++ b/internal/controller/reconciler_networkpolicy_test.go
@@ -255,7 +255,7 @@ func TestReconcileNetworkPolicy_CiliumForbiddenDegrades(t *testing.T) {
 	scheme := rollingRestartScheme(t)
 
 	cluster := &ackov1alpha1.AerospikeCluster{
-		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: ctrlTestNamespace},
+		ObjectMeta: metav1.ObjectMeta{Name: monitoringTestCluster, Namespace: ctrlTestNamespace},
 		Spec: ackov1alpha1.AerospikeClusterSpec{
 			Size:  1,
 			Image: "aerospike:ce-8.1.1.1",
@@ -298,7 +298,7 @@ func TestReconcileNetworkPolicy_CiliumOtherErrorStillFails(t *testing.T) {
 	scheme := rollingRestartScheme(t)
 
 	cluster := &ackov1alpha1.AerospikeCluster{
-		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: ctrlTestNamespace},
+		ObjectMeta: metav1.ObjectMeta{Name: monitoringTestCluster, Namespace: ctrlTestNamespace},
 		Spec: ackov1alpha1.AerospikeClusterSpec{
 			Size:  1,
 			Image: "aerospike:ce-8.1.1.1",


### PR DESCRIPTION
## Problem

One defect — *a 403 on an optional resource is treated as fatal* — in three places, plus the missing grant that triggers it.

**(a) The chart ClusterRole is missing `prometheusrules`.**

`config/rbac/role.yaml:116-128` (controller-gen generated) grants:

```yaml
- apiGroups: [monitoring.coreos.com]
  resources: [prometheusrules, servicemonitors]
```

`charts/aerospike-ce-kubernetes-operator/templates/clusterrole-manager.yaml:118-129` granted only `servicemonitors`. `grep -rn prometheusrules charts/` returned nothing at all, so **every** Helm install — README Option A, the recommended path — ran without that permission.

**(b) `reconcileMonitoring` treats a 403 as a fatal reconcile error.**

`internal/controller/reconciler_monitoring.go:69` calls `reconcilePrometheusRule` unconditionally, and that function issues a `Get` even when the feature is *disabled*, in order to clean up a stale object (`:276`). Its error funnel handled `apierrors.IsNotFound` and `meta.IsNoMatchError` but not `apierrors.IsForbidden`, so the 403 was returned as a hard error at `:292`.

That error path is `reconcilePrometheusRule` → `reconcileMonitoring` → `reconcileCluster` → `handleReconcileError` → circuit breaker. On any cluster that has the Prometheus-Operator CRDs installed (anything running kube-prometheus-stack) the Get resolves, gets denied, and **fails every reconcile regardless of the cluster's monitoring settings** — `monitoring: {}` or no monitoring block at all still hits it. After `maxFailedReconciles` (10) the cluster sits in `BackoffActive`: no scale, no rolling restart, no config change, no ACL sync is ever applied again, while the data plane keeps running unmanaged. The operator cannot respond to a node failure.

**(c) `validateServiceMonitorUniqueness` rejects the CR at admission on a 403 — worse than (b).**

`api/v1alpha1/aerospikecluster_webhook.go:450` has the identical funnel over a ServiceMonitor `Get` on the non-cached `APIReader`:

```go
case meta.IsNoMatchError(err):
    return nil
default:
    return fmt.Errorf("getting ServiceMonitor %q in namespace %q: %w", ...)
```

A `Forbidden` hits `default`, so admission **rejects the AerospikeCluster**. The user cannot create or update the CR at all, and therefore cannot edit their way out of it — strictly worse than the reconcile freeze in (b).

This is reachable in exactly the scenario the chart supports with `--set rbac.create=false` (added in #325 for cluster-admin / RBAC-only installs): the cluster admin writes the operator's role by hand and trims `monitoring.coreos.com` out of it. The doc comment added in the first commit cites "an RBAC-only install trimmed by the cluster admin" as a reason to degrade — and this webhook path is precisely where that scenario stops being a degradation and becomes an outright rejection.

**(d) `reconcileCiliumNetworkPolicy` — same funnel, narrower exposure.**

`internal/controller/reconciler_networkpolicy.go:183`, same `IsNoMatchError`-only shape for an optional CRD. Its error reaches `handleReconcileError` and the circuit breaker via `reconciler.go:609`. The chart *does* grant `cilium.io`, so this one is not triggered by the missing grant in (a) — but an RBAC-only install, a policy-engine denial or a ResourceQuota all reach it.

## Fix

**Chart:** added `prometheusrules` to the manager ClusterRole.

**Controller (monitoring):** `IsForbidden` now degrades the feature exactly as `IsNoMatchError` already did — both mean "this optional resource is unreachable by design". Applied to both the ServiceMonitor and PrometheusRule branches:

```go
switch {
case meta.IsNoMatchError(err):
    log.Info("PrometheusRule CRD not installed, skipping")
case errors.IsForbidden(err):
    logForbiddenMonitoringResource(
        log, prEnabled, "PrometheusRule", utils.PrometheusRuleName(cluster.Name), err)
default:
    return fmt.Errorf("reconciling PrometheusRule: %w", err)
}
```

`apierrors.IsForbidden` resolves through `errors.As` (apimachinery v0.35.0, `reasonAndCodeForError`), so it still matches after the inner functions wrap with `%w`. This covers the 403 on `Create`/`Update`/`Delete` too, not just the `Get` — every one of those funnels back through the same return.

**Webhook:** added `case apierrors.IsForbidden(err): return nil` to `validateServiceMonitorUniqueness`. The probe is an optimisation, not a correctness requirement — it turns a name collision into a clear admission error instead of a confusing reconcile failure. Without permission to run it we lose that nicety and nothing else; the reconciler still degrades the feature safely.

**CiliumNetworkPolicy:** same degradation, logged at `Error` since the policy was explicitly enabled and is not being applied.

**Log level.** A 403 is not only an RBAC gap: the API server returns `Forbidden` for a ValidatingWebhook or Kyverno/Gatekeeper denial and for ResourceQuota exhaustion too, so any of those silently disables monitoring through this same path. There is no `MonitoringReady` status condition to read instead (`grep -rn "MonitoringReady\|ConditionMonitoring" internal api` returns nothing), so the log is currently the only signal. `logForbiddenMonitoringResource` therefore logs at **Error** when the resource is *enabled* — the operator is not delivering something the user asked for — and stays at **Info** when disabled, where the 403 only blocks a stale-object cleanup `Get` and an Error on every reconcile would train operators to ignore the operator's Error logs. **Publishing a degraded status condition is the proper follow-up and is not in this PR.**

**Deliberately unchanged:** the metrics `Service`. Its error returns at `reconciler_monitoring.go:59-61`, *before* the switch, because a core `Service` is a required permission rather than an optional integration — a 403 there should fail loudly.

## Verification

### RBAC

Normalised rule-set diff (apiGroups/resources/verbs sorted, rules sorted) of the rendered chart role against the generated role — **before** the fix:

```
13c13
< {"apiGroups": ["monitoring.coreos.com"], "resources": ["prometheusrules", "servicemonitors"], "verbs": [...]}
---
> {"apiGroups": ["monitoring.coreos.com"], "resources": ["servicemonitors"], "verbs": [...]}
```

**After** the fix: 16 rules vs 16 rules, `diff` empty in both directions — the two rule sets are identical, so there is no remaining divergence anywhere in the role. This was the only one, nothing else needed changing, and nothing was widened.

`helm template charts/aerospike-ce-kubernetes-operator | grep -A3 prometheusrules`:

```yaml
      - prometheusrules
      - servicemonitors
    verbs:
      - create
```

`helm lint charts/aerospike-ce-kubernetes-operator` → `1 chart(s) linted, 0 chart(s) failed`.

### Tests

**9 cases across 7 test functions. All are plain unit tests** — `fake.NewClientBuilder` + `interceptor.NewClient`, no API server and no envtest — following the pattern already established at `reconciler_monitoring_unit_test.go:330`.

| Test | Cases | Fails on unpatched code |
| --- | --- | --- |
| `TestReconcileMonitoring_ForbiddenDegradesFeature` | 3 (monitoring unconfigured; monitoring on with the optional resources off; both explicitly on) | yes |
| `TestReconcileMonitoring_UnexpectedErrorStillFailsReconcile` | 1 | no — over-degradation guard |
| `TestValidateServiceMonitorUniqueness_ForbiddenDoesNotRejectCR` | 1 | yes |
| `TestValidate_ForbiddenServiceMonitorProbeStillAdmits` | 1 (drives `ValidateCreate` **and** `ValidateUpdate`) | yes |
| `TestValidateServiceMonitorUniqueness_OtherErrorsStillReject` | 1 | no — over-degradation guard |
| `TestReconcileNetworkPolicy_CiliumForbiddenDegrades` | 1 | yes |
| `TestReconcileNetworkPolicy_CiliumOtherErrorStillFails` | 1 | no — over-degradation guard |

So **6 of the 9 cases fail on unpatched code; the other 3 pass on both sides by design** — they exist to prove the fix does not over-degrade, i.e. that a non-403 API failure still propagates rather than being swallowed.

With the two source fixes from the second commit stashed:

```
--- FAIL: TestValidateServiceMonitorUniqueness_ForbiddenDoesNotRejectCR (0.03s)
--- FAIL: TestValidate_ForbiddenServiceMonitorProbeStillAdmits (0.00s)
--- PASS: TestValidateServiceMonitorUniqueness_OtherErrorsStillReject (0.00s)
FAIL  .../api/v1alpha1  0.905s
--- FAIL: TestReconcileNetworkPolicy_CiliumForbiddenDegrades (0.04s)
--- PASS: TestReconcileNetworkPolicy_CiliumOtherErrorStillFails (0.00s)
FAIL  .../internal/controller  1.082s
```

With `reconciler_monitoring.go` stashed:

```
--- FAIL: TestReconcileMonitoring_ForbiddenDegradesFeature (0.04s)
    --- FAIL: /monitoring_not_configured (0.04s)
    --- FAIL: /monitoring_enabled,_optional_resources_disabled (0.00s)
    --- FAIL: /optional_resources_explicitly_enabled (0.00s)
FAIL
```

All 9 pass with the fixes applied.

### Commands

| Command | Result |
| --- | --- |
| `go build ./...` | exit 0, no output |
| `go vet ./...` | exit 0, no output |
| `gofmt -l .` | empty |
| `go test ./api/...` | `ok .../api/v1alpha1 0.418s` |
| `go test ./internal/controller/...` | `ok .../internal/controller 0.644s` (0 failed, 0 skipped) |
| `go test ./...` | every package `ok` or "no test files"; zero failures |

`golangci-lint` was **not** run — `.custom-gcl.yml` requires a custom build with a `logcheck` plugin that is not available in this environment. No kind/kubectl/docker commands were run and the e2e suite was not executed.

## Risk

- **Existing installs need the chart upgrade to pick up the RBAC.** The ClusterRole change only takes effect on `helm upgrade`. The controller and webhook halves are what unbrick an already-wedged cluster *without* one, which is why they are in the same PR.
- **A 403 on an explicitly-enabled feature is now non-fatal.** If a user sets `monitoring.prometheusRule.enabled: true` and the request is denied, the resource is not created and the only signal is a per-reconcile `log.Error` carrying the 403 text. That is a deliberate trade — freezing the entire control loop over an optional integration is strictly worse — and it matches how the CRD-absent case has always behaved. The absence of a status condition is the real gap; see the follow-up note above.
- **The webhook change removes an admission-time collision check when access is denied.** A user could then create two AerospikeClusters whose ServiceMonitor names collide, and find out at reconcile time instead of at admission. That is the pre-existing behaviour for a missing CRD, and it is a far better failure than being unable to write the CR at all.
- **Log volume.** Like the pre-existing CRD-absent skip, this logs once per reconcile rather than once per condition. No dedup cache was added.
- **Not covered: the root cause of the RBAC drift.** Nothing in CI asserts that the chart ClusterRole matches `config/rbac/role.yaml`, so this can regress the moment a new `+kubebuilder:rbac` marker is added. The normalised-diff script used above would make a good `verify-generated` CI job; that is a separate P1 finding and is out of scope here.
- **Not covered: e2e.** No e2e test creates a cluster `ServiceMonitor`/`PrometheusRule`, so the `reconcileMonitoring` path still has no end-to-end coverage. A monitoring e2e would have caught this defect.
- **Not audited: every other `IsNoMatchError`-only funnel in the repo.** The three fixed here are the ones I traced end to end. A sweep for the same shape elsewhere would be worthwhile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
