### PR TITLE
fix(webhook): reject CE TLS at network.tls and network.* tls-* keys

### DIFF
--- a/api/v1alpha1/aerospikecluster_webhook.go
+++ b/api/v1alpha1/aerospikecluster_webhook.go
@@ -711,10 +711,13 @@ func (v *AerospikeClusterValidator) validateAerospikeConfig(config map[string]an
 		errors = append(errors, "aerospikeConfig must not contain 'xdr' section (XDR is Enterprise-only)")
 	}
 
-	// CE does not support TLS
+	// CE does not support TLS. The top-level key is only the smaller half of the
+	// surface — Aerospike documents TLS inside the network stanza, so
+	// validateNetworkTLSCE covers where users actually write it.
 	if _, exists := config["tls"]; exists {
 		errors = append(errors, "aerospikeConfig must not contain 'tls' section (TLS is Enterprise-only)")
 	}
+	errors = append(errors, validateNetworkTLSCE("aerospikeConfig", config)...)
 
 	// Count namespaces (CE limit: 2)
 	if nsSection, exists := config["namespaces"]; exists {
@@ -810,6 +813,85 @@ func (v *AerospikeClusterValidator) validateAerospikeConfig(config map[string]an
 	}
 
 	return errors, warnings
+}
+
+// tlsKeyPrefix is the prefix shared by every per-endpoint TLS key that
+// Aerospike accepts inside a network sub-stanza: tls-port, tls-name,
+// tls-authenticate-client, tls-mutual-authentication, ... No Community Edition
+// configuration key starts with it, so a prefix match is both sufficient to
+// catch the whole family and safe against rejecting a legitimate CE key.
+const tlsKeyPrefix = "tls-"
+
+// tlsNetworkSubsections lists the network sub-stanzas that accept per-endpoint
+// TLS keys.
+var tlsNetworkSubsections = []string{"service", "heartbeat", "fabric"}
+
+// validateNetworkTLSCE rejects Enterprise-only TLS configuration inside the
+// network stanza.
+//
+// The top-level aerospikeConfig["tls"] check is not where TLS lives. Real
+// Aerospike TLS is configured as:
+//
+//	network {
+//	    tls <name> { cert-file ...; key-file ...; ca-file ... }
+//	    service   { port 3000; tls-port 4333; tls-name <name> }
+//	    heartbeat { mode mesh; tls-port 3012; tls-name <name> }
+//	    fabric    { port 3001; tls-port 3011; tls-name <name> }
+//	}
+//
+// which is exactly what the Aerospike documentation tells a user to write, and
+// none of it was checked. configgen then passes it straight through:
+// generateNetworkSection renders any sub-map under `network` verbatim and
+// scalar tls-* keys go through writeMapEntries unfiltered, so the
+// Enterprise-only stanza reaches aerospike.conf and the CE asd process refuses
+// to start — a permanent CrashLoopBackOff with no admission error naming the
+// Enterprise feature. On a live cluster it is worse: the edit changes the
+// config hash, so the rolling restart walks every pod into the crash loop one
+// batch at a time.
+//
+// fieldPath is the user-facing prefix for error messages (e.g.
+// "aerospikeConfig"). The reported path always names the offending key in full
+// so an operator can find and remove it.
+func validateNetworkTLSCE(fieldPath string, config map[string]any) []string {
+	netCfg, ok := config["network"].(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	var errs []string
+
+	// `network { tls <name> { ... } }` — the certificate/key material. The
+	// presence of the key is enough; the value shape is irrelevant, because a
+	// user who wrote it intended an Enterprise feature either way.
+	if _, exists := netCfg["tls"]; exists {
+		errs = append(errs, fmt.Sprintf(
+			"%s.network must not contain 'tls' section (TLS is Enterprise-only)", fieldPath))
+	}
+
+	// Per-endpoint tls-* keys under service / heartbeat / fabric.
+	for _, subsection := range tlsNetworkSubsections {
+		subMap, ok := netCfg[subsection].(map[string]any)
+		if !ok {
+			continue
+		}
+		// Collect and sort: map iteration order is random, and a stanza can
+		// carry several tls-* keys at once. An unstable admission message would
+		// be confusing to read and impossible to assert on.
+		var tlsKeys []string
+		for key := range subMap {
+			if strings.HasPrefix(key, tlsKeyPrefix) {
+				tlsKeys = append(tlsKeys, key)
+			}
+		}
+		slices.Sort(tlsKeys)
+		for _, key := range tlsKeys {
+			errs = append(errs, fmt.Sprintf(
+				"%s.network.%s.%s is not allowed in CE edition (TLS is Enterprise-only)",
+				fieldPath, subsection, key))
+		}
+	}
+
+	return errs
 }
 
 // enterpriseOnlySecurityKeys lists security sub-keys that are Enterprise-only.

--- a/api/v1alpha1/aerospikeclustertemplate_webhook.go
+++ b/api/v1alpha1/aerospikeclustertemplate_webhook.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -205,6 +206,9 @@ func (v *AerospikeClusterTemplateValidator) validate(tmpl *AerospikeClusterTempl
 // Mirrors the CE constraints enforced in validateAerospikeConfig on the
 // AerospikeCluster webhook:
 //   - top-level "xdr" and "tls" keys are forbidden,
+//   - per-endpoint "tls-*" keys are forbidden, and a nested "network" map is
+//     handed to validateNetworkTLSCE (see that function for why the plain
+//     "tls" key is not the whole TLS surface),
 //   - "security" sub-keys listed in enterpriseOnlySecurityKeys are forbidden,
 //   - when isNamespaceDefaults is true, top-level keys listed in
 //     enterpriseOnlyNamespaceKeys are forbidden (compression, strong-
@@ -230,6 +234,26 @@ func validateTemplateConfigBannedKeys(fieldPath string, cfg map[string]any, isNa
 		errs = append(errs, fmt.Sprintf(
 			"%s must not contain 'tls' section (TLS is Enterprise-only)", fieldPath))
 	}
+	// Per-endpoint TLS keys (tls-port, tls-name, tls-authenticate-client, ...).
+	// A template's service/namespaceDefaults map is merged into the cluster's
+	// aerospikeConfig and rendered by configgen, so an Enterprise-only tls-*
+	// key here reaches aerospike.conf the same way a top-level 'tls' section
+	// would and crashes the CE asd process at startup.
+	var tlsKeys []string
+	for key := range cfg {
+		if strings.HasPrefix(key, tlsKeyPrefix) {
+			tlsKeys = append(tlsKeys, key)
+		}
+	}
+	slices.Sort(tlsKeys)
+	for _, key := range tlsKeys {
+		errs = append(errs, fmt.Sprintf(
+			"%s.%s is not allowed in CE edition (TLS is Enterprise-only)", fieldPath, key))
+	}
+	// A nested network map is not reachable through the current typed template
+	// fields (TemplateNetworkConfig exposes heartbeat only), but these maps are
+	// PreserveUnknownFields, so check it rather than rely on that staying true.
+	errs = append(errs, validateNetworkTLSCE(fieldPath, cfg)...)
 	if secSection, exists := cfg["security"]; exists {
 		secMap, ok := secSection.(map[string]any)
 		if !ok {

--- a/api/v1alpha1/aerospikeclustertemplate_webhook_test.go
+++ b/api/v1alpha1/aerospikeclustertemplate_webhook_test.go
@@ -759,3 +759,155 @@ func TestTemplateResourcesEqualRequestsLimits(t *testing.T) {
 		})
 	}
 }
+
+// --- CE network-TLS rejection on the template path ---
+
+// TestAerospikeClusterTemplateValidate_TLSKeysRejected mirrors the cluster
+// webhook's network-TLS check on the template's own aerospikeConfig maps. A
+// template's service / namespaceDefaults map is merged into every cluster that
+// references it, so an Enterprise-only tls-* key there crashes the CE asd
+// process on each of those clusters at once.
+func TestAerospikeClusterTemplateValidate_TLSKeysRejected(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   *TemplateAerospikeConfig
+		wantPath string
+	}{
+		{
+			name: "tls-port in service",
+			config: &TemplateAerospikeConfig{
+				Service: &AerospikeConfigSpec{
+					Value: map[string]any{"tls-port": 4333},
+				},
+			},
+			wantPath: "spec.aerospikeConfig.service.tls-port",
+		},
+		{
+			name: "tls-authenticate-client in service",
+			config: &TemplateAerospikeConfig{
+				Service: &AerospikeConfigSpec{
+					Value: map[string]any{"tls-authenticate-client": "any"},
+				},
+			},
+			wantPath: "spec.aerospikeConfig.service.tls-authenticate-client",
+		},
+		{
+			name: "tls-name in namespaceDefaults",
+			config: &TemplateAerospikeConfig{
+				NamespaceDefaults: &AerospikeConfigSpec{
+					Value: map[string]any{"tls-name": "aerospike-tls"},
+				},
+			},
+			wantPath: "spec.aerospikeConfig.namespaceDefaults.tls-name",
+		},
+		{
+			// These maps are PreserveUnknownFields, so a nested network map is
+			// checked rather than assumed impossible.
+			name: "nested network.tls in service",
+			config: &TemplateAerospikeConfig{
+				Service: &AerospikeConfigSpec{
+					Value: map[string]any{
+						"network": map[string]any{
+							"tls": map[string]any{
+								"aerospike-tls": map[string]any{"cert-file": "/cert.pem"},
+							},
+						},
+					},
+				},
+			},
+			wantPath: "spec.aerospikeConfig.service.network must not contain 'tls' section",
+		},
+		{
+			name: "nested network.heartbeat.tls-port in service",
+			config: &TemplateAerospikeConfig{
+				Service: &AerospikeConfigSpec{
+					Value: map[string]any{
+						"network": map[string]any{
+							"heartbeat": map[string]any{"tls-port": 3012},
+						},
+					},
+				},
+			},
+			wantPath: "spec.aerospikeConfig.service.network.heartbeat.tls-port",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			v := &AerospikeClusterTemplateValidator{}
+			tmpl := &AerospikeClusterTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: "tls-tmpl", Namespace: "default"},
+				Spec: AerospikeClusterTemplateSpec{
+					AerospikeConfig: tc.config,
+				},
+			}
+
+			_, err := v.ValidateCreate(context.Background(), tmpl)
+			if err == nil {
+				t.Fatalf("ValidateCreate() = nil, want error for %s", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.wantPath) {
+				t.Errorf("error must name %q, got: %v", tc.wantPath, err)
+			}
+			if !strings.Contains(err.Error(), "TLS is Enterprise-only") {
+				t.Errorf("error must name the Enterprise feature, got: %v", err)
+			}
+		})
+	}
+}
+
+// TestAerospikeClusterTemplateValidate_TLSKeysRejectedOnUpdate pins that the
+// check runs on UPDATE too — editing a live template re-bases every cluster
+// that references it.
+func TestAerospikeClusterTemplateValidate_TLSKeysRejectedOnUpdate(t *testing.T) {
+	v := &AerospikeClusterTemplateValidator{}
+	oldTmpl := &AerospikeClusterTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "tls-tmpl", Namespace: "default"},
+		Spec: AerospikeClusterTemplateSpec{
+			AerospikeConfig: &TemplateAerospikeConfig{
+				Service: &AerospikeConfigSpec{
+					Value: map[string]any{"proto-fd-max": 15000},
+				},
+			},
+		},
+	}
+	newTmpl := oldTmpl.DeepCopy()
+	newTmpl.Spec.AerospikeConfig.Service.Value["tls-port"] = 4333
+
+	_, err := v.ValidateUpdate(context.Background(), oldTmpl, newTmpl)
+	if err == nil {
+		t.Fatal("ValidateUpdate() = nil, want error for tls-port added on update")
+	}
+	if !strings.Contains(err.Error(), "spec.aerospikeConfig.service.tls-port") {
+		t.Errorf("expected the offending key path in the error, got: %v", err)
+	}
+}
+
+// TestAerospikeClusterTemplateValidate_NonTLSKeysAccepted is the
+// over-rejection guard: ordinary CE template defaults must still pass.
+func TestAerospikeClusterTemplateValidate_NonTLSKeysAccepted(t *testing.T) {
+	v := &AerospikeClusterTemplateValidator{}
+	tmpl := &AerospikeClusterTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "plain-tmpl", Namespace: "default"},
+		Spec: AerospikeClusterTemplateSpec{
+			AerospikeConfig: &TemplateAerospikeConfig{
+				Service: &AerospikeConfigSpec{
+					Value: map[string]any{
+						"proto-fd-max":    15000,
+						"enable-security": false,
+					},
+				},
+				NamespaceDefaults: &AerospikeConfigSpec{
+					Value: map[string]any{
+						"replication-factor": 2,
+						"default-ttl":        "30d",
+					},
+				},
+			},
+		},
+	}
+
+	if _, err := v.ValidateCreate(context.Background(), tmpl); err != nil {
+		t.Errorf("ValidateCreate() = %v, want nil for plain CE template defaults", err)
+	}
+}

