### PR TITLE
fix(controller): reclaim orphaned PVCs keyed on observed rack state

### DIFF
--- a/charts/aerospike-ce-kubernetes-operator/templates/clusterrole-manager.yaml
+++ b/charts/aerospike-ce-kubernetes-operator/templates/clusterrole-manager.yaml
@@ -118,6 +118,7 @@ rules:
   - apiGroups:
       - monitoring.coreos.com
     resources:
+      - prometheusrules
       - servicemonitors
     verbs:
       - create

--- a/internal/controller/reconciler_monitoring.go
+++ b/internal/controller/reconciler_monitoring.go
@@ -33,6 +33,18 @@ var prometheusRuleGVK = schema.GroupVersionKind{
 	Kind:    "PrometheusRule",
 }
 
+// reconcileMonitoring reconciles the metrics Service plus the two optional
+// Prometheus-Operator resources.
+//
+// ServiceMonitor and PrometheusRule are best-effort: the CRDs may not be
+// installed, and the operator's ClusterRole may not grant access to them (a
+// chart install that predates the RBAC entry, or an RBAC-only install trimmed
+// by the cluster admin). Both of those conditions must degrade the individual
+// feature, never fail the reconcile — an error returned from here reaches
+// handleReconcileError, and after maxFailedReconciles consecutive failures the
+// circuit breaker freezes scale, rolling restart, config and ACL
+// reconciliation for the whole cluster. Losing the entire control loop over an
+// optional monitoring integration is never the right trade.
 func (r *AerospikeClusterReconciler) reconcileMonitoring(
 	ctx context.Context,
 	cluster *ackov1alpha1.AerospikeCluster,
@@ -53,10 +65,15 @@ func (r *AerospikeClusterReconciler) reconcileMonitoring(
 		cluster.Spec.Monitoring.ServiceMonitor.Enabled
 
 	if err := r.reconcileServiceMonitor(ctx, cluster, smEnabled); err != nil {
-		// Only log and skip if the CRD is not installed; propagate other errors.
-		if meta.IsNoMatchError(err) {
+		// Only log and skip if the CRD is not installed or the operator is not
+		// allowed to touch it; propagate other errors.
+		switch {
+		case meta.IsNoMatchError(err):
 			log.Info("ServiceMonitor CRD not installed, skipping")
-		} else {
+		case errors.IsForbidden(err):
+			log.Info("ServiceMonitor access denied by RBAC, skipping",
+				"name", utils.ServiceMonitorName(cluster.Name), "error", err.Error())
+		default:
 			return fmt.Errorf("reconciling ServiceMonitor: %w", err)
 		}
 	}
@@ -67,9 +84,13 @@ func (r *AerospikeClusterReconciler) reconcileMonitoring(
 		cluster.Spec.Monitoring.PrometheusRule.Enabled
 
 	if err := r.reconcilePrometheusRule(ctx, cluster, prEnabled); err != nil {
-		if meta.IsNoMatchError(err) {
+		switch {
+		case meta.IsNoMatchError(err):
 			log.Info("PrometheusRule CRD not installed, skipping")
-		} else {
+		case errors.IsForbidden(err):
+			log.Info("PrometheusRule access denied by RBAC, skipping",
+				"name", utils.PrometheusRuleName(cluster.Name), "error", err.Error())
+		default:
 			return fmt.Errorf("reconciling PrometheusRule: %w", err)
 		}
 	}

--- a/internal/controller/reconciler_monitoring_unit_test.go
+++ b/internal/controller/reconciler_monitoring_unit_test.go
@@ -10,6 +10,8 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -356,5 +358,145 @@ func TestReconcileMetricsService_CleanupGetErrorNotSwallowed(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "getting metrics service") {
 		t.Errorf("expected wrapped cleanup Get error, got: %v", err)
+	}
+}
+
+// monitoringResourceFor returns the monitoring.coreos.com resource name for an
+// unstructured object, or "" if the object is not one of the two optional
+// Prometheus-Operator kinds.
+func monitoringResourceFor(obj client.Object) string {
+	u, ok := obj.(*unstructured.Unstructured)
+	if !ok {
+		return ""
+	}
+	gvk := u.GroupVersionKind()
+	if gvk.Group != "monitoring.coreos.com" {
+		return ""
+	}
+	switch gvk.Kind {
+	case "ServiceMonitor":
+		return "servicemonitors"
+	case "PrometheusRule":
+		return "prometheusrules"
+	}
+	return ""
+}
+
+// monitoringGetErrClient builds a fake client whose Get fails for every
+// monitoring.coreos.com object with the error errFor produces for that
+// resource, while serving every other Get normally.
+func monitoringGetErrClient(scheme *runtime.Scheme, errFor func(resource string) error) client.WithWatch {
+	base := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	return interceptor.NewClient(base, interceptor.Funcs{
+		Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey,
+			obj client.Object, opts ...client.GetOption) error {
+			if resource := monitoringResourceFor(obj); resource != "" {
+				return errFor(resource)
+			}
+			return c.Get(ctx, key, obj, opts...)
+		},
+	})
+}
+
+func forbiddenMonitoringErr(resource string) error {
+	return apierrors.NewForbidden(
+		schema.GroupResource{Group: "monitoring.coreos.com", Resource: resource},
+		"demo",
+		errors.New(`clusterrole "acko-manager" does not grant this resource`),
+	)
+}
+
+// TestReconcileMonitoring_ForbiddenDegradesFeature is the regression test for
+// the RBAC-403 cluster freeze. reconcilePrometheusRule issues a Get on *every*
+// reconcile — including when the feature is disabled, where the Get exists only
+// to clean up a stale object. A chart install whose manager ClusterRole omits
+// monitoring.coreos.com/prometheusrules therefore got a 403 on every pass, and
+// the error funnelled into handleReconcileError until the circuit breaker
+// wedged the cluster in BackoffActive: no scale, no rolling restart, no config
+// change, no ACL sync. A 403 on an optional resource must degrade that one
+// feature and leave the reconcile successful, exactly as a missing CRD does.
+func TestReconcileMonitoring_ForbiddenDegradesFeature(t *testing.T) {
+	tests := []struct {
+		name       string
+		monitoring *ackov1alpha1.AerospikeMonitoringSpec
+	}{
+		{
+			// The reported failure mode: the cluster asks for no monitoring at
+			// all, yet the stale-object cleanup Get still 403s.
+			name:       "monitoring not configured",
+			monitoring: nil,
+		},
+		{
+			name: "monitoring enabled, optional resources disabled",
+			monitoring: &ackov1alpha1.AerospikeMonitoringSpec{
+				Enabled:       true,
+				ExporterImage: "exporter:v1",
+				Port:          9145,
+			},
+		},
+		{
+			name: "optional resources explicitly enabled",
+			monitoring: &ackov1alpha1.AerospikeMonitoringSpec{
+				Enabled:       true,
+				ExporterImage: "exporter:v1",
+				Port:          9145,
+				ServiceMonitor: &ackov1alpha1.ServiceMonitorSpec{
+					Enabled:  true,
+					Interval: "30s",
+				},
+				PrometheusRule: &ackov1alpha1.PrometheusRuleSpec{
+					Enabled: true,
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			scheme := rollingRestartScheme(t)
+
+			cluster := &ackov1alpha1.AerospikeCluster{}
+			cluster.Name = "demo"
+			cluster.Namespace = ctrlTestNamespace
+			cluster.Spec.Monitoring = tc.monitoring
+
+			r := &AerospikeClusterReconciler{
+				Client: monitoringGetErrClient(scheme, forbiddenMonitoringErr),
+				Scheme: scheme,
+			}
+
+			if err := r.reconcileMonitoring(context.Background(), cluster); err != nil {
+				t.Fatalf("reconcileMonitoring() = %v, want nil: a 403 on an optional "+
+					"monitoring resource must not fail the reconcile", err)
+			}
+		})
+	}
+}
+
+// TestReconcileMonitoring_UnexpectedErrorStillFailsReconcile guards the other
+// side of the fix: only "this resource is unreachable by design" errors — a
+// missing CRD or a 403 — are allowed to degrade the feature. A transient API
+// failure must still surface, or a real outage would be silently swallowed.
+func TestReconcileMonitoring_UnexpectedErrorStillFailsReconcile(t *testing.T) {
+	scheme := rollingRestartScheme(t)
+
+	cluster := &ackov1alpha1.AerospikeCluster{}
+	cluster.Name = "demo"
+	cluster.Namespace = ctrlTestNamespace
+
+	r := &AerospikeClusterReconciler{
+		Client: monitoringGetErrClient(scheme, func(string) error {
+			return apierrors.NewInternalError(errMonitoringGetFailure)
+		}),
+		Scheme: scheme,
+	}
+
+	err := r.reconcileMonitoring(context.Background(), cluster)
+	if err == nil {
+		t.Fatal("reconcileMonitoring() = nil, want error for a non-403 API failure")
+	}
+	if !strings.Contains(err.Error(), "reconciling ServiceMonitor") {
+		t.Errorf("expected the ServiceMonitor error to propagate, got: %v", err)
 	}
 }

--- a/internal/controller/reconciler_pvc_reclaim_test.go
+++ b/internal/controller/reconciler_pvc_reclaim_test.go
@@ -1,0 +1,509 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/utils"
+)
+
+// --- PVC reclamation after scale-down ---
+//
+// The cleanup used to sit inside reconcileStatefulSet's `needsUpdate` branch, so
+// it ran only on the pass that performed the scale-down — the one pass on which
+// it can never succeed, because the removed pods are still terminating. On the
+// next pass the StatefulSet already read the desired size, both hashes matched,
+// and the function returned before the cleanup was reachable. With the default
+// scale-down batch size returning the whole delta, that deferred pass was the
+// only pass, so every cascadeDelete PVC leaked permanently — and because PVC
+// names are ordinal-derived, a later scale-up remounted the exact device the
+// removed node wrote.
+//
+// These tests pin both halves: reclamation now happens on the converged pass,
+// and it can never select a PVC that a live pod is using.
+
+const pvcReclaimRackID = 0
+
+func pvcReclaimCluster(cascadeDelete bool) *ackov1alpha1.AerospikeCluster {
+	return &ackov1alpha1.AerospikeCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: ctrlTestNamespace},
+		Spec: ackov1alpha1.AerospikeClusterSpec{
+			Size:    1,
+			Image:   "aerospike:ce-8.1.1.1",
+			Storage: pvcReclaimStorage(cascadeDelete),
+		},
+	}
+}
+
+func pvcReclaimStorage(cascadeDelete bool) *ackov1alpha1.AerospikeStorageSpec {
+	return &ackov1alpha1.AerospikeStorageSpec{
+		Volumes: []ackov1alpha1.VolumeSpec{
+			{
+				Name: "data",
+				Source: ackov1alpha1.VolumeSource{
+					PersistentVolume: &ackov1alpha1.PersistentVolumeSpec{Size: "10Gi"},
+				},
+				CascadeDelete: &cascadeDelete,
+			},
+		},
+	}
+}
+
+// pvcReclaimPVC builds a PVC named the way a StatefulSet names it —
+// <volume>-<stsName>-<ordinal> — carrying the cluster labels the operator
+// stamps onto VolumeClaimTemplates, so the label-scoped query matches it.
+func pvcReclaimPVC(clusterName string, ordinal int) *corev1.PersistentVolumeClaim {
+	stsName := utils.StatefulSetName(clusterName, pvcReclaimRackID)
+	return &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("data-%s-%d", stsName, ordinal),
+			Namespace: ctrlTestNamespace,
+			Labels:    utils.LabelsForCluster(clusterName),
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("10Gi"),
+				},
+			},
+		},
+	}
+}
+
+// pvcReclaimPod builds a rack pod named <stsName>-<ordinal>.
+func pvcReclaimPod(clusterName string, ordinal int) *corev1.Pod {
+	stsName := utils.StatefulSetName(clusterName, pvcReclaimRackID)
+	return pvcReclaimNamedPod(clusterName, fmt.Sprintf("%s-%d", stsName, ordinal))
+}
+
+func pvcReclaimNamedPod(clusterName, podName string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: ctrlTestNamespace,
+			Labels:    utils.LabelsForRack(clusterName, pvcReclaimRackID),
+		},
+	}
+}
+
+// pvcNames returns the sorted set of PVC names still present in the namespace.
+func pvcNames(t *testing.T, c client.Client, clusterName string) map[string]bool {
+	t.Helper()
+	present := map[string]bool{}
+	for ordinal := 0; ordinal < 6; ordinal++ {
+		pvc := pvcReclaimPVC(clusterName, ordinal)
+		err := c.Get(context.Background(),
+			types.NamespacedName{Name: pvc.Name, Namespace: pvc.Namespace},
+			&corev1.PersistentVolumeClaim{})
+		switch {
+		case err == nil:
+			present[pvc.Name] = true
+		case apierrors.IsNotFound(err):
+		default:
+			t.Fatalf("Get PVC %s: %v", pvc.Name, err)
+		}
+	}
+	return present
+}
+
+func pvcReclaimReconciler(scheme *runtime.Scheme, objs ...client.Object) *AerospikeClusterReconciler {
+	return &AerospikeClusterReconciler{
+		Client:   fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build(),
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(8),
+	}
+}
+
+// TestReconcileStatefulSet_ReclaimsOrphanedPVCsOnConvergedPass is the
+// regression test for the leak. The StatefulSet has already been scaled down to
+// 1 replica, the removed pod is gone, and both hashes match — so
+// reconcileStatefulSet takes the `!needsUpdate` early return, which is exactly
+// where the old code stopped being able to reclaim anything. The orphaned PVC
+// must be gone by the end of this pass, and the in-use one must not be.
+func TestReconcileStatefulSet_ReclaimsOrphanedPVCsOnConvergedPass(t *testing.T) {
+	scheme := rollingRestartScheme(t)
+
+	cluster := pvcReclaimCluster(true)
+	rack := &ackov1alpha1.Rack{ID: pvcReclaimRackID}
+	stsName := utils.StatefulSetName(cluster.Name, rack.ID)
+
+	const configHash = "cfg-SAME"
+	podSpecHash := computePodSpecHash(cluster, rack)
+	oneReplica := int32(1)
+
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{Name: stsName, Namespace: ctrlTestNamespace},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &oneReplica,
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						utils.ConfigHashAnnotation:  configHash,
+						utils.PodSpecHashAnnotation: podSpecHash,
+					},
+				},
+			},
+		},
+	}
+
+	r := pvcReclaimReconciler(scheme,
+		sts,
+		pvcReclaimPod(cluster.Name, 0),
+		pvcReclaimPVC(cluster.Name, 0), // in use by demo-0-0
+		pvcReclaimPVC(cluster.Name, 1), // orphaned by an earlier scale-down
+	)
+
+	deferred, err := r.reconcileStatefulSet(
+		context.Background(), cluster, rack, nil, configHash, 1)
+	if err != nil {
+		t.Fatalf("reconcileStatefulSet() error = %v", err)
+	}
+	if deferred {
+		t.Fatal("reconcileStatefulSet() deferred = true, want false on a converged rack")
+	}
+
+	present := pvcNames(t, r.Client, cluster.Name)
+	if !present[fmt.Sprintf("data-%s-0", stsName)] {
+		t.Error("PVC at ordinal 0 was deleted; it is in use by a running pod")
+	}
+	if present[fmt.Sprintf("data-%s-1", stsName)] {
+		t.Error("orphaned PVC at ordinal 1 was not reclaimed on the converged pass")
+	}
+}
+
+// TestReclaimOrphanedRackPVCs_NeverSelectsInUsePVC is the safety test. Deleting
+// a PVC that a running Aerospike node has mounted destroys that node's data, so
+// only ordinals at or above the StatefulSet's own replica count may ever be
+// considered — and never the desired rack size, which during a batched
+// scale-down is lower than the count the StatefulSet is actually running.
+func TestReclaimOrphanedRackPVCs_NeverSelectsInUsePVC(t *testing.T) {
+	tests := []struct {
+		name string
+		// specReplicas is the StatefulSet's own spec.replicas.
+		specReplicas int32
+		// podOrdinals are the pods currently observed for the rack.
+		podOrdinals []int
+		// pvcOrdinals are the PVCs that exist.
+		pvcOrdinals []int
+		// wantDeleted lists the ordinals that must be reclaimed; every other
+		// PVC in pvcOrdinals must survive.
+		wantDeleted []int
+	}{
+		{
+			name:         "fully converged rack reclaims nothing",
+			specReplicas: 3,
+			podOrdinals:  []int{0, 1, 2},
+			pvcOrdinals:  []int{0, 1, 2},
+			wantDeleted:  nil,
+		},
+		{
+			name:         "one ordinal above the replica count is reclaimed",
+			specReplicas: 2,
+			podOrdinals:  []int{0, 1},
+			pvcOrdinals:  []int{0, 1, 2},
+			wantDeleted:  []int{2},
+		},
+		{
+			name:         "several ordinals above the replica count are reclaimed",
+			specReplicas: 1,
+			podOrdinals:  []int{0},
+			pvcOrdinals:  []int{0, 1, 2, 3},
+			wantDeleted:  []int{1, 2, 3},
+		},
+		{
+			// A cluster that is entirely down still keeps every PVC below the
+			// replica count: those volumes belong to nodes that will come back.
+			name:         "no pods observed still preserves ordinals below the replica count",
+			specReplicas: 3,
+			podOrdinals:  nil,
+			pvcOrdinals:  []int{0, 1, 2, 3},
+			wantDeleted:  []int{3},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			scheme := rollingRestartScheme(t)
+			cluster := pvcReclaimCluster(true)
+			stsName := utils.StatefulSetName(cluster.Name, pvcReclaimRackID)
+
+			var objs []client.Object
+			for _, ordinal := range tc.podOrdinals {
+				objs = append(objs, pvcReclaimPod(cluster.Name, ordinal))
+			}
+			for _, ordinal := range tc.pvcOrdinals {
+				objs = append(objs, pvcReclaimPVC(cluster.Name, ordinal))
+			}
+
+			r := pvcReclaimReconciler(scheme, objs...)
+			replicas := tc.specReplicas
+			r.reclaimOrphanedRackPVCs(context.Background(), cluster,
+				pvcReclaimRackID, stsName, &replicas, cluster.Spec.Storage)
+
+			shouldBeGone := map[int]bool{}
+			for _, ordinal := range tc.wantDeleted {
+				shouldBeGone[ordinal] = true
+			}
+
+			present := pvcNames(t, r.Client, cluster.Name)
+			for _, ordinal := range tc.pvcOrdinals {
+				name := fmt.Sprintf("data-%s-%d", stsName, ordinal)
+				if shouldBeGone[ordinal] && present[name] {
+					t.Errorf("PVC %s should have been reclaimed (replicas=%d)", name, tc.specReplicas)
+				}
+				if !shouldBeGone[ordinal] && !present[name] {
+					t.Errorf("PVC %s was deleted but its ordinal is below replicas=%d", name, tc.specReplicas)
+				}
+			}
+		})
+	}
+}
+
+// TestReclaimOrphanedRackPVCs_DefersWhilePodAboveReplicaCountExists covers the
+// mid-scale-down window. The pod being removed is still terminating and still
+// has its volume mounted, so nothing may be reclaimed until it is gone.
+func TestReclaimOrphanedRackPVCs_DefersWhilePodAboveReplicaCountExists(t *testing.T) {
+	scheme := rollingRestartScheme(t)
+	cluster := pvcReclaimCluster(true)
+	stsName := utils.StatefulSetName(cluster.Name, pvcReclaimRackID)
+
+	r := pvcReclaimReconciler(scheme,
+		pvcReclaimPod(cluster.Name, 0),
+		pvcReclaimPod(cluster.Name, 1), // still terminating
+		pvcReclaimPVC(cluster.Name, 0),
+		pvcReclaimPVC(cluster.Name, 1),
+	)
+
+	replicas := int32(1)
+	r.reclaimOrphanedRackPVCs(context.Background(), cluster,
+		pvcReclaimRackID, stsName, &replicas, cluster.Spec.Storage)
+
+	present := pvcNames(t, r.Client, cluster.Name)
+	for ordinal := 0; ordinal < 2; ordinal++ {
+		name := fmt.Sprintf("data-%s-%d", stsName, ordinal)
+		if !present[name] {
+			t.Errorf("PVC %s was deleted while pod %s-1 is still terminating", name, stsName)
+		}
+	}
+}
+
+// TestReclaimOrphanedRackPVCs_DefersOnUnparseablePodName fails closed: a pod
+// whose ordinal cannot be read must never be assumed to sit below the replica
+// count. podOrdinal returns 0 for such a name, which would have read as "not an
+// orphan candidate" and allowed the deletion to proceed.
+func TestReclaimOrphanedRackPVCs_DefersOnUnparseablePodName(t *testing.T) {
+	scheme := rollingRestartScheme(t)
+	cluster := pvcReclaimCluster(true)
+	stsName := utils.StatefulSetName(cluster.Name, pvcReclaimRackID)
+
+	r := pvcReclaimReconciler(scheme,
+		pvcReclaimNamedPod(cluster.Name, stsName+"-not-a-number"),
+		pvcReclaimPVC(cluster.Name, 0),
+		pvcReclaimPVC(cluster.Name, 1),
+	)
+
+	replicas := int32(1)
+	r.reclaimOrphanedRackPVCs(context.Background(), cluster,
+		pvcReclaimRackID, stsName, &replicas, cluster.Spec.Storage)
+
+	present := pvcNames(t, r.Client, cluster.Name)
+	if !present[fmt.Sprintf("data-%s-1", stsName)] {
+		t.Error("PVC was reclaimed despite a rack pod with an unparseable ordinal")
+	}
+}
+
+// TestReclaimOrphanedRackPVCs_SkipsWhenReplicaCountUnknown guards the nil case.
+// Treating a nil spec.replicas as 0 would make every PVC in the rack an orphan
+// candidate — including every in-use one.
+func TestReclaimOrphanedRackPVCs_SkipsWhenReplicaCountUnknown(t *testing.T) {
+	scheme := rollingRestartScheme(t)
+	cluster := pvcReclaimCluster(true)
+	stsName := utils.StatefulSetName(cluster.Name, pvcReclaimRackID)
+
+	r := pvcReclaimReconciler(scheme,
+		pvcReclaimPVC(cluster.Name, 0),
+		pvcReclaimPVC(cluster.Name, 1),
+	)
+
+	r.reclaimOrphanedRackPVCs(context.Background(), cluster,
+		pvcReclaimRackID, stsName, nil, cluster.Spec.Storage)
+
+	present := pvcNames(t, r.Client, cluster.Name)
+	for ordinal := 0; ordinal < 2; ordinal++ {
+		name := fmt.Sprintf("data-%s-%d", stsName, ordinal)
+		if !present[name] {
+			t.Errorf("PVC %s was deleted with an unknown replica count", name)
+		}
+	}
+}
+
+// TestReclaimOrphanedRackPVCs_SkipsAtZeroReplicas keeps whole-rack teardown out
+// of this path: at zero replicas every ordinal is >= the replica count, and
+// deleting by ordinal would duplicate the rack-removal decision without its
+// guards.
+func TestReclaimOrphanedRackPVCs_SkipsAtZeroReplicas(t *testing.T) {
+	scheme := rollingRestartScheme(t)
+	cluster := pvcReclaimCluster(true)
+	stsName := utils.StatefulSetName(cluster.Name, pvcReclaimRackID)
+
+	r := pvcReclaimReconciler(scheme,
+		pvcReclaimPVC(cluster.Name, 0),
+		pvcReclaimPVC(cluster.Name, 1),
+	)
+
+	replicas := int32(0)
+	r.reclaimOrphanedRackPVCs(context.Background(), cluster,
+		pvcReclaimRackID, stsName, &replicas, cluster.Spec.Storage)
+
+	present := pvcNames(t, r.Client, cluster.Name)
+	for ordinal := 0; ordinal < 2; ordinal++ {
+		name := fmt.Sprintf("data-%s-%d", stsName, ordinal)
+		if !present[name] {
+			t.Errorf("PVC %s was deleted for a rack at zero replicas", name)
+		}
+	}
+}
+
+// TestReclaimOrphanedRackPVCs_NonCascadeVolumesIssueNoList pins the
+// steady-state cost. cascadeDelete defaults to false, so most clusters must not
+// pay for a pod List or a PVC List on every reconcile — the check happens before
+// either one.
+func TestReclaimOrphanedRackPVCs_NonCascadeVolumesIssueNoList(t *testing.T) {
+	scheme := rollingRestartScheme(t)
+	cluster := pvcReclaimCluster(false)
+	stsName := utils.StatefulSetName(cluster.Name, pvcReclaimRackID)
+
+	base := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(pvcReclaimPVC(cluster.Name, 0), pvcReclaimPVC(cluster.Name, 1)).
+		Build()
+
+	lists := 0
+	wrapped := interceptor.NewClient(base, interceptor.Funcs{
+		List: func(ctx context.Context, c client.WithWatch,
+			list client.ObjectList, opts ...client.ListOption) error {
+			lists++
+			return c.List(ctx, list, opts...)
+		},
+	})
+
+	r := &AerospikeClusterReconciler{
+		Client:   wrapped,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(8),
+	}
+
+	replicas := int32(1)
+	r.reclaimOrphanedRackPVCs(context.Background(), cluster,
+		pvcReclaimRackID, stsName, &replicas, cluster.Spec.Storage)
+
+	if lists != 0 {
+		t.Errorf("issued %d List call(s) for a cluster with no cascadeDelete volume, want 0", lists)
+	}
+
+	present := pvcNames(t, r.Client, cluster.Name)
+	for ordinal := 0; ordinal < 2; ordinal++ {
+		name := fmt.Sprintf("data-%s-%d", stsName, ordinal)
+		if !present[name] {
+			t.Errorf("non-cascadeDelete PVC %s was deleted", name)
+		}
+	}
+}
+
+// TestReclaimOrphanedRackPVCs_Idempotent pins that repeated passes are safe —
+// the function now runs on every reconcile, so a second call over the same state
+// must be a no-op rather than an error or a duplicate event.
+func TestReclaimOrphanedRackPVCs_Idempotent(t *testing.T) {
+	scheme := rollingRestartScheme(t)
+	cluster := pvcReclaimCluster(true)
+	stsName := utils.StatefulSetName(cluster.Name, pvcReclaimRackID)
+
+	recorder := record.NewFakeRecorder(8)
+	r := &AerospikeClusterReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+			pvcReclaimPod(cluster.Name, 0),
+			pvcReclaimPVC(cluster.Name, 0),
+			pvcReclaimPVC(cluster.Name, 1),
+		).Build(),
+		Scheme:   scheme,
+		Recorder: recorder,
+	}
+
+	replicas := int32(1)
+	for pass := 1; pass <= 3; pass++ {
+		r.reclaimOrphanedRackPVCs(context.Background(), cluster,
+			pvcReclaimRackID, stsName, &replicas, cluster.Spec.Storage)
+	}
+
+	present := pvcNames(t, r.Client, cluster.Name)
+	if !present[fmt.Sprintf("data-%s-0", stsName)] {
+		t.Error("in-use PVC at ordinal 0 was deleted")
+	}
+	if present[fmt.Sprintf("data-%s-1", stsName)] {
+		t.Error("orphaned PVC at ordinal 1 was not reclaimed")
+	}
+
+	// Exactly one cleanup event: the first pass deletes, the rest find nothing.
+	events := 0
+	for {
+		select {
+		case <-recorder.Events:
+			events++
+			continue
+		default:
+		}
+		break
+	}
+	if events != 1 {
+		t.Errorf("recorded %d events over 3 passes, want 1", events)
+	}
+}
+
+func TestRackPodOrdinal(t *testing.T) {
+	tests := []struct {
+		podName string
+		want    int
+		wantOK  bool
+	}{
+		{"demo-0-0", 0, true},
+		{"demo-0-7", 7, true},
+		{"demo-0-12", 12, true},
+		{"my-cluster-2-3", 3, true},
+		// The ordinal is the segment after the LAST dash, so a leading '-' is
+		// always consumed as the separator and the parsed value can never be
+		// negative. Pinned here because the reclamation guard's lower bound
+		// depends on it.
+		{"demo-0--1", 1, true},
+		// Fail closed: none of these may be read as ordinal 0.
+		{"demo-0-abc", 0, false},
+		{"demo-0-", 0, false},
+		{"nodashes", 0, false},
+		{"", 0, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.podName, func(t *testing.T) {
+			got, ok := rackPodOrdinal(tc.podName)
+			if ok != tc.wantOK {
+				t.Fatalf("rackPodOrdinal(%q) ok = %v, want %v", tc.podName, ok, tc.wantOK)
+			}
+			if ok && got != tc.want {
+				t.Errorf("rackPodOrdinal(%q) = %d, want %d", tc.podName, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/controller/reconciler_statefulset.go
+++ b/internal/controller/reconciler_statefulset.go
@@ -99,6 +99,14 @@ func (r *AerospikeClusterReconciler) reconcileStatefulSet(
 	if existing.Spec.Replicas != nil {
 		oldReplicas = *existing.Spec.Replicas
 	}
+
+	// Reclaim PVCs orphaned above the StatefulSet's *observed* replica count.
+	// Runs on every pass, before any of the mutation logic below, so it is
+	// reached whichever way this function returns — see reclaimOrphanedRackPVCs
+	// for why keying it on the replica delta of a single reconcile leaked every
+	// scale-down PVC permanently.
+	r.reclaimOrphanedRackPVCs(ctx, cluster, rack.ID, stsName, existing.Spec.Replicas, storageSpec)
+
 	needsUpdate := oldReplicas != rackSize
 	var existingHash, existingPodSpecHash string
 	if existing.Spec.Template.Annotations != nil {
@@ -187,11 +195,13 @@ func (r *AerospikeClusterReconciler) reconcileStatefulSet(
 			"Rack %d scaled from %d to %d replicas", rack.ID, oldReplicas, targetReplicas)
 	}
 
-	// Cleanup orphaned PVCs after scale-down.
-	if scaleDown {
-		r.cleanupOrphanedPVCsAfterScaleDown(ctx, cluster, rack.ID, stsName, targetReplicas, oldReplicas, storageSpec)
-	}
-
+	// PVC reclamation for the ordinals this patch just removed happens on the
+	// NEXT reconcile, from the call at the top of this function: the pods are
+	// still terminating right now (deletion is asynchronous and they carry a
+	// preStop sleep), so any attempt here would defer anyway. Patching
+	// spec.replicas bumps the StatefulSet generation, and the ReadyReplicas
+	// change as the pods go away is a second trigger, so the follow-up reconcile
+	// is guaranteed rather than left to the resync period.
 	return false, nil
 }
 
@@ -230,46 +240,137 @@ func (r *AerospikeClusterReconciler) checkScaleDownReadiness(
 	return false, nil
 }
 
-// cleanupOrphanedPVCsAfterScaleDown verifies pods have terminated and then deletes orphaned PVCs.
-// Pod termination is asynchronous — PVCs are only deleted once all scaled-down pods are gone.
-func (r *AerospikeClusterReconciler) cleanupOrphanedPVCsAfterScaleDown(
+// reclaimOrphanedRackPVCs deletes cascade-delete PVCs left above the rack's
+// current replica count. It is idempotent and safe to call on every reconcile.
+//
+// Keyed on OBSERVED state, not on the replica delta of one reconcile. The
+// previous call site sat inside the `needsUpdate` branch and so ran only on the
+// pass that performed the scale-down — the single pass on which it can never
+// succeed, because pod deletion is asynchronous and the pods carry a preStop
+// sleep, so it always hit the "still terminating" deferral. On the next
+// reconcile the StatefulSet already read the desired size, both hashes matched,
+// and reconcileStatefulSet returned before the cleanup was reachable. Since the
+// default getScaleDownBatchSize returns the whole delta, the deferred pass was
+// the ONLY pass, so every cascadeDelete PVC leaked permanently.
+//
+// The leak is not merely wasted storage. StatefulSet PVC names are
+// ordinal-derived, so a later scale-up remounts the exact device the removed
+// node wrote, and the init container only wipes volumes explicitly marked
+// dirty — an Aerospike node can rejoin the cluster carrying records the
+// operator was told to destroy.
+//
+// Safety, in the order the guards run:
+//
+//   - specReplicas is the StatefulSet's own spec.replicas, NEVER the desired
+//     rack size. During a batched scale-down the ordinals between the two still
+//     have live pods, and deleting their PVCs would pull the volume out from
+//     under a running Aerospike node. A nil or non-positive value means the
+//     observed replica count is unknown or the rack is being torn down
+//     entirely, and reclamation is skipped rather than guessed at.
+//   - Only PVCs at ordinal >= specReplicas are ever considered, and only ones
+//     the operator owns and marked cascadeDelete. Both bounds live in
+//     storage.DeleteOrphanedCascadeDeletePVCs; a PVC in use by a pod at an
+//     ordinal below specReplicas cannot be selected by construction.
+//   - A pod observed at or above specReplicas defers the whole pass: that pod
+//     is still terminating and still mounting its volume.
+//
+// Cost on the steady-state path: nothing at all for clusters with no
+// cascadeDelete PV volume (the common case — cascadeDelete defaults to false),
+// which is checked before either List is issued.
+func (r *AerospikeClusterReconciler) reclaimOrphanedRackPVCs(
 	ctx context.Context,
 	cluster *ackov1alpha1.AerospikeCluster,
 	rackID int,
 	stsName string,
-	targetReplicas, oldReplicas int32,
+	specReplicas *int32,
 	storageSpec *ackov1alpha1.AerospikeStorageSpec,
 ) {
 	log := logf.FromContext(ctx)
 
+	// Cheapest gate first: with no cascade-delete PV volume there is nothing to
+	// reclaim, so skip the pod List and the PVC List entirely.
+	if !storage.HasCascadeDeletePVCs(storageSpec) {
+		return
+	}
+
+	// Without an observed replica count there is no safe lower bound on which
+	// ordinals are orphaned. Treating nil as 0 would make every PVC in the rack
+	// a candidate.
+	if specReplicas == nil {
+		log.V(1).Info("Skipping PVC reclamation: StatefulSet has no observed replica count",
+			"statefulset", stsName)
+		return
+	}
+	currentReplicas := *specReplicas
+
+	// A rack at zero replicas is being torn down, not scaled down. Whole-rack
+	// PVC deletion belongs to the rack-removal / cluster-deletion path, which
+	// deletes by ownership rather than by ordinal; reclaiming from ordinal 0
+	// here would duplicate that decision without its guards.
+	if currentReplicas < 1 {
+		log.V(1).Info("Skipping PVC reclamation: rack is at zero replicas",
+			"statefulset", stsName)
+		return
+	}
+
 	rackPods, listErr := r.listRackPods(ctx, cluster, rackID)
 	if listErr != nil {
-		log.Error(listErr, "Failed to list rack pods for PVC cleanup check, deferring PVC cleanup",
+		log.Error(listErr, "Failed to list rack pods for PVC reclamation, deferring",
 			"statefulset", stsName)
 		return
 	}
 
 	for i := range rackPods {
-		if podOrdinal(rackPods[i].Name) >= int(targetReplicas) {
-			log.Info("Deferring PVC cleanup: scaled-down pods still terminating",
-				"statefulset", stsName, "targetReplicas", targetReplicas)
+		ordinal, ok := rackPodOrdinal(rackPods[i].Name)
+		if !ok || ordinal >= int(currentReplicas) {
+			// Fail closed on an unparseable name: a pod whose ordinal we cannot
+			// read must never be assumed to be below the replica count.
+			log.V(1).Info("Deferring PVC reclamation: a pod at or above the replica count is still present",
+				"statefulset", stsName, "pod", rackPods[i].Name, "replicas", currentReplicas)
 			return
 		}
 	}
 
-	log.Info("All scaled-down pods terminated, cleaning up orphaned cascade-delete PVCs",
-		"name", stsName, "old", oldReplicas, "new", targetReplicas)
+	log.V(1).Info("Checking for orphaned cascade-delete PVCs",
+		"statefulset", stsName, "replicas", currentReplicas)
 	deleted, err := storage.DeleteOrphanedCascadeDeletePVCs(
-		ctx, r.Client, cluster.Namespace, cluster.Name, stsName, targetReplicas, storageSpec)
+		ctx, r.Client, cluster.Namespace, cluster.Name, stsName, currentReplicas, storageSpec)
 	if err != nil {
 		log.Error(err, "Failed to delete orphaned cascade PVCs", "statefulset", stsName)
 		r.Recorder.Eventf(cluster, corev1.EventTypeWarning, EventPVCCleanupFailed,
 			"Failed to delete orphaned cascade PVCs for %s: %v", stsName, err)
 	} else if deleted > 0 {
-		log.Info("Deleted orphaned cascade-delete PVCs", "statefulset", stsName, "count", deleted)
+		log.Info("Deleted orphaned cascade-delete PVCs",
+			"statefulset", stsName, "count", deleted, "replicas", currentReplicas)
 		r.Recorder.Eventf(cluster, corev1.EventTypeNormal, EventPVCCleanedUp,
-			"Deleted %d orphaned PVC(s) for %s after scale-down", deleted, stsName)
+			"Deleted %d orphaned PVC(s) for %s above replica count %d", deleted, stsName, currentReplicas)
 	}
+}
+
+// rackPodOrdinal parses the StatefulSet ordinal from a pod name, reporting
+// whether the parse succeeded.
+//
+// podOrdinal returns 0 for a name it cannot parse, which is fine for restart
+// *ordering* but not for a destructive decision: "ordinal 0" would read as
+// "below the replica count, therefore not blocking PVC deletion". Reclamation
+// uses this instead and fails closed.
+func rackPodOrdinal(podName string) (int, bool) {
+	idx := strings.LastIndex(podName, "-")
+	if idx < 0 {
+		return 0, false
+	}
+	ordinal, err := strconv.Atoi(podName[idx+1:])
+	if err != nil {
+		return 0, false
+	}
+	// The ordinal is the segment after the last dash, so a leading '-' is always
+	// consumed as the separator and Atoi can never return a negative value here.
+	// The bound is asserted rather than assumed because the reclamation guard's
+	// "ordinal >= replicas" comparison depends on it.
+	if ordinal < 0 {
+		return 0, false
+	}
+	return ordinal, true
 }
 
 func (r *AerospikeClusterReconciler) buildStatefulSet(

--- a/internal/storage/pvc.go
+++ b/internal/storage/pvc.go
@@ -60,21 +60,14 @@ func GetPVCsForStatefulSet(ctx context.Context, c client.Client, namespace, clus
 	return matched, nil
 }
 
-// DeleteOrphanedCascadeDeletePVCs removes PVCs for pod ordinals >= desiredReplicas,
-// but only for volumes that have cascadeDelete enabled. Non-cascade PVCs are preserved.
-// This is the correct function to use during scale-down.
-func DeleteOrphanedCascadeDeletePVCs(
-	ctx context.Context,
-	c client.Client,
-	namespace, clusterName, stsName string,
-	desiredReplicas int32,
-	storageSpec *v1alpha1.AerospikeStorageSpec,
-) (int, error) {
+// cascadeDeleteVolumeNames returns the set of PV-backed volume names that have
+// cascadeDelete enabled. Volumes without a PersistentVolume source have no PVC
+// to reclaim, and cascadeDelete defaults to false, so the set is empty for any
+// cluster that has not opted in.
+func cascadeDeleteVolumeNames(storageSpec *v1alpha1.AerospikeStorageSpec) map[string]bool {
 	if storageSpec == nil {
-		return 0, nil
+		return nil
 	}
-
-	// Build a set of volume names that have cascadeDelete enabled
 	cascadeVolumes := make(map[string]bool)
 	for i := range storageSpec.Volumes {
 		vol := &storageSpec.Volumes[i]
@@ -82,7 +75,37 @@ func DeleteOrphanedCascadeDeletePVCs(
 			cascadeVolumes[vol.Name] = true
 		}
 	}
+	return cascadeVolumes
+}
 
+// HasCascadeDeletePVCs reports whether the spec declares any PV-backed volume
+// with cascadeDelete enabled — i.e. whether there is anything for
+// DeleteOrphanedCascadeDeletePVCs to reclaim at all.
+//
+// Callers use it as a cheap pre-gate so the steady-state reconcile path skips
+// the PVC List entirely for clusters that never opt into cascadeDelete. It
+// shares cascadeDeleteVolumeNames with the deleter deliberately: a gate that
+// could ever be looser than the deleter's own predicate would let a caller
+// believe it had reclaimed PVCs it never looked at.
+func HasCascadeDeletePVCs(storageSpec *v1alpha1.AerospikeStorageSpec) bool {
+	return len(cascadeDeleteVolumeNames(storageSpec)) > 0
+}
+
+// DeleteOrphanedCascadeDeletePVCs removes PVCs for pod ordinals >= desiredReplicas,
+// but only for volumes that have cascadeDelete enabled. Non-cascade PVCs are preserved.
+// This is the correct function to use during scale-down.
+//
+// desiredReplicas must be the replica count the StatefulSet is actually running
+// (its own spec.replicas), never a lower target the operator is still working
+// towards: ordinals between the two still have live pods holding their volumes.
+func DeleteOrphanedCascadeDeletePVCs(
+	ctx context.Context,
+	c client.Client,
+	namespace, clusterName, stsName string,
+	desiredReplicas int32,
+	storageSpec *v1alpha1.AerospikeStorageSpec,
+) (int, error) {
+	cascadeVolumes := cascadeDeleteVolumeNames(storageSpec)
 	if len(cascadeVolumes) == 0 {
 		return 0, nil
 	}
@@ -222,19 +245,7 @@ func DeleteCascadeDeletePVCs(
 	namespace, clusterName, stsName string,
 	storageSpec *v1alpha1.AerospikeStorageSpec,
 ) error {
-	if storageSpec == nil {
-		return nil
-	}
-
-	// Build a set of volume names that have cascadeDelete enabled
-	cascadeVolumes := make(map[string]bool)
-	for i := range storageSpec.Volumes {
-		vol := &storageSpec.Volumes[i]
-		if vol.Source.PersistentVolume != nil && ResolveCascadeDelete(vol, storageSpec) {
-			cascadeVolumes[vol.Name] = true
-		}
-	}
-
+	cascadeVolumes := cascadeDeleteVolumeNames(storageSpec)
 	if len(cascadeVolumes) == 0 {
 		return nil
 	}


### PR DESCRIPTION
## Problem

`internal/controller/reconciler_statefulset.go:102`:

```go
needsUpdate := oldReplicas != rackSize
```

gates the whole update block, and the PVC cleanup call sat **inside** it at `:191`:

```go
if scaleDown {
    r.cleanupOrphanedPVCsAfterScaleDown(ctx, cluster, rack.ID, stsName, targetReplicas, oldReplicas, storageSpec)
}
```

On the pass that performs the scale-down, the cleanup returns early because the removed pods are still terminating (`:253-257` — deletion is asynchronous and the pods carry a `preStop` sleep):

```go
for i := range rackPods {
    if podOrdinal(rackPods[i].Name) >= int(targetReplicas) {
        log.Info("Deferring PVC cleanup: scaled-down pods still terminating", ...)
        return
    }
}
```

On the next reconcile the StatefulSet already reads `rackSize`, both hashes match, and `:116` returns before the cleanup is reachable again. Since the default `getScaleDownBatchSize` returns the full delta (`:432`), the deferred pass is the **only** pass — so **every `cascadeDelete: true` PVC leaked permanently, on every scale-down.**

Beyond the storage cost this is a data-correctness risk. StatefulSet PVC names are ordinal-derived, so a later scale-up remounts the exact device the removed node wrote, and the init container only wipes volumes explicitly marked dirty — **an Aerospike node can rejoin the cluster carrying records the operator was told to destroy.**

## Fix

`reclaimOrphanedRackPVCs` replaces `cleanupOrphanedPVCsAfterScaleDown` and is called **once near the top of `reconcileStatefulSet`**, before any of the mutation logic, so it is reached on every pass whichever way the function returns — including the `!needsUpdate` early return where the retry used to die.

It is keyed on the StatefulSet's own **observed `spec.replicas`**, never on the replica delta and never on the desired `rackSize`. That distinction is the whole safety argument: during a batched scale-down, `rackSize <= targetReplicas <= spec.replicas`, and the ordinals between `rackSize` and `spec.replicas` still have **live pods holding their volumes**. Keying on `rackSize` would delete in-use PVCs.

Reclamation for the ordinals a patch just removed therefore happens on the *following* reconcile. That follow-up is guaranteed, not left to the 10-hour resync: patching `spec.replicas` bumps the StatefulSet generation, and the `ReadyReplicas` change as the pods go away is a second trigger — both are in the `Owns(&appsv1.StatefulSet{}, predicate.Or(GenerationChangedPredicate, statefulSetReadyReplicasPredicate))` watch. A batched scale-down reclaims incrementally: each pass reclaims the previous batch's ordinals at the top, then patches the next batch.

**Guards, cheapest first:**

| Guard | Why |
| --- | --- |
| No cascadeDelete PV-backed volume | Short-circuits before *either* List. `cascadeDelete` defaults to false, so this is the steady-state path for most clusters. New `storage.HasCascadeDeletePVCs` shares `cascadeDeleteVolumeNames` with the deleter, so the gate can never be looser than what the deleter actually selects. |
| `spec.replicas == nil` | Skips rather than treating nil as 0 — which would make **every** PVC in the rack an orphan candidate. |
| `spec.replicas < 1` | A rack at zero replicas is being torn down, not scaled down. Whole-rack PVC deletion belongs to the rack-removal / cluster-deletion path, which deletes by ownership rather than by ordinal. |
| Any observed pod at or above the replica count | That pod is still terminating and still mounting its volume. New `rackPodOrdinal` fails **closed** on an unparseable name — `podOrdinal` returns 0 there, which is fine for restart *ordering* but would read as "below the replica count, therefore not blocking deletion" in a destructive decision. |

The `ordinal >= desiredReplicas` bound plus the cascadeDelete and name/label ownership filters stay where they were, inside `storage.DeleteOrphanedCascadeDeletePVCs`, so **a PVC in use by a pod below the replica count cannot be selected by construction** — the pod gate is a second layer, not the load-bearing one.

Also refactored the duplicated `cascadeVolumes` map construction out of `DeleteOrphanedCascadeDeletePVCs` and `DeleteCascadeDeletePVCs` into `cascadeDeleteVolumeNames`, so the new gate and both deleters share one predicate.

Log levels moved to `V(1)` for the per-reconcile "checking" and "deferring" lines, since this now runs every pass; the "Deleted N PVCs" line and its Event stay at `Info` and still only fire when something was actually reclaimed.

## Verification

**The regression test fails with the old call site and passes with the new one.** I restored the pre-fix placement (cleanup only inside `if scaleDown`, after the patch) and re-ran:

```
=== WITHOUT the fix (old call site restored) ===
--- FAIL: TestReconcileStatefulSet_ReclaimsOrphanedPVCsOnConvergedPass (0.04s)
FAIL  .../internal/controller  0.678s

=== fix restored ===
ok    .../internal/controller  0.525s
```

That test drives the real `reconcileStatefulSet` with matching hashes and `spec.replicas == rackSize`, so it exercises exactly the `!needsUpdate` early return where the bug lived.

**Safety tests — an in-use PVC is never selected:**

```
--- PASS: TestReclaimOrphanedRackPVCs_NeverSelectsInUsePVC
    --- PASS: /fully_converged_rack_reclaims_nothing
    --- PASS: /one_ordinal_above_the_replica_count_is_reclaimed
    --- PASS: /several_ordinals_above_the_replica_count_are_reclaimed
    --- PASS: /no_pods_observed_still_preserves_ordinals_below_the_replica_count
--- PASS: TestReclaimOrphanedRackPVCs_DefersWhilePodAboveReplicaCountExists
--- PASS: TestReclaimOrphanedRackPVCs_DefersOnUnparseablePodName
--- PASS: TestReclaimOrphanedRackPVCs_SkipsWhenReplicaCountUnknown
--- PASS: TestReclaimOrphanedRackPVCs_SkipsAtZeroReplicas
--- PASS: TestReclaimOrphanedRackPVCs_NonCascadeVolumesIssueNoList
--- PASS: TestReclaimOrphanedRackPVCs_Idempotent
--- PASS: TestRackPodOrdinal (9 cases)
```

Each case asserts both directions: the orphan is gone **and** every PVC below the replica count survives. `..._NonCascadeVolumesIssueNoList` uses an `interceptor` List counter to prove the steady-state path issues **zero** List calls. `..._Idempotent` runs three passes and asserts exactly one Event.

| Command | Result |
| --- | --- |
| `go build ./...` | exit 0, no output |
| `go vet ./...` | exit 0, no output |
| `gofmt -l .` | empty |
| `go test ./internal/controller/...` | `ok ... 0.831s` |
| `go test ./internal/storage/...` | `ok` |
| `go test ./...` | all packages `ok` / no test files; zero failures |

`golangci-lint` was not run — `.custom-gcl.yml` requires a custom build with a `logcheck` plugin that is not available here. No kind/kubectl/docker commands were run and the e2e suite was not executed.

## Risk

This is the riskiest of the three fixes in this batch — a wrong predicate deletes a live PVC — so the notes below are deliberately explicit about what protects what.

- **The load-bearing invariant is `ordinal >= sts.spec.replicas`.** A StatefulSet only runs pods at ordinals `0..spec.replicas-1`, so a PVC at or above `spec.replicas` has no live pod by definition. That bound was already in `DeleteOrphanedCascadeDeletePVCs` and is unchanged; the fix only changed *which value* is passed to it and *when* the function is called. Passing `rackSize` instead would have been the dangerous version and is explicitly avoided.
- **Behaviour change: reclamation now happens for pre-existing leaks.** On upgrade, the first reconcile of a cluster that has leaked PVCs from past scale-downs will delete them. That is the intended fix, but it means an operator who was relying on the leak to keep old data (e.g. planning to scale back up and reuse it) loses it. Anyone in that position should set `cascadeDelete: false` before upgrading. Worth a release note.
- **Steady-state cost for cascadeDelete clusters:** one cached pod List plus one cached PVC List per rack per reconcile. Both are label-scoped and served from the informer cache, and PVC list/watch is already granted and already used by the scale-down and cluster-delete paths. Clusters without cascadeDelete pay nothing (test-enforced). I considered a durable "cleanup pending" marker to avoid the List entirely, but every option — a new status field, a StatefulSet annotation, in-memory state — is either a larger change than this fix warrants or loses the pending state on operator restart. Called out here rather than hidden.
- **Not covered: the freshly-created StatefulSet path.** `reconcileStatefulSet` returns at `:83` after creating a new StatefulSet, before the reclamation call. A rack whose StatefulSet was deleted and recreated at a smaller size can still have PVCs above the new replica count. That overlaps the separate rack-removal finding (#342) and was left out to keep this change focused.
- **Not covered: a rack at zero replicas.** Deliberately skipped, per the guard table above. If a rack legitimately sits at 0 replicas with its StatefulSet still present, its PVCs are not reclaimed here.
- **Not covered: e2e.** There is no Kind test asserting orphaned PVCs are actually gone after a scale-down — `test/e2e/e2e_cluster_test.go` has zero PVC assertions. That gap is what let this defect survive; closing it is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