--- a/api/v1alpha1/webhook_test.go
+++ b/api/v1alpha1/webhook_test.go
@@ -7097,3 +7097,414 @@ func TestValidate_CEImageVersionEnforcement(t *testing.T) {
 		})
 	}
 }
+
+// --- CE network-TLS rejection tests ---
+//
+// The pre-existing CE TLS check looked only at the top-level
+// aerospikeConfig["tls"] key. Real Aerospike TLS lives inside the network
+// stanza — `network { tls <name> { ... } }` plus tls-port / tls-name /
+// tls-authenticate-client on each of service, heartbeat and fabric — which is
+// what the Aerospike documentation tells users to write. configgen renders any
+// sub-map under `network` verbatim, so an unchecked stanza reached
+// aerospike.conf and the CE asd process refused to start: permanent
+// CrashLoopBackOff, no admission error naming the Enterprise feature, and on a
+// live cluster the config-hash change rolled every pod into it batch by batch.
+
+func TestValidate_NetworkTLSRejected(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+
+	tests := []struct {
+		name    string
+		network map[string]any
+		// wantPath is the key path the admission error must name so an operator
+		// can find and delete the offending key.
+		wantPath string
+	}{
+		{
+			name: "network.tls certificate stanza",
+			network: map[string]any{
+				"tls": map[string]any{
+					"aerospike-tls": map[string]any{
+						"cert-file": "/etc/aerospike/cert.pem",
+						"key-file":  "/etc/aerospike/key.pem",
+					},
+				},
+			},
+			wantPath: "aerospikeConfig.network must not contain 'tls' section",
+		},
+		{
+			// Presence of the key is enough — a nil value still says the user
+			// intended TLS, and configgen would render an empty stanza.
+			name:     "network.tls with a nil value",
+			network:  map[string]any{"tls": nil},
+			wantPath: "aerospikeConfig.network must not contain 'tls' section",
+		},
+		{
+			name: "network.service.tls-port",
+			network: map[string]any{
+				"service": map[string]any{
+					"port":     3000,
+					"tls-port": 4333,
+				},
+			},
+			wantPath: "aerospikeConfig.network.service.tls-port",
+		},
+		{
+			name: "network.service.tls-authenticate-client",
+			network: map[string]any{
+				"service": map[string]any{
+					"tls-authenticate-client": "any",
+				},
+			},
+			wantPath: "aerospikeConfig.network.service.tls-authenticate-client",
+		},
+		{
+			// heartbeat has its own sub-generator (generateHeartbeatSubsection),
+			// so it needs its own case rather than sharing the service path.
+			name: "network.heartbeat.tls-port",
+			network: map[string]any{
+				"heartbeat": map[string]any{
+					"mode":     "mesh",
+					"tls-port": 3012,
+				},
+			},
+			wantPath: "aerospikeConfig.network.heartbeat.tls-port",
+		},
+		{
+			name: "network.heartbeat.tls-name",
+			network: map[string]any{
+				"heartbeat": map[string]any{
+					"mode":     "mesh",
+					"tls-name": "aerospike-tls",
+				},
+			},
+			wantPath: "aerospikeConfig.network.heartbeat.tls-name",
+		},
+		{
+			name: "network.fabric.tls-port",
+			network: map[string]any{
+				"fabric": map[string]any{
+					"port":     3001,
+					"tls-port": 3011,
+				},
+			},
+			wantPath: "aerospikeConfig.network.fabric.tls-port",
+		},
+		{
+			name: "network.fabric.tls-name",
+			network: map[string]any{
+				"fabric": map[string]any{
+					"tls-name": "aerospike-tls",
+				},
+			},
+			wantPath: "aerospikeConfig.network.fabric.tls-name",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cluster := &AerospikeCluster{
+				Spec: AerospikeClusterSpec{
+					Size:  3,
+					Image: "aerospike:ce-8.1.1.1",
+					AerospikeConfig: &AerospikeConfigSpec{
+						Value: map[string]any{"network": tc.network},
+					},
+				},
+			}
+
+			_, err := v.validate(cluster)
+			if err == nil {
+				t.Fatalf("validate() = nil, want error for %s", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.wantPath) {
+				t.Errorf("error must name the offending key path %q, got: %v", tc.wantPath, err)
+			}
+			// Every CE rejection names the Enterprise feature (goal 3-5), so an
+			// operator can tell "not supported here" from "you typed it wrong".
+			if !strings.Contains(err.Error(), "TLS is Enterprise-only") {
+				t.Errorf("error must name the Enterprise feature, got: %v", err)
+			}
+		})
+	}
+}
+
+// TestValidate_NetworkTLSRejectedAcrossAllEndpointsAtOnce pins that a full TLS
+// configuration — the shape a user copies out of the Aerospike docs — is
+// reported key by key rather than only at the first hit, so one admission
+// round-trip tells the operator everything to remove.
+func TestValidate_NetworkTLSRejectedAcrossAllEndpointsAtOnce(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+	cluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:  3,
+			Image: "aerospike:ce-8.1.1.1",
+			AerospikeConfig: &AerospikeConfigSpec{
+				Value: map[string]any{
+					"network": map[string]any{
+						"tls": map[string]any{
+							"aerospike-tls": map[string]any{"cert-file": "/cert.pem"},
+						},
+						"service": map[string]any{
+							"port":     3000,
+							"tls-port": 4333,
+							"tls-name": "aerospike-tls",
+						},
+						"heartbeat": map[string]any{
+							"mode":     "mesh",
+							"tls-port": 3012,
+						},
+						"fabric": map[string]any{
+							"tls-port": 3011,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := v.validate(cluster)
+	if err == nil {
+		t.Fatal("validate() = nil, want error for a full network TLS configuration")
+	}
+
+	wantPaths := []string{
+		"aerospikeConfig.network must not contain 'tls' section",
+		"aerospikeConfig.network.service.tls-name",
+		"aerospikeConfig.network.service.tls-port",
+		"aerospikeConfig.network.heartbeat.tls-port",
+		"aerospikeConfig.network.fabric.tls-port",
+	}
+	for _, want := range wantPaths {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("expected %q in error, got: %v", want, err)
+		}
+	}
+}
+
+// TestValidate_NetworkNonTLSKeysAccepted is the over-rejection guard: an
+// ordinary CE network stanza must still pass. Without this the tls- prefix
+// match could quietly reject valid configurations.
+func TestValidate_NetworkNonTLSKeysAccepted(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+	cluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:  3,
+			Image: "aerospike:ce-8.1.1.1",
+			AerospikeConfig: &AerospikeConfigSpec{
+				Value: map[string]any{
+					"network": map[string]any{
+						"service": map[string]any{
+							"port":           3000,
+							"access-address": "10.0.0.1",
+							"access-port":    3000,
+						},
+						"heartbeat": map[string]any{
+							"mode":     "mesh",
+							"port":     3002,
+							"interval": 150,
+							"timeout":  10,
+						},
+						"fabric": map[string]any{
+							"port":             3001,
+							"channel-bulk-fds": 2,
+						},
+						"info": map[string]any{
+							"port": 3003,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if _, err := v.validate(cluster); err != nil {
+		t.Errorf("validate() = %v, want nil for a plain CE network stanza", err)
+	}
+}
+
+// TestValidateUpdate_NetworkTLSRejected pins that the new check runs on UPDATE
+// as well as CREATE. This is the path that matters most: adding TLS to a live
+// cluster changes the config hash, so an admitted edit would roll every pod
+// into a crash loop one batch at a time. ValidateUpdate funnels into the same
+// validateWithCtx -> validate() chain as ValidateCreate, and this test pins
+// that it stays that way.
+func TestValidateUpdate_NetworkTLSRejected(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+
+	oldCluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:  3,
+			Image: "aerospike:ce-8.1.1.1",
+			AerospikeConfig: &AerospikeConfigSpec{
+				Value: map[string]any{
+					"network": map[string]any{
+						"heartbeat": map[string]any{"mode": "mesh", "port": 3002},
+					},
+				},
+			},
+		},
+	}
+	newCluster := oldCluster.DeepCopy()
+	newCluster.Spec.AerospikeConfig.Value["network"] = map[string]any{
+		"heartbeat": map[string]any{
+			"mode":     "mesh",
+			"port":     3002,
+			"tls-port": 3012,
+			"tls-name": "aerospike-tls",
+		},
+	}
+
+	_, err := v.ValidateUpdate(context.Background(), oldCluster, newCluster)
+	if err == nil {
+		t.Fatal("ValidateUpdate() = nil, want error for network TLS added on update")
+	}
+	if !strings.Contains(err.Error(), "aerospikeConfig.network.heartbeat.tls-port") {
+		t.Errorf("expected the offending key path in the error, got: %v", err)
+	}
+}
+
+// TestValidate_PerRackNetworkTLSRejected covers the per-rack bypass route: a
+// rack's aerospikeConfig is DeepMerged into the effective config and rendered
+// into that rack's ConfigMap, so it must be held to the same CE constraints as
+// the cluster-level config.
+func TestValidate_PerRackNetworkTLSRejected(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+	cluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:  3,
+			Image: "aerospike:ce-8.1.1.1",
+			RackConfig: &RackConfig{
+				Racks: []Rack{
+					{
+						ID: 1,
+						AerospikeConfig: &AerospikeConfigSpec{
+							Value: map[string]any{
+								"network": map[string]any{
+									"service": map[string]any{"tls-port": 4333},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := v.validate(cluster)
+	if err == nil {
+		t.Fatal("validate() = nil, want error for network TLS in a per-rack config")
+	}
+	if !strings.Contains(err.Error(), "aerospikeConfig.network.service.tls-port") {
+		t.Errorf("expected the offending key path in the error, got: %v", err)
+	}
+}
+
+// TestValidate_OverridesTLSKeysRejected covers the templated-bypass route for
+// per-endpoint TLS keys: spec.overrides.aerospikeConfig.{service,
+// namespaceDefaults} are merged into the cluster's effective config, so a
+// tls-* key there reaches aerospike.conf exactly like a cluster-level one.
+func TestValidate_OverridesTLSKeysRejected(t *testing.T) {
+	tests := []struct {
+		name      string
+		overrides *AerospikeClusterTemplateSpec
+		wantPath  string
+	}{
+		{
+			name: "tls-port in overrides service",
+			overrides: &AerospikeClusterTemplateSpec{
+				AerospikeConfig: &TemplateAerospikeConfig{
+					Service: &AerospikeConfigSpec{
+						Value: map[string]any{"tls-port": 4333},
+					},
+				},
+			},
+			wantPath: "spec.overrides.aerospikeConfig.service.tls-port",
+		},
+		{
+			name: "tls-name in overrides namespaceDefaults",
+			overrides: &AerospikeClusterTemplateSpec{
+				AerospikeConfig: &TemplateAerospikeConfig{
+					NamespaceDefaults: &AerospikeConfigSpec{
+						Value: map[string]any{"tls-name": "aerospike-tls"},
+					},
+				},
+			},
+			wantPath: "spec.overrides.aerospikeConfig.namespaceDefaults.tls-name",
+		},
+		{
+			name: "nested network.tls in overrides service",
+			overrides: &AerospikeClusterTemplateSpec{
+				AerospikeConfig: &TemplateAerospikeConfig{
+					Service: &AerospikeConfigSpec{
+						Value: map[string]any{
+							"network": map[string]any{
+								"tls": map[string]any{"aerospike-tls": map[string]any{}},
+							},
+						},
+					},
+				},
+			},
+			wantPath: "spec.overrides.aerospikeConfig.service.network must not contain 'tls' section",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			v := &AerospikeClusterValidator{}
+			cluster := &AerospikeCluster{
+				Spec: AerospikeClusterSpec{
+					Size:        3,
+					Image:       "aerospike:ce-8.1.1.1",
+					TemplateRef: &TemplateRef{Name: "prod"},
+					Overrides:   tc.overrides,
+				},
+			}
+
+			_, err := v.validate(cluster)
+			if err == nil {
+				t.Fatalf("validate() = nil, want error for %s", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.wantPath) {
+				t.Errorf("error must name %q, got: %v", tc.wantPath, err)
+			}
+			if !strings.Contains(err.Error(), "TLS is Enterprise-only") {
+				t.Errorf("error must name the Enterprise feature, got: %v", err)
+			}
+		})
+	}
+}
+
+// TestValidate_OverridesNonTLSKeysAccepted is the over-rejection guard for the
+// overrides path.
+func TestValidate_OverridesNonTLSKeysAccepted(t *testing.T) {
+	v := &AerospikeClusterValidator{}
+	cluster := &AerospikeCluster{
+		Spec: AerospikeClusterSpec{
+			Size:        3,
+			Image:       "aerospike:ce-8.1.1.1",
+			TemplateRef: &TemplateRef{Name: "prod"},
+			Overrides: &AerospikeClusterTemplateSpec{
+				AerospikeConfig: &TemplateAerospikeConfig{
+					Service: &AerospikeConfigSpec{
+						Value: map[string]any{
+							"proto-fd-max":       15000,
+							"enable-security":    false,
+							"transaction-max-ms": 1000,
+						},
+					},
+					NamespaceDefaults: &AerospikeConfigSpec{
+						Value: map[string]any{
+							"replication-factor": 2,
+							"default-ttl":        "30d",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if _, err := v.validate(cluster); err != nil {
+		t.Errorf("validate() = %v, want nil for plain CE overrides", err)
+	}
+}

--- a/internal/template/resolver.go
+++ b/internal/template/resolver.go
@@ -19,6 +19,7 @@ package template
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -99,10 +100,67 @@ func isEnterpriseTag(image string) bool {
 	return strings.HasPrefix(tagLower, "ee-") || strings.HasPrefix(tagLower, "ent-")
 }
 
+// tlsKeyPrefixCE is the prefix shared by every per-endpoint TLS key Aerospike
+// accepts inside a network sub-stanza (tls-port, tls-name,
+// tls-authenticate-client, ...). No CE configuration key starts with it.
+// Mirrors api/v1alpha1.tlsKeyPrefix — duplicated to keep this file's
+// package-local-mirror convention.
+const tlsKeyPrefixCE = "tls-"
+
+// tlsNetworkSubsectionsCE lists the network sub-stanzas that accept
+// per-endpoint TLS keys. Mirrors api/v1alpha1.tlsNetworkSubsections.
+var tlsNetworkSubsectionsCE = []string{"service", "heartbeat", "fabric"}
+
+// validateMergedNetworkTLSCE rejects Enterprise-only TLS configuration inside
+// the merged config's network stanza: the `network { tls <name> { ... } }`
+// definition and per-endpoint tls-* keys under service / heartbeat / fabric.
+//
+// This is the post-merge half of the check — the merged map is what configgen
+// actually consumes, and a template default combined with a cluster override
+// can produce a TLS stanza that neither input carried on its own. Mirrors
+// api/v1alpha1.validateNetworkTLSCE; see that function for why the top-level
+// `tls` key alone does not cover the TLS surface.
+func validateMergedNetworkTLSCE(config map[string]any) []string {
+	netCfg, ok := config["network"].(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	var errs []string
+
+	if _, exists := netCfg["tls"]; exists {
+		errs = append(errs,
+			"merged aerospikeConfig.network must not contain 'tls' section (TLS is Enterprise-only)")
+	}
+
+	for _, subsection := range tlsNetworkSubsectionsCE {
+		subMap, ok := netCfg[subsection].(map[string]any)
+		if !ok {
+			continue
+		}
+		// Sorted for a deterministic message: map iteration order is random and
+		// a stanza can carry several tls-* keys at once.
+		var tlsKeys []string
+		for key := range subMap {
+			if strings.HasPrefix(key, tlsKeyPrefixCE) {
+				tlsKeys = append(tlsKeys, key)
+			}
+		}
+		slices.Sort(tlsKeys)
+		for _, key := range tlsKeys {
+			errs = append(errs, fmt.Sprintf(
+				"merged aerospikeConfig.network.%s.%s is not allowed in CE edition (TLS is Enterprise-only)",
+				subsection, key))
+		}
+	}
+
+	return errs
+}
+
 // validateMergedConfigCE reapplies the CE-specific aerospikeConfig checks
-// (xdr/tls absent, no enterprise security sub-keys, no enterprise namespace
-// keys) on the materialised cluster config map. Mirrors the CE checks
-// performed by the cluster webhook on the raw aerospikeConfig.
+// (xdr/tls absent — including network TLS, no enterprise security sub-keys, no
+// enterprise namespace keys) on the materialised cluster config map. Mirrors
+// the CE checks performed by the cluster webhook on the raw aerospikeConfig.
 func validateMergedConfigCE(config map[string]any) []string {
 	if config == nil {
 		return nil
@@ -115,6 +173,7 @@ func validateMergedConfigCE(config map[string]any) []string {
 	if _, exists := config["tls"]; exists {
 		errs = append(errs, "merged aerospikeConfig must not contain 'tls' section (TLS is Enterprise-only)")
 	}
+	errs = append(errs, validateMergedNetworkTLSCE(config)...)
 	if secSection, exists := config["security"]; exists {
 		if secMap, ok := secSection.(map[string]any); ok {
 			for enterpriseKey, reason := range enterpriseOnlySecurityKeysCE {

--- a/internal/template/resolver_test.go
+++ b/internal/template/resolver_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package template
 
 import (
+	"strings"
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -871,5 +872,101 @@ func TestApplyAerospikeConfig_RefusesNonMapService(t *testing.T) {
 	// Make sure we did NOT overwrite the user's payload with the template merge.
 	if got, ok := cluster.Spec.AerospikeConfig.Value["service"].(string); !ok || got != "this-should-be-a-map" {
 		t.Errorf("expected original service value preserved, got %v", cluster.Spec.AerospikeConfig.Value["service"])
+	}
+}
+
+// --- post-merge CE network-TLS re-validation ---
+
+// TestValidateMergedSpecCE_RejectsNetworkTLS covers the post-merge half of the
+// network-TLS check. The merged map is what configgen actually consumes, and a
+// template default combined with a cluster override can produce a TLS stanza
+// that neither input carried on its own — so the check has to run here as well
+// as at admission time.
+func TestValidateMergedSpecCE_RejectsNetworkTLS(t *testing.T) {
+	tests := []struct {
+		name     string
+		network  map[string]any
+		wantPath string
+	}{
+		{
+			name: "network.tls certificate stanza",
+			network: map[string]any{
+				"tls": map[string]any{
+					"aerospike-tls": map[string]any{"cert-file": "/cert.pem"},
+				},
+			},
+			wantPath: "merged aerospikeConfig.network must not contain 'tls' section",
+		},
+		{
+			name:     "network.service.tls-port",
+			network:  map[string]any{"service": map[string]any{"tls-port": 4333}},
+			wantPath: "merged aerospikeConfig.network.service.tls-port",
+		},
+		{
+			name: "network.heartbeat.tls-name",
+			network: map[string]any{
+				"heartbeat": map[string]any{"mode": "mesh", "tls-name": "aerospike-tls"},
+			},
+			wantPath: "merged aerospikeConfig.network.heartbeat.tls-name",
+		},
+		{
+			name:     "network.fabric.tls-port",
+			network:  map[string]any{"fabric": map[string]any{"tls-port": 3011}},
+			wantPath: "merged aerospikeConfig.network.fabric.tls-port",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			spec := &ackov1alpha1.AerospikeClusterSpec{
+				Size:  3,
+				Image: testImageCE8,
+				AerospikeConfig: &ackov1alpha1.AerospikeConfigSpec{
+					Value: map[string]any{"network": tc.network},
+				},
+			}
+
+			errs := validateMergedSpecCE(spec)
+			if len(errs) == 0 {
+				t.Fatalf("validateMergedSpecCE() = no errors, want one for %s", tc.name)
+			}
+			joined := strings.Join(errs, "; ")
+			if !strings.Contains(joined, tc.wantPath) {
+				t.Errorf("errors must name %q, got: %v", tc.wantPath, errs)
+			}
+			if !strings.Contains(joined, "TLS is Enterprise-only") {
+				t.Errorf("errors must name the Enterprise feature, got: %v", errs)
+			}
+		})
+	}
+}
+
+// TestValidateMergedSpecCE_AcceptsPlainNetworkStanza is the over-rejection
+// guard for the merged path: an ordinary CE network stanza must produce no
+// errors.
+func TestValidateMergedSpecCE_AcceptsPlainNetworkStanza(t *testing.T) {
+	spec := &ackov1alpha1.AerospikeClusterSpec{
+		Size:  3,
+		Image: testImageCE8,
+		AerospikeConfig: &ackov1alpha1.AerospikeConfigSpec{
+			Value: map[string]any{
+				"network": map[string]any{
+					"service": map[string]any{
+						"port":           3000,
+						"access-address": "10.0.0.1",
+					},
+					"heartbeat": map[string]any{
+						"mode":     "mesh",
+						"port":     3002,
+						"interval": 150,
+					},
+					"fabric": map[string]any{"port": 3001},
+				},
+			},
+		},
+	}
+
+	if errs := validateMergedSpecCE(spec); len(errs) > 0 {
+		t.Errorf("unexpected errors for a plain CE network stanza: %v", errs)
 	}
 }


### PR DESCRIPTION
## Problem

All three CE validation layers tested only the **top level** `config["tls"]`:

- `api/v1alpha1/aerospikecluster_webhook.go:715` — `validateAerospikeConfig`
- `api/v1alpha1/aerospikeclustertemplate_webhook.go:229` — `validateTemplateConfigBannedKeys`
- `internal/template/resolver.go:115` — `validateMergedConfigCE`

That is not where Aerospike TLS lives. The form the Aerospike documentation tells a user to write is:

```
network {
    tls aerospike-tls { cert-file ...; key-file ...; ca-file ... }
    service   { port 3000; tls-port 4333; tls-name aerospike-tls }
    heartbeat { mode mesh;  tls-port 3012; tls-name aerospike-tls }
    fabric    { port 3001;  tls-port 3011; tls-name aerospike-tls }
}
```

None of that was checked by any layer, and configgen passes it straight through: `generateNetworkSection` renders **any** sub-map under `network` verbatim as a nested stanza (`internal/configgen/network.go:31-36`) and scalar `tls-*` keys go through `writeMapEntries` unfiltered.

So a user writes TLS where the docs say to write it, **admission passes**, and the CE `asd` process rejects the Enterprise-only stanza at startup: permanent CrashLoopBackOff with no admission error naming the Enterprise feature. This is precisely the failure the CE validation exists to prevent.

On a live cluster it is worse than a bad create. The edit arrives as an `aerospikeConfig` change, so it bumps the config hash, and the rolling restart carries every pod into the crash loop one batch at a time until the cluster is down.

Two further bypass routes shared the same gap, because they reuse the same two functions: per-rack `aerospikeConfig` (`aerospikecluster_webhook.go:1485` calls `validateAerospikeConfig`) and `spec.overrides.aerospikeConfig.{service,namespaceDefaults}` (`:686-698` call `validateTemplateConfigBannedKeys`).

## Fix

Every layer now rejects:

1. a `tls` key under `network` — presence is enough, the value shape is irrelevant;
2. any key matching `tls-*` under `network.service`, `network.heartbeat`, `network.fabric`.

The prefix match covers the whole family (`tls-port`, `tls-name`, `tls-authenticate-client`, `tls-mutual-authentication`, …) and is safe because no Community Edition configuration key starts with `tls-`.

New `validateNetworkTLSCE(fieldPath, config)` in `aerospikecluster_webhook.go`, wired into `validateAerospikeConfig` (which is also the per-rack validator) and into `validateTemplateConfigBannedKeys` (which is also the overrides validator). `internal/template/resolver.go` gets `validateMergedNetworkTLSCE`, a package-local mirror following that file's existing convention (`enterpriseOnlySecurityKeysCE`, `imageTag`, `isEnterpriseTag` are all mirrored the same way).

`validateTemplateConfigBannedKeys` additionally rejects `tls-*` keys directly on the map it is handed, since a template's `service` / `namespaceDefaults` map is merged into every cluster that references the template.

**Message wording** reuses the established shapes and names the Enterprise feature (goal 3-5), matching the XDR rejection at `:707` and the multicast rejection at `:809`:

```
aerospikeConfig.network must not contain 'tls' section (TLS is Enterprise-only)
aerospikeConfig.network.heartbeat.tls-port is not allowed in CE edition (TLS is Enterprise-only)
merged aerospikeConfig.network.service.tls-name is not allowed in CE edition (TLS is Enterprise-only)
spec.aerospikeConfig.service.tls-port is not allowed in CE edition (TLS is Enterprise-only)
```

The full key path is always reported so an operator can find and delete the key. Keys are sorted before reporting — map iteration order is random and a stanza can carry several `tls-*` keys at once, so an unsorted message would be unstable across admission attempts.

## Verification

**The check runs on UPDATE, not just CREATE.** `ValidateUpdate` ends with `return v.validateWithCtx(ctx, cluster)` (`aerospikecluster_webhook.go:352`), the same chain `ValidateCreate` uses. `TestValidateUpdate_NetworkTLSRejected` and `TestAerospikeClusterTemplateValidate_TLSKeysRejectedOnUpdate` pin that it stays that way.

**New tests** (table-driven, matching the existing suite's style):

| Test | Covers |
| --- | --- |
| `TestValidate_NetworkTLSRejected` | 8 cases: `network.tls` (map + nil value), `tls-port`/`tls-authenticate-client` on service, `tls-port`/`tls-name` on heartbeat, `tls-port`/`tls-name` on fabric |
| `TestValidate_NetworkTLSRejectedAcrossAllEndpointsAtOnce` | a full docs-shaped TLS config reports every key, not just the first |
| `TestValidate_NetworkNonTLSKeysAccepted` | over-rejection guard: plain CE `network` with `port`, `access-address`, `access-port`, `mode`, `interval`, `timeout`, `channel-bulk-fds`, `info` must PASS |
| `TestValidateUpdate_NetworkTLSRejected` | update path |
| `TestValidate_PerRackNetworkTLSRejected` | `rackConfig.racks[].aerospikeConfig` bypass route |
| `TestValidate_OverridesTLSKeysRejected` / `..._OverridesNonTLSKeysAccepted` | `spec.overrides` bypass route + its over-rejection guard |
| `TestAerospikeClusterTemplateValidate_TLSKeysRejected` | 5 cases on the template's own `service` / `namespaceDefaults`, incl. nested `network.tls` and `network.heartbeat.tls-port` |
| `TestAerospikeClusterTemplateValidate_TLSKeysRejectedOnUpdate` / `..._NonTLSKeysAccepted` | template update path + over-rejection guard |
| `TestValidateMergedSpecCE_RejectsNetworkTLS` / `..._AcceptsPlainNetworkStanza` | post-merge layer, 4 reject cases + accept case |

Each rejection case asserts both the exact offending key path **and** that the message names the Enterprise feature.

**Every new rejection test fails without the source fix.** With `aerospikecluster_webhook.go`, `aerospikeclustertemplate_webhook.go` and `resolver.go` stashed:

```
--- FAIL: TestAerospikeClusterTemplateValidate_TLSKeysRejected (0.00s)
--- FAIL: TestAerospikeClusterTemplateValidate_TLSKeysRejectedOnUpdate (0.00s)
--- FAIL: TestValidate_NetworkTLSRejected (0.00s)
--- FAIL: TestValidate_NetworkTLSRejectedAcrossAllEndpointsAtOnce (0.00s)
--- FAIL: TestValidateUpdate_NetworkTLSRejected (0.00s)
--- FAIL: TestValidate_PerRackNetworkTLSRejected (0.00s)
--- FAIL: TestValidate_OverridesTLSKeysRejected (0.00s)
FAIL  .../api/v1alpha1  1.143s
--- FAIL: TestValidateMergedSpecCE_RejectsNetworkTLS (0.00s)
FAIL  .../internal/template  0.605s
```

| Command | Result |
| --- | --- |
| `go build ./...` | exit 0, no output |
| `go vet ./...` | exit 0, no output |
| `gofmt -l .` | empty |
| `go test ./api/... ./internal/template/...` | `ok .../api/v1alpha1 0.792s`, `ok .../internal/template 0.421s` |
| `go test ./...` | all packages `ok` / no test files; zero failures |

`golangci-lint` was not run — `.custom-gcl.yml` requires a custom build with a `logcheck` plugin that is not available here.

## Risk

- **This rejects configurations that were previously admitted.** Any existing `AerospikeCluster` carrying `network.tls` or `network.*.tls-*` will now fail on its next update. Those clusters are already broken (their pods cannot start on CE), so failing admission is strictly better than the current silent CrashLoopBackOff — but it is a behaviour change for anyone who has such an object stored, and an operator editing an unrelated field on one will now see a TLS error. Worth a release note.
- **The `tls-` prefix match is broad by design.** It rejects any future `tls-*` key without needing a list update. Verified against the CE configuration reference that no legitimate CE key starts with `tls-`; the accept-guard tests exist to catch it if that ever changes.
- **`spec.aerospikeConfig.service` `tls-*` keys are rejected too.** Aerospike puts these under `network.service`, not the top-level `service` stanza, so a `tls-port` there is invalid in *any* edition. Rejecting it with a "TLS is Enterprise-only" message is accurate about the feature and catches a plausible misplacement, but the message does not say "you also put it in the wrong stanza".
- **The template's typed `network` field cannot express this.** `TemplateNetworkConfig` exposes only `Heartbeat` (`aerospikeclustertemplate_types.go:54-59`), so `network.tls` is not reachable through a template's own `aerospikeConfig.network` today. The nested-`network` check on `validateTemplateConfigBannedKeys` is defensive: those maps are `PreserveUnknownFields`, and the post-merge layer catches whatever the merge produces regardless.
- **Not covered:** configgen is unchanged. It still renders whatever it is given, so validation remains the only barrier — a code path that reaches `generateNetworkSection` without passing a webhook (`failurePolicy: Ignore`, a future internal caller) would still emit the stanza. The post-merge `validateMergedConfigCE` check is the defence-in-depth layer for the template path specifically; there is no equivalent last-mile check inside configgen itself.
- **Not covered:** no e2e test attempts a TLS config against a real CE image. Coverage here is unit-level only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
