### PR TITLE
fix(controller): reclaim orphaned PVCs keyed on observed rack state

### DIFF
--- a/internal/controller/reconciler_pvc_reclaim_test.go
+++ b/internal/controller/reconciler_pvc_reclaim_test.go
@@ -1,0 +1,509 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	ackov1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/utils"
+)
+
+// --- PVC reclamation after scale-down ---
+//
+// The cleanup used to sit inside reconcileStatefulSet's `needsUpdate` branch, so
+// it ran only on the pass that performed the scale-down — the one pass on which
+// it can never succeed, because the removed pods are still terminating. On the
+// next pass the StatefulSet already read the desired size, both hashes matched,
+// and the function returned before the cleanup was reachable. With the default
+// scale-down batch size returning the whole delta, that deferred pass was the
+// only pass, so every cascadeDelete PVC leaked permanently — and because PVC
+// names are ordinal-derived, a later scale-up remounted the exact device the
+// removed node wrote.
+//
+// These tests pin both halves: reclamation now happens on the converged pass,
+// and it can never select a PVC that a live pod is using.
+
+const pvcReclaimRackID = 0
+
+func pvcReclaimCluster(cascadeDelete bool) *ackov1alpha1.AerospikeCluster {
+	return &ackov1alpha1.AerospikeCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: ctrlTestNamespace},
+		Spec: ackov1alpha1.AerospikeClusterSpec{
+			Size:    1,
+			Image:   "aerospike:ce-8.1.1.1",
+			Storage: pvcReclaimStorage(cascadeDelete),
+		},
+	}
+}
+
+func pvcReclaimStorage(cascadeDelete bool) *ackov1alpha1.AerospikeStorageSpec {
+	return &ackov1alpha1.AerospikeStorageSpec{
+		Volumes: []ackov1alpha1.VolumeSpec{
+			{
+				Name: "data",
+				Source: ackov1alpha1.VolumeSource{
+					PersistentVolume: &ackov1alpha1.PersistentVolumeSpec{Size: "10Gi"},
+				},
+				CascadeDelete: &cascadeDelete,
+			},
+		},
+	}
+}
+
+// pvcReclaimPVC builds a PVC named the way a StatefulSet names it —
+// <volume>-<stsName>-<ordinal> — carrying the cluster labels the operator
+// stamps onto VolumeClaimTemplates, so the label-scoped query matches it.
+func pvcReclaimPVC(clusterName string, ordinal int) *corev1.PersistentVolumeClaim {
+	stsName := utils.StatefulSetName(clusterName, pvcReclaimRackID)
+	return &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("data-%s-%d", stsName, ordinal),
+			Namespace: ctrlTestNamespace,
+			Labels:    utils.LabelsForCluster(clusterName),
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("10Gi"),
+				},
+			},
+		},
+	}
+}
+
+// pvcReclaimPod builds a rack pod named <stsName>-<ordinal>.
+func pvcReclaimPod(clusterName string, ordinal int) *corev1.Pod {
+	stsName := utils.StatefulSetName(clusterName, pvcReclaimRackID)
+	return pvcReclaimNamedPod(clusterName, fmt.Sprintf("%s-%d", stsName, ordinal))
+}
+
+func pvcReclaimNamedPod(clusterName, podName string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: ctrlTestNamespace,
+			Labels:    utils.LabelsForRack(clusterName, pvcReclaimRackID),
+		},
+	}
+}
+
+// pvcNames returns the sorted set of PVC names still present in the namespace.
+func pvcNames(t *testing.T, c client.Client, clusterName string) map[string]bool {
+	t.Helper()
+	present := map[string]bool{}
+	for ordinal := 0; ordinal < 6; ordinal++ {
+		pvc := pvcReclaimPVC(clusterName, ordinal)
+		err := c.Get(context.Background(),
+			types.NamespacedName{Name: pvc.Name, Namespace: pvc.Namespace},
+			&corev1.PersistentVolumeClaim{})
+		switch {
+		case err == nil:
+			present[pvc.Name] = true
+		case apierrors.IsNotFound(err):
+		default:
+			t.Fatalf("Get PVC %s: %v", pvc.Name, err)
+		}
+	}
+	return present
+}
+
+func pvcReclaimReconciler(scheme *runtime.Scheme, objs ...client.Object) *AerospikeClusterReconciler {
+	return &AerospikeClusterReconciler{
+		Client:   fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build(),
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(8),
+	}
+}
+
+// TestReconcileStatefulSet_ReclaimsOrphanedPVCsOnConvergedPass is the
+// regression test for the leak. The StatefulSet has already been scaled down to
+// 1 replica, the removed pod is gone, and both hashes match — so
+// reconcileStatefulSet takes the `!needsUpdate` early return, which is exactly
+// where the old code stopped being able to reclaim anything. The orphaned PVC
+// must be gone by the end of this pass, and the in-use one must not be.
+func TestReconcileStatefulSet_ReclaimsOrphanedPVCsOnConvergedPass(t *testing.T) {
+	scheme := rollingRestartScheme(t)
+
+	cluster := pvcReclaimCluster(true)
+	rack := &ackov1alpha1.Rack{ID: pvcReclaimRackID}
+	stsName := utils.StatefulSetName(cluster.Name, rack.ID)
+
+	const configHash = "cfg-SAME"
+	podSpecHash := computePodSpecHash(cluster, rack)
+	oneReplica := int32(1)
+
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{Name: stsName, Namespace: ctrlTestNamespace},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &oneReplica,
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						utils.ConfigHashAnnotation:  configHash,
+						utils.PodSpecHashAnnotation: podSpecHash,
+					},
+				},
+			},
+		},
+	}
+
+	r := pvcReclaimReconciler(scheme,
+		sts,
+		pvcReclaimPod(cluster.Name, 0),
+		pvcReclaimPVC(cluster.Name, 0), // in use by demo-0-0
+		pvcReclaimPVC(cluster.Name, 1), // orphaned by an earlier scale-down
+	)
+
+	deferred, err := r.reconcileStatefulSet(
+		context.Background(), cluster, rack, nil, configHash, 1)
+	if err != nil {
+		t.Fatalf("reconcileStatefulSet() error = %v", err)
+	}
+	if deferred {
+		t.Fatal("reconcileStatefulSet() deferred = true, want false on a converged rack")
+	}
+
+	present := pvcNames(t, r.Client, cluster.Name)
+	if !present[fmt.Sprintf("data-%s-0", stsName)] {
+		t.Error("PVC at ordinal 0 was deleted; it is in use by a running pod")
+	}
+	if present[fmt.Sprintf("data-%s-1", stsName)] {
+		t.Error("orphaned PVC at ordinal 1 was not reclaimed on the converged pass")
+	}
+}
+
+// TestReclaimOrphanedRackPVCs_NeverSelectsInUsePVC is the safety test. Deleting
+// a PVC that a running Aerospike node has mounted destroys that node's data, so
+// only ordinals at or above the StatefulSet's own replica count may ever be
+// considered — and never the desired rack size, which during a batched
+// scale-down is lower than the count the StatefulSet is actually running.
+func TestReclaimOrphanedRackPVCs_NeverSelectsInUsePVC(t *testing.T) {
+	tests := []struct {
+		name string
+		// specReplicas is the StatefulSet's own spec.replicas.
+		specReplicas int32
+		// podOrdinals are the pods currently observed for the rack.
+		podOrdinals []int
+		// pvcOrdinals are the PVCs that exist.
+		pvcOrdinals []int
+		// wantDeleted lists the ordinals that must be reclaimed; every other
+		// PVC in pvcOrdinals must survive.
+		wantDeleted []int
+	}{
+		{
+			name:         "fully converged rack reclaims nothing",
+			specReplicas: 3,
+			podOrdinals:  []int{0, 1, 2},
+			pvcOrdinals:  []int{0, 1, 2},
+			wantDeleted:  nil,
+		},
+		{
+			name:         "one ordinal above the replica count is reclaimed",
+			specReplicas: 2,
+			podOrdinals:  []int{0, 1},
+			pvcOrdinals:  []int{0, 1, 2},
+			wantDeleted:  []int{2},
+		},
+		{
+			name:         "several ordinals above the replica count are reclaimed",
+			specReplicas: 1,
+			podOrdinals:  []int{0},
+			pvcOrdinals:  []int{0, 1, 2, 3},
+			wantDeleted:  []int{1, 2, 3},
+		},
+		{
+			// A cluster that is entirely down still keeps every PVC below the
+			// replica count: those volumes belong to nodes that will come back.
+			name:         "no pods observed still preserves ordinals below the replica count",
+			specReplicas: 3,
+			podOrdinals:  nil,
+			pvcOrdinals:  []int{0, 1, 2, 3},
+			wantDeleted:  []int{3},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			scheme := rollingRestartScheme(t)
+			cluster := pvcReclaimCluster(true)
+			stsName := utils.StatefulSetName(cluster.Name, pvcReclaimRackID)
+
+			var objs []client.Object
+			for _, ordinal := range tc.podOrdinals {
+				objs = append(objs, pvcReclaimPod(cluster.Name, ordinal))
+			}
+			for _, ordinal := range tc.pvcOrdinals {
+				objs = append(objs, pvcReclaimPVC(cluster.Name, ordinal))
+			}
+
+			r := pvcReclaimReconciler(scheme, objs...)
+			replicas := tc.specReplicas
+			r.reclaimOrphanedRackPVCs(context.Background(), cluster,
+				pvcReclaimRackID, stsName, &replicas, cluster.Spec.Storage)
+
+			shouldBeGone := map[int]bool{}
+			for _, ordinal := range tc.wantDeleted {
+				shouldBeGone[ordinal] = true
+			}
+
+			present := pvcNames(t, r.Client, cluster.Name)
+			for _, ordinal := range tc.pvcOrdinals {
+				name := fmt.Sprintf("data-%s-%d", stsName, ordinal)
+				if shouldBeGone[ordinal] && present[name] {
+					t.Errorf("PVC %s should have been reclaimed (replicas=%d)", name, tc.specReplicas)
+				}
+				if !shouldBeGone[ordinal] && !present[name] {
+					t.Errorf("PVC %s was deleted but its ordinal is below replicas=%d", name, tc.specReplicas)
+				}
+			}
+		})
+	}
+}
+
+// TestReclaimOrphanedRackPVCs_DefersWhilePodAboveReplicaCountExists covers the
+// mid-scale-down window. The pod being removed is still terminating and still
+// has its volume mounted, so nothing may be reclaimed until it is gone.
+func TestReclaimOrphanedRackPVCs_DefersWhilePodAboveReplicaCountExists(t *testing.T) {
+	scheme := rollingRestartScheme(t)
+	cluster := pvcReclaimCluster(true)
+	stsName := utils.StatefulSetName(cluster.Name, pvcReclaimRackID)
+
+	r := pvcReclaimReconciler(scheme,
+		pvcReclaimPod(cluster.Name, 0),
+		pvcReclaimPod(cluster.Name, 1), // still terminating
+		pvcReclaimPVC(cluster.Name, 0),
+		pvcReclaimPVC(cluster.Name, 1),
+	)
+
+	replicas := int32(1)
+	r.reclaimOrphanedRackPVCs(context.Background(), cluster,
+		pvcReclaimRackID, stsName, &replicas, cluster.Spec.Storage)
+
+	present := pvcNames(t, r.Client, cluster.Name)
+	for ordinal := 0; ordinal < 2; ordinal++ {
+		name := fmt.Sprintf("data-%s-%d", stsName, ordinal)
+		if !present[name] {
+			t.Errorf("PVC %s was deleted while pod %s-1 is still terminating", name, stsName)
+		}
+	}
+}
+
+// TestReclaimOrphanedRackPVCs_DefersOnUnparseablePodName fails closed: a pod
+// whose ordinal cannot be read must never be assumed to sit below the replica
+// count. podOrdinal returns 0 for such a name, which would have read as "not an
+// orphan candidate" and allowed the deletion to proceed.
+func TestReclaimOrphanedRackPVCs_DefersOnUnparseablePodName(t *testing.T) {
+	scheme := rollingRestartScheme(t)
+	cluster := pvcReclaimCluster(true)
+	stsName := utils.StatefulSetName(cluster.Name, pvcReclaimRackID)
+
+	r := pvcReclaimReconciler(scheme,
+		pvcReclaimNamedPod(cluster.Name, stsName+"-not-a-number"),
+		pvcReclaimPVC(cluster.Name, 0),
+		pvcReclaimPVC(cluster.Name, 1),
+	)
+
+	replicas := int32(1)
+	r.reclaimOrphanedRackPVCs(context.Background(), cluster,
+		pvcReclaimRackID, stsName, &replicas, cluster.Spec.Storage)
+
+	present := pvcNames(t, r.Client, cluster.Name)
+	if !present[fmt.Sprintf("data-%s-1", stsName)] {
+		t.Error("PVC was reclaimed despite a rack pod with an unparseable ordinal")
+	}
+}
+
+// TestReclaimOrphanedRackPVCs_SkipsWhenReplicaCountUnknown guards the nil case.
+// Treating a nil spec.replicas as 0 would make every PVC in the rack an orphan
+// candidate — including every in-use one.
+func TestReclaimOrphanedRackPVCs_SkipsWhenReplicaCountUnknown(t *testing.T) {
+	scheme := rollingRestartScheme(t)
+	cluster := pvcReclaimCluster(true)
+	stsName := utils.StatefulSetName(cluster.Name, pvcReclaimRackID)
+
+	r := pvcReclaimReconciler(scheme,
+		pvcReclaimPVC(cluster.Name, 0),
+		pvcReclaimPVC(cluster.Name, 1),
+	)
+
+	r.reclaimOrphanedRackPVCs(context.Background(), cluster,
+		pvcReclaimRackID, stsName, nil, cluster.Spec.Storage)
+
+	present := pvcNames(t, r.Client, cluster.Name)
+	for ordinal := 0; ordinal < 2; ordinal++ {
+		name := fmt.Sprintf("data-%s-%d", stsName, ordinal)
+		if !present[name] {
+			t.Errorf("PVC %s was deleted with an unknown replica count", name)
+		}
+	}
+}
+
+// TestReclaimOrphanedRackPVCs_SkipsAtZeroReplicas keeps whole-rack teardown out
+// of this path: at zero replicas every ordinal is >= the replica count, and
+// deleting by ordinal would duplicate the rack-removal decision without its
+// guards.
+func TestReclaimOrphanedRackPVCs_SkipsAtZeroReplicas(t *testing.T) {
+	scheme := rollingRestartScheme(t)
+	cluster := pvcReclaimCluster(true)
+	stsName := utils.StatefulSetName(cluster.Name, pvcReclaimRackID)
+
+	r := pvcReclaimReconciler(scheme,
+		pvcReclaimPVC(cluster.Name, 0),
+		pvcReclaimPVC(cluster.Name, 1),
+	)
+
+	replicas := int32(0)
+	r.reclaimOrphanedRackPVCs(context.Background(), cluster,
+		pvcReclaimRackID, stsName, &replicas, cluster.Spec.Storage)
+
+	present := pvcNames(t, r.Client, cluster.Name)
+	for ordinal := 0; ordinal < 2; ordinal++ {
+		name := fmt.Sprintf("data-%s-%d", stsName, ordinal)
+		if !present[name] {
+			t.Errorf("PVC %s was deleted for a rack at zero replicas", name)
+		}
+	}
+}
+
+// TestReclaimOrphanedRackPVCs_NonCascadeVolumesIssueNoList pins the
+// steady-state cost. cascadeDelete defaults to false, so most clusters must not
+// pay for a pod List or a PVC List on every reconcile — the check happens before
+// either one.
+func TestReclaimOrphanedRackPVCs_NonCascadeVolumesIssueNoList(t *testing.T) {
+	scheme := rollingRestartScheme(t)
+	cluster := pvcReclaimCluster(false)
+	stsName := utils.StatefulSetName(cluster.Name, pvcReclaimRackID)
+
+	base := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(pvcReclaimPVC(cluster.Name, 0), pvcReclaimPVC(cluster.Name, 1)).
+		Build()
+
+	lists := 0
+	wrapped := interceptor.NewClient(base, interceptor.Funcs{
+		List: func(ctx context.Context, c client.WithWatch,
+			list client.ObjectList, opts ...client.ListOption) error {
+			lists++
+			return c.List(ctx, list, opts...)
+		},
+	})
+
+	r := &AerospikeClusterReconciler{
+		Client:   wrapped,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(8),
+	}
+
+	replicas := int32(1)
+	r.reclaimOrphanedRackPVCs(context.Background(), cluster,
+		pvcReclaimRackID, stsName, &replicas, cluster.Spec.Storage)
+
+	if lists != 0 {
+		t.Errorf("issued %d List call(s) for a cluster with no cascadeDelete volume, want 0", lists)
+	}
+
+	present := pvcNames(t, r.Client, cluster.Name)
+	for ordinal := 0; ordinal < 2; ordinal++ {
+		name := fmt.Sprintf("data-%s-%d", stsName, ordinal)
+		if !present[name] {
+			t.Errorf("non-cascadeDelete PVC %s was deleted", name)
+		}
+	}
+}
+
+// TestReclaimOrphanedRackPVCs_Idempotent pins that repeated passes are safe —
+// the function now runs on every reconcile, so a second call over the same state
+// must be a no-op rather than an error or a duplicate event.
+func TestReclaimOrphanedRackPVCs_Idempotent(t *testing.T) {
+	scheme := rollingRestartScheme(t)
+	cluster := pvcReclaimCluster(true)
+	stsName := utils.StatefulSetName(cluster.Name, pvcReclaimRackID)
+
+	recorder := record.NewFakeRecorder(8)
+	r := &AerospikeClusterReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+			pvcReclaimPod(cluster.Name, 0),
+			pvcReclaimPVC(cluster.Name, 0),
+			pvcReclaimPVC(cluster.Name, 1),
+		).Build(),
+		Scheme:   scheme,
+		Recorder: recorder,
+	}
+
+	replicas := int32(1)
+	for pass := 1; pass <= 3; pass++ {
+		r.reclaimOrphanedRackPVCs(context.Background(), cluster,
+			pvcReclaimRackID, stsName, &replicas, cluster.Spec.Storage)
+	}
+
+	present := pvcNames(t, r.Client, cluster.Name)
+	if !present[fmt.Sprintf("data-%s-0", stsName)] {
+		t.Error("in-use PVC at ordinal 0 was deleted")
+	}
+	if present[fmt.Sprintf("data-%s-1", stsName)] {
+		t.Error("orphaned PVC at ordinal 1 was not reclaimed")
+	}
+
+	// Exactly one cleanup event: the first pass deletes, the rest find nothing.
+	events := 0
+	for {
+		select {
+		case <-recorder.Events:
+			events++
+			continue
+		default:
+		}
+		break
+	}
+	if events != 1 {
+		t.Errorf("recorded %d events over 3 passes, want 1", events)
+	}
+}
+
+func TestRackPodOrdinal(t *testing.T) {
+	tests := []struct {
+		podName string
+		want    int
+		wantOK  bool
+	}{
+		{"demo-0-0", 0, true},
+		{"demo-0-7", 7, true},
+		{"demo-0-12", 12, true},
+		{"my-cluster-2-3", 3, true},
+		// The ordinal is the segment after the LAST dash, so a leading '-' is
+		// always consumed as the separator and the parsed value can never be
+		// negative. Pinned here because the reclamation guard's lower bound
+		// depends on it.
+		{"demo-0--1", 1, true},
+		// Fail closed: none of these may be read as ordinal 0.
+		{"demo-0-abc", 0, false},
+		{"demo-0-", 0, false},
+		{"nodashes", 0, false},
+		{"", 0, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.podName, func(t *testing.T) {
+			got, ok := rackPodOrdinal(tc.podName)
+			if ok != tc.wantOK {
+				t.Fatalf("rackPodOrdinal(%q) ok = %v, want %v", tc.podName, ok, tc.wantOK)
+			}
+			if ok && got != tc.want {
+				t.Errorf("rackPodOrdinal(%q) = %d, want %d", tc.podName, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/controller/reconciler_pvc_reclaim_test.go
+++ b/internal/controller/reconciler_pvc_reclaim_test.go
@@ -33,10 +33,14 @@ import (
 // names are ordinal-derived, a later scale-up remounted the exact device the
 // removed node wrote.
 //
-// These tests pin both halves: reclamation now happens on the converged pass,
-// and it can never select a PVC that a live pod is using.
+// Reclamation is destructive, so the tests below are split into two groups:
+// those that pin that an orphan IS reclaimed, and a larger set that pin every
+// way a PVC must be REJECTED. The rejection set is the one that matters.
 
-const pvcReclaimRackID = 0
+const (
+	pvcReclaimRackID = 0
+	pvcReclaimStsUID = types.UID("sts-uid-demo-0")
+)
 
 func pvcReclaimCluster(cascadeDelete bool) *ackov1alpha1.AerospikeCluster {
 	return &ackov1alpha1.AerospikeCluster{
@@ -63,16 +67,56 @@ func pvcReclaimStorage(cascadeDelete bool) *ackov1alpha1.AerospikeStorageSpec {
 	}
 }
 
-// pvcReclaimPVC builds a PVC named the way a StatefulSet names it —
-// <volume>-<stsName>-<ordinal> — carrying the cluster labels the operator
-// stamps onto VolumeClaimTemplates, so the label-scoped query matches it.
+// pvcReclaimSts builds the StatefulSet the reclaim predicate is evaluated
+// against: the observed replica count, the UID PVC ownerReferences are matched
+// on, and the VolumeClaimTemplate names a PVC's volume must be one of.
+func pvcReclaimSts(clusterName string, replicas *int32, vctNames ...string) *appsv1.StatefulSet {
+	vcts := make([]corev1.PersistentVolumeClaim, 0, len(vctNames))
+	for _, name := range vctNames {
+		vcts = append(vcts, corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+		})
+	}
+	return &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      utils.StatefulSetName(clusterName, pvcReclaimRackID),
+			Namespace: ctrlTestNamespace,
+			UID:       pvcReclaimStsUID,
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas:             replicas,
+			VolumeClaimTemplates: vcts,
+		},
+	}
+}
+
+func int32Ptr(v int32) *int32 { return &v }
+
+// pvcReclaimPVCName builds a StatefulSet-style PVC name:
+// <volume>-<stsName>-<ordinal>.
+func pvcReclaimPVCName(clusterName, volume string, ordinal int) string {
+	return fmt.Sprintf("%s-%s-%d", volume, utils.StatefulSetName(clusterName, pvcReclaimRackID), ordinal)
+}
+
+// pvcReclaimPVC builds a PVC carrying the cluster labels the operator stamps
+// onto VolumeClaimTemplates, and NO ownerReferences — which is the normal shape
+// for a StatefulSet volumeClaimTemplate PVC, since the StatefulSet controller
+// only adds one when persistentVolumeClaimRetentionPolicy is set to Delete and
+// this operator never sets that field.
 func pvcReclaimPVC(clusterName string, ordinal int) *corev1.PersistentVolumeClaim {
-	stsName := utils.StatefulSetName(clusterName, pvcReclaimRackID)
+	return pvcReclaimPVCNamed(clusterName, pvcReclaimPVCName(clusterName, "data", ordinal), true)
+}
+
+func pvcReclaimPVCNamed(clusterName, name string, labelled bool) *corev1.PersistentVolumeClaim {
+	var labels map[string]string
+	if labelled {
+		labels = utils.LabelsForCluster(clusterName)
+	}
 	return &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("data-%s-%d", stsName, ordinal),
+			Name:      name,
 			Namespace: ctrlTestNamespace,
-			Labels:    utils.LabelsForCluster(clusterName),
+			Labels:    labels,
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{
 			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
@@ -85,40 +129,51 @@ func pvcReclaimPVC(clusterName string, ordinal int) *corev1.PersistentVolumeClai
 	}
 }
 
-// pvcReclaimPod builds a rack pod named <stsName>-<ordinal>.
-func pvcReclaimPod(clusterName string, ordinal int) *corev1.Pod {
-	stsName := utils.StatefulSetName(clusterName, pvcReclaimRackID)
-	return pvcReclaimNamedPod(clusterName, fmt.Sprintf("%s-%d", stsName, ordinal))
+func withOwnerUID(pvc *corev1.PersistentVolumeClaim, uid types.UID) *corev1.PersistentVolumeClaim {
+	pvc.OwnerReferences = []metav1.OwnerReference{{
+		APIVersion: "apps/v1",
+		Kind:       "StatefulSet",
+		Name:       "some-statefulset",
+		UID:        uid,
+	}}
+	return pvc
 }
 
-func pvcReclaimNamedPod(clusterName, podName string) *corev1.Pod {
+// pvcReclaimPod builds a rack pod named <stsName>-<ordinal> carrying the rack
+// labels listRackPods selects on.
+func pvcReclaimPod(clusterName string, ordinal int) *corev1.Pod {
+	stsName := utils.StatefulSetName(clusterName, pvcReclaimRackID)
+	return pvcReclaimNamedPod(clusterName, fmt.Sprintf("%s-%d", stsName, ordinal), true)
+}
+
+func pvcReclaimNamedPod(clusterName, podName string, rackLabelled bool) *corev1.Pod {
+	labels := utils.LabelsForCluster(clusterName)
+	if rackLabelled {
+		labels = utils.LabelsForRack(clusterName, pvcReclaimRackID)
+	}
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      podName,
 			Namespace: ctrlTestNamespace,
-			Labels:    utils.LabelsForRack(clusterName, pvcReclaimRackID),
+			Labels:    labels,
 		},
 	}
 }
 
-// pvcNames returns the sorted set of PVC names still present in the namespace.
-func pvcNames(t *testing.T, c client.Client, clusterName string) map[string]bool {
+func pvcExists(t *testing.T, c client.Client, name string) bool {
 	t.Helper()
-	present := map[string]bool{}
-	for ordinal := 0; ordinal < 6; ordinal++ {
-		pvc := pvcReclaimPVC(clusterName, ordinal)
-		err := c.Get(context.Background(),
-			types.NamespacedName{Name: pvc.Name, Namespace: pvc.Namespace},
-			&corev1.PersistentVolumeClaim{})
-		switch {
-		case err == nil:
-			present[pvc.Name] = true
-		case apierrors.IsNotFound(err):
-		default:
-			t.Fatalf("Get PVC %s: %v", pvc.Name, err)
-		}
+	err := c.Get(context.Background(),
+		types.NamespacedName{Name: name, Namespace: ctrlTestNamespace},
+		&corev1.PersistentVolumeClaim{})
+	switch {
+	case err == nil:
+		return true
+	case apierrors.IsNotFound(err):
+		return false
+	default:
+		t.Fatalf("Get PVC %s: %v", name, err)
+		return false
 	}
-	return present
 }
 
 func pvcReclaimReconciler(scheme *runtime.Scheme, objs ...client.Object) *AerospikeClusterReconciler {
@@ -129,34 +184,28 @@ func pvcReclaimReconciler(scheme *runtime.Scheme, objs ...client.Object) *Aerosp
 	}
 }
 
+// --- the orphan IS reclaimed ---
+
 // TestReconcileStatefulSet_ReclaimsOrphanedPVCsOnConvergedPass is the
 // regression test for the leak. The StatefulSet has already been scaled down to
 // 1 replica, the removed pod is gone, and both hashes match — so
 // reconcileStatefulSet takes the `!needsUpdate` early return, which is exactly
-// where the old code stopped being able to reclaim anything. The orphaned PVC
-// must be gone by the end of this pass, and the in-use one must not be.
+// where the old code stopped being able to reclaim anything.
 func TestReconcileStatefulSet_ReclaimsOrphanedPVCsOnConvergedPass(t *testing.T) {
 	scheme := rollingRestartScheme(t)
 
 	cluster := pvcReclaimCluster(true)
 	rack := &ackov1alpha1.Rack{ID: pvcReclaimRackID}
-	stsName := utils.StatefulSetName(cluster.Name, rack.ID)
 
 	const configHash = "cfg-SAME"
 	podSpecHash := computePodSpecHash(cluster, rack)
-	oneReplica := int32(1)
 
-	sts := &appsv1.StatefulSet{
-		ObjectMeta: metav1.ObjectMeta{Name: stsName, Namespace: ctrlTestNamespace},
-		Spec: appsv1.StatefulSetSpec{
-			Replicas: &oneReplica,
-			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						utils.ConfigHashAnnotation:  configHash,
-						utils.PodSpecHashAnnotation: podSpecHash,
-					},
-				},
+	sts := pvcReclaimSts(cluster.Name, int32Ptr(1), "data")
+	sts.Spec.Template = corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				utils.ConfigHashAnnotation:  configHash,
+				utils.PodSpecHashAnnotation: podSpecHash,
 			},
 		},
 	}
@@ -177,32 +226,73 @@ func TestReconcileStatefulSet_ReclaimsOrphanedPVCsOnConvergedPass(t *testing.T) 
 		t.Fatal("reconcileStatefulSet() deferred = true, want false on a converged rack")
 	}
 
-	present := pvcNames(t, r.Client, cluster.Name)
-	if !present[fmt.Sprintf("data-%s-0", stsName)] {
+	if !pvcExists(t, r.Client, pvcReclaimPVCName(cluster.Name, "data", 0)) {
 		t.Error("PVC at ordinal 0 was deleted; it is in use by a running pod")
 	}
-	if present[fmt.Sprintf("data-%s-1", stsName)] {
+	if pvcExists(t, r.Client, pvcReclaimPVCName(cluster.Name, "data", 1)) {
 		t.Error("orphaned PVC at ordinal 1 was not reclaimed on the converged pass")
 	}
 }
 
-// TestReclaimOrphanedRackPVCs_NeverSelectsInUsePVC is the safety test. Deleting
-// a PVC that a running Aerospike node has mounted destroys that node's data, so
-// only ordinals at or above the StatefulSet's own replica count may ever be
-// considered — and never the desired rack size, which during a batched
-// scale-down is lower than the count the StatefulSet is actually running.
+// TestReclaimOrphanedRackPVCs_SelectsPVCWithNoOwnerReferences documents the
+// ownership contract deliberately: a PVC with no ownerReferences at all IS
+// reclaimable, because that is the default shape of every StatefulSet
+// volumeClaimTemplate PVC. persistentVolumeClaimRetentionPolicy defaults to
+// Retain/Retain ("retained until manually deleted") and this operator never
+// sets it, so the StatefulSet controller stamps no ownerReference. Requiring one
+// would reclaim nothing at all and silently disable the fix.
+func TestReclaimOrphanedRackPVCs_SelectsPVCWithNoOwnerReferences(t *testing.T) {
+	scheme := rollingRestartScheme(t)
+	cluster := pvcReclaimCluster(true)
+
+	orphan := pvcReclaimPVC(cluster.Name, 1)
+	if len(orphan.OwnerReferences) != 0 {
+		t.Fatalf("fixture should have no ownerReferences, got %v", orphan.OwnerReferences)
+	}
+
+	r := pvcReclaimReconciler(scheme, pvcReclaimPod(cluster.Name, 0), orphan)
+	r.reclaimOrphanedRackPVCs(context.Background(), cluster, pvcReclaimRackID,
+		pvcReclaimSts(cluster.Name, int32Ptr(1), "data"), cluster.Spec.Storage)
+
+	if pvcExists(t, r.Client, orphan.Name) {
+		t.Error("orphan with no ownerReferences was not reclaimed; the default " +
+			"StatefulSet PVC shape must remain reclaimable")
+	}
+}
+
+// TestReclaimOrphanedRackPVCs_SelectsPVCOwnedByThisStatefulSet covers the other
+// accepted shape: an ownerReference that matches the StatefulSet's UID, which is
+// what a cluster running persistentVolumeClaimRetentionPolicy: whenDeleted=Delete
+// would produce.
+func TestReclaimOrphanedRackPVCs_SelectsPVCOwnedByThisStatefulSet(t *testing.T) {
+	scheme := rollingRestartScheme(t)
+	cluster := pvcReclaimCluster(true)
+
+	orphan := withOwnerUID(pvcReclaimPVC(cluster.Name, 1), pvcReclaimStsUID)
+
+	r := pvcReclaimReconciler(scheme, pvcReclaimPod(cluster.Name, 0), orphan)
+	r.reclaimOrphanedRackPVCs(context.Background(), cluster, pvcReclaimRackID,
+		pvcReclaimSts(cluster.Name, int32Ptr(1), "data"), cluster.Spec.Storage)
+
+	if pvcExists(t, r.Client, orphan.Name) {
+		t.Error("orphan owned by this StatefulSet was not reclaimed")
+	}
+}
+
+// --- every way a PVC must be REJECTED ---
+
+// TestReclaimOrphanedRackPVCs_NeverSelectsInUsePVC is the core safety test.
+// Deleting a PVC a running Aerospike node has mounted destroys that node's data,
+// so only ordinals at or above the StatefulSet's own replica count may ever be
+// considered — never the desired rack size, which during a batched scale-down is
+// lower than the count the StatefulSet is actually running.
 func TestReclaimOrphanedRackPVCs_NeverSelectsInUsePVC(t *testing.T) {
 	tests := []struct {
-		name string
-		// specReplicas is the StatefulSet's own spec.replicas.
+		name         string
 		specReplicas int32
-		// podOrdinals are the pods currently observed for the rack.
-		podOrdinals []int
-		// pvcOrdinals are the PVCs that exist.
-		pvcOrdinals []int
-		// wantDeleted lists the ordinals that must be reclaimed; every other
-		// PVC in pvcOrdinals must survive.
-		wantDeleted []int
+		podOrdinals  []int
+		pvcOrdinals  []int
+		wantDeleted  []int
 	}{
 		{
 			name:         "fully converged rack reclaims nothing",
@@ -226,13 +316,23 @@ func TestReclaimOrphanedRackPVCs_NeverSelectsInUsePVC(t *testing.T) {
 			wantDeleted:  []int{1, 2, 3},
 		},
 		{
-			// A cluster that is entirely down still keeps every PVC below the
-			// replica count: those volumes belong to nodes that will come back.
-			name:         "no pods observed still preserves ordinals below the replica count",
+			// Previously this case asserted that ordinal 3 was reclaimed with no
+			// pods observed at all. That encoded a weaker contract than the code
+			// can safely offer: an empty pod list is indistinguishable from a
+			// label query that is not seeing live pods, and the per-pod ordinal
+			// check then passes vacuously. The pass must now defer entirely.
+			name:         "no pods observed defers rather than reclaiming",
 			specReplicas: 3,
 			podOrdinals:  nil,
 			pvcOrdinals:  []int{0, 1, 2, 3},
-			wantDeleted:  []int{3},
+			wantDeleted:  nil,
+		},
+		{
+			name:         "fewer pods than replicas defers",
+			specReplicas: 3,
+			podOrdinals:  []int{0, 1},
+			pvcOrdinals:  []int{0, 1, 2, 3},
+			wantDeleted:  nil,
 		},
 	}
 
@@ -240,7 +340,6 @@ func TestReclaimOrphanedRackPVCs_NeverSelectsInUsePVC(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			scheme := rollingRestartScheme(t)
 			cluster := pvcReclaimCluster(true)
-			stsName := utils.StatefulSetName(cluster.Name, pvcReclaimRackID)
 
 			var objs []client.Object
 			for _, ordinal := range tc.podOrdinals {
@@ -251,36 +350,166 @@ func TestReclaimOrphanedRackPVCs_NeverSelectsInUsePVC(t *testing.T) {
 			}
 
 			r := pvcReclaimReconciler(scheme, objs...)
-			replicas := tc.specReplicas
-			r.reclaimOrphanedRackPVCs(context.Background(), cluster,
-				pvcReclaimRackID, stsName, &replicas, cluster.Spec.Storage)
+			r.reclaimOrphanedRackPVCs(context.Background(), cluster, pvcReclaimRackID,
+				pvcReclaimSts(cluster.Name, int32Ptr(tc.specReplicas), "data"), cluster.Spec.Storage)
 
 			shouldBeGone := map[int]bool{}
 			for _, ordinal := range tc.wantDeleted {
 				shouldBeGone[ordinal] = true
 			}
 
-			present := pvcNames(t, r.Client, cluster.Name)
 			for _, ordinal := range tc.pvcOrdinals {
-				name := fmt.Sprintf("data-%s-%d", stsName, ordinal)
-				if shouldBeGone[ordinal] && present[name] {
+				name := pvcReclaimPVCName(cluster.Name, "data", ordinal)
+				present := pvcExists(t, r.Client, name)
+				if shouldBeGone[ordinal] && present {
 					t.Errorf("PVC %s should have been reclaimed (replicas=%d)", name, tc.specReplicas)
 				}
-				if !shouldBeGone[ordinal] && !present[name] {
-					t.Errorf("PVC %s was deleted but its ordinal is below replicas=%d", name, tc.specReplicas)
+				if !shouldBeGone[ordinal] && !present {
+					t.Errorf("PVC %s was deleted but must have been preserved (replicas=%d)",
+						name, tc.specReplicas)
 				}
 			}
 		})
 	}
 }
 
-// TestReclaimOrphanedRackPVCs_DefersWhilePodAboveReplicaCountExists covers the
-// mid-scale-down window. The pod being removed is still terminating and still
-// has its volume mounted, so nothing may be reclaimed until it is gone.
-func TestReclaimOrphanedRackPVCs_DefersWhilePodAboveReplicaCountExists(t *testing.T) {
+// TestReclaimOrphanedRackPVCs_DefersWhenPodsMissingRackLabel is the fail-open
+// counterexample. listRackPods selects on LabelsForRack — the cluster labels
+// plus RackLabel. Pods carrying only the cluster labels are invisible to it, so
+// the per-pod ordinal check passes over an empty list while live pods sit above
+// the replica count. Requiring len(pods) == spec.replicas closes that: the pod
+// list is load-bearing, not a second layer.
+func TestReclaimOrphanedRackPVCs_DefersWhenPodsMissingRackLabel(t *testing.T) {
 	scheme := rollingRestartScheme(t)
 	cluster := pvcReclaimCluster(true)
 	stsName := utils.StatefulSetName(cluster.Name, pvcReclaimRackID)
+
+	r := pvcReclaimReconciler(scheme,
+		// Live pods at ordinals 0-2, none visible to listRackPods.
+		pvcReclaimNamedPod(cluster.Name, fmt.Sprintf("%s-0", stsName), false),
+		pvcReclaimNamedPod(cluster.Name, fmt.Sprintf("%s-1", stsName), false),
+		pvcReclaimNamedPod(cluster.Name, fmt.Sprintf("%s-2", stsName), false),
+		pvcReclaimPVC(cluster.Name, 0),
+		pvcReclaimPVC(cluster.Name, 1),
+		pvcReclaimPVC(cluster.Name, 2),
+	)
+
+	// The StatefulSet is mid-scale-down: replicas already reads 1 while pods
+	// 1 and 2 are still running.
+	r.reclaimOrphanedRackPVCs(context.Background(), cluster, pvcReclaimRackID,
+		pvcReclaimSts(cluster.Name, int32Ptr(1), "data"), cluster.Spec.Storage)
+
+	for ordinal := 0; ordinal < 3; ordinal++ {
+		name := pvcReclaimPVCName(cluster.Name, "data", ordinal)
+		if !pvcExists(t, r.Client, name) {
+			t.Errorf("PVC %s was deleted while a live pod at that ordinal exists "+
+				"but is invisible to the rack label query", name)
+		}
+	}
+}
+
+// TestReclaimOrphanedRackPVCs_NeverSelectsForeignOwnedPVC pins the
+// ownerReference check. A PVC that names some other owner — a sibling
+// StatefulSet, another cluster, a hand-created claim — must never be reclaimed
+// even though its name matches the ordinal pattern and its labels match.
+func TestReclaimOrphanedRackPVCs_NeverSelectsForeignOwnedPVC(t *testing.T) {
+	scheme := rollingRestartScheme(t)
+	cluster := pvcReclaimCluster(true)
+
+	foreign := withOwnerUID(pvcReclaimPVC(cluster.Name, 1), types.UID("some-other-statefulset-uid"))
+
+	r := pvcReclaimReconciler(scheme, pvcReclaimPod(cluster.Name, 0), foreign)
+	r.reclaimOrphanedRackPVCs(context.Background(), cluster, pvcReclaimRackID,
+		pvcReclaimSts(cluster.Name, int32Ptr(1), "data"), cluster.Spec.Storage)
+
+	if !pvcExists(t, r.Client, foreign.Name) {
+		t.Error("PVC owned by a foreign UID was reclaimed")
+	}
+}
+
+// TestReclaimOrphanedRackPVCs_NeverSelectsUnlabelledPVC proves reclamation does
+// not inherit GetPVCsForStatefulSet's namespace-wide fallback, where a name
+// substring is the only ownership signal. That fallback exists for cluster
+// deletion; reclamation runs on every reconcile of every rack and must not use
+// it.
+func TestReclaimOrphanedRackPVCs_NeverSelectsUnlabelledPVC(t *testing.T) {
+	scheme := rollingRestartScheme(t)
+	cluster := pvcReclaimCluster(true)
+
+	// Name matches the ordinal pattern exactly, but carries no cluster labels.
+	unlabelled := pvcReclaimPVCNamed(cluster.Name,
+		pvcReclaimPVCName(cluster.Name, "data", 9), false)
+
+	r := pvcReclaimReconciler(scheme, pvcReclaimPod(cluster.Name, 0), unlabelled)
+	r.reclaimOrphanedRackPVCs(context.Background(), cluster, pvcReclaimRackID,
+		pvcReclaimSts(cluster.Name, int32Ptr(1), "data"), cluster.Spec.Storage)
+
+	if !pvcExists(t, r.Client, unlabelled.Name) {
+		t.Error("unlabelled PVC was reclaimed through a name-only ownership test")
+	}
+}
+
+// TestReclaimOrphanedRackPVCs_NeverSelectsVolumeNotInStatefulSet pins the
+// VolumeClaimTemplate check against the case that actually needs it: spec drift.
+//
+// VolumeClaimTemplates are immutable after StatefulSet creation, so a user who
+// adds a cascadeDelete volume to spec.storage leaves the live StatefulSet with
+// the old VCT set. The cascadeDelete filter alone would then accept a PVC for
+// the newly-declared volume even though this StatefulSet never provisioned it —
+// so the volume name is checked against the live object's own templates.
+func TestReclaimOrphanedRackPVCs_NeverSelectsVolumeNotInStatefulSet(t *testing.T) {
+	scheme := rollingRestartScheme(t)
+	cluster := pvcReclaimCluster(true)
+
+	// spec.storage now declares a second cascadeDelete volume, "scratch" ...
+	cascade := true
+	cluster.Spec.Storage.Volumes = append(cluster.Spec.Storage.Volumes, ackov1alpha1.VolumeSpec{
+		Name: "scratch",
+		Source: ackov1alpha1.VolumeSource{
+			PersistentVolume: &ackov1alpha1.PersistentVolumeSpec{Size: "5Gi"},
+		},
+		CascadeDelete: &cascade,
+	})
+
+	// ... but the live StatefulSet's VCTs still only carry "data", so this claim
+	// belongs to something else despite matching labels, ordinal and cascade.
+	foreignVol := pvcReclaimPVCNamed(cluster.Name,
+		pvcReclaimPVCName(cluster.Name, "scratch", 1), true)
+
+	r := pvcReclaimReconciler(scheme, pvcReclaimPod(cluster.Name, 0), foreignVol)
+	r.reclaimOrphanedRackPVCs(context.Background(), cluster, pvcReclaimRackID,
+		pvcReclaimSts(cluster.Name, int32Ptr(1), "data"), cluster.Spec.Storage)
+
+	if !pvcExists(t, r.Client, foreignVol.Name) {
+		t.Error("PVC whose volume is not a VolumeClaimTemplate of this StatefulSet was reclaimed")
+	}
+}
+
+// TestReclaimOrphanedRackPVCs_NeverSelectsMalformedOrdinal covers a PVC whose
+// trailing segment does not parse as an ordinal. It must be skipped, not
+// treated as ordinal 0 or as an orphan.
+func TestReclaimOrphanedRackPVCs_NeverSelectsMalformedOrdinal(t *testing.T) {
+	scheme := rollingRestartScheme(t)
+	cluster := pvcReclaimCluster(true)
+	stsName := utils.StatefulSetName(cluster.Name, pvcReclaimRackID)
+
+	malformed := pvcReclaimPVCNamed(cluster.Name, fmt.Sprintf("data-%s-abc", stsName), true)
+
+	r := pvcReclaimReconciler(scheme, pvcReclaimPod(cluster.Name, 0), malformed)
+	r.reclaimOrphanedRackPVCs(context.Background(), cluster, pvcReclaimRackID,
+		pvcReclaimSts(cluster.Name, int32Ptr(1), "data"), cluster.Spec.Storage)
+
+	if !pvcExists(t, r.Client, malformed.Name) {
+		t.Error("PVC with a malformed ordinal was reclaimed")
+	}
+}
+
+// TestReclaimOrphanedRackPVCs_DefersWhilePodAboveReplicaCountExists covers the
+// mid-scale-down window: the pod being removed is still terminating and still
+// has its volume mounted.
+func TestReclaimOrphanedRackPVCs_DefersWhilePodAboveReplicaCountExists(t *testing.T) {
+	scheme := rollingRestartScheme(t)
+	cluster := pvcReclaimCluster(true)
 
 	r := pvcReclaimReconciler(scheme,
 		pvcReclaimPod(cluster.Name, 0),
@@ -289,15 +518,13 @@ func TestReclaimOrphanedRackPVCs_DefersWhilePodAboveReplicaCountExists(t *testin
 		pvcReclaimPVC(cluster.Name, 1),
 	)
 
-	replicas := int32(1)
-	r.reclaimOrphanedRackPVCs(context.Background(), cluster,
-		pvcReclaimRackID, stsName, &replicas, cluster.Spec.Storage)
+	r.reclaimOrphanedRackPVCs(context.Background(), cluster, pvcReclaimRackID,
+		pvcReclaimSts(cluster.Name, int32Ptr(1), "data"), cluster.Spec.Storage)
 
-	present := pvcNames(t, r.Client, cluster.Name)
 	for ordinal := 0; ordinal < 2; ordinal++ {
-		name := fmt.Sprintf("data-%s-%d", stsName, ordinal)
-		if !present[name] {
-			t.Errorf("PVC %s was deleted while pod %s-1 is still terminating", name, stsName)
+		name := pvcReclaimPVCName(cluster.Name, "data", ordinal)
+		if !pvcExists(t, r.Client, name) {
+			t.Errorf("PVC %s was deleted while a pod above the replica count is still terminating", name)
 		}
 	}
 }
@@ -312,17 +539,15 @@ func TestReclaimOrphanedRackPVCs_DefersOnUnparseablePodName(t *testing.T) {
 	stsName := utils.StatefulSetName(cluster.Name, pvcReclaimRackID)
 
 	r := pvcReclaimReconciler(scheme,
-		pvcReclaimNamedPod(cluster.Name, stsName+"-not-a-number"),
+		pvcReclaimNamedPod(cluster.Name, stsName+"-not-a-number", true),
 		pvcReclaimPVC(cluster.Name, 0),
 		pvcReclaimPVC(cluster.Name, 1),
 	)
 
-	replicas := int32(1)
-	r.reclaimOrphanedRackPVCs(context.Background(), cluster,
-		pvcReclaimRackID, stsName, &replicas, cluster.Spec.Storage)
+	r.reclaimOrphanedRackPVCs(context.Background(), cluster, pvcReclaimRackID,
+		pvcReclaimSts(cluster.Name, int32Ptr(1), "data"), cluster.Spec.Storage)
 
-	present := pvcNames(t, r.Client, cluster.Name)
-	if !present[fmt.Sprintf("data-%s-1", stsName)] {
+	if !pvcExists(t, r.Client, pvcReclaimPVCName(cluster.Name, "data", 1)) {
 		t.Error("PVC was reclaimed despite a rack pod with an unparseable ordinal")
 	}
 }
@@ -333,20 +558,18 @@ func TestReclaimOrphanedRackPVCs_DefersOnUnparseablePodName(t *testing.T) {
 func TestReclaimOrphanedRackPVCs_SkipsWhenReplicaCountUnknown(t *testing.T) {
 	scheme := rollingRestartScheme(t)
 	cluster := pvcReclaimCluster(true)
-	stsName := utils.StatefulSetName(cluster.Name, pvcReclaimRackID)
 
 	r := pvcReclaimReconciler(scheme,
 		pvcReclaimPVC(cluster.Name, 0),
 		pvcReclaimPVC(cluster.Name, 1),
 	)
 
-	r.reclaimOrphanedRackPVCs(context.Background(), cluster,
-		pvcReclaimRackID, stsName, nil, cluster.Spec.Storage)
+	r.reclaimOrphanedRackPVCs(context.Background(), cluster, pvcReclaimRackID,
+		pvcReclaimSts(cluster.Name, nil, "data"), cluster.Spec.Storage)
 
-	present := pvcNames(t, r.Client, cluster.Name)
 	for ordinal := 0; ordinal < 2; ordinal++ {
-		name := fmt.Sprintf("data-%s-%d", stsName, ordinal)
-		if !present[name] {
+		name := pvcReclaimPVCName(cluster.Name, "data", ordinal)
+		if !pvcExists(t, r.Client, name) {
 			t.Errorf("PVC %s was deleted with an unknown replica count", name)
 		}
 	}
@@ -355,25 +578,22 @@ func TestReclaimOrphanedRackPVCs_SkipsWhenReplicaCountUnknown(t *testing.T) {
 // TestReclaimOrphanedRackPVCs_SkipsAtZeroReplicas keeps whole-rack teardown out
 // of this path: at zero replicas every ordinal is >= the replica count, and
 // deleting by ordinal would duplicate the rack-removal decision without its
-// guards.
+// guards. Documented in the PR as a known, deliberate gap.
 func TestReclaimOrphanedRackPVCs_SkipsAtZeroReplicas(t *testing.T) {
 	scheme := rollingRestartScheme(t)
 	cluster := pvcReclaimCluster(true)
-	stsName := utils.StatefulSetName(cluster.Name, pvcReclaimRackID)
 
 	r := pvcReclaimReconciler(scheme,
 		pvcReclaimPVC(cluster.Name, 0),
 		pvcReclaimPVC(cluster.Name, 1),
 	)
 
-	replicas := int32(0)
-	r.reclaimOrphanedRackPVCs(context.Background(), cluster,
-		pvcReclaimRackID, stsName, &replicas, cluster.Spec.Storage)
+	r.reclaimOrphanedRackPVCs(context.Background(), cluster, pvcReclaimRackID,
+		pvcReclaimSts(cluster.Name, int32Ptr(0), "data"), cluster.Spec.Storage)
 
-	present := pvcNames(t, r.Client, cluster.Name)
 	for ordinal := 0; ordinal < 2; ordinal++ {
-		name := fmt.Sprintf("data-%s-%d", stsName, ordinal)
-		if !present[name] {
+		name := pvcReclaimPVCName(cluster.Name, "data", ordinal)
+		if !pvcExists(t, r.Client, name) {
 			t.Errorf("PVC %s was deleted for a rack at zero replicas", name)
 		}
 	}
@@ -386,7 +606,6 @@ func TestReclaimOrphanedRackPVCs_SkipsAtZeroReplicas(t *testing.T) {
 func TestReclaimOrphanedRackPVCs_NonCascadeVolumesIssueNoList(t *testing.T) {
 	scheme := rollingRestartScheme(t)
 	cluster := pvcReclaimCluster(false)
-	stsName := utils.StatefulSetName(cluster.Name, pvcReclaimRackID)
 
 	base := fake.NewClientBuilder().WithScheme(scheme).
 		WithObjects(pvcReclaimPVC(cluster.Name, 0), pvcReclaimPVC(cluster.Name, 1)).
@@ -407,18 +626,16 @@ func TestReclaimOrphanedRackPVCs_NonCascadeVolumesIssueNoList(t *testing.T) {
 		Recorder: record.NewFakeRecorder(8),
 	}
 
-	replicas := int32(1)
-	r.reclaimOrphanedRackPVCs(context.Background(), cluster,
-		pvcReclaimRackID, stsName, &replicas, cluster.Spec.Storage)
+	r.reclaimOrphanedRackPVCs(context.Background(), cluster, pvcReclaimRackID,
+		pvcReclaimSts(cluster.Name, int32Ptr(1), "data"), cluster.Spec.Storage)
 
 	if lists != 0 {
 		t.Errorf("issued %d List call(s) for a cluster with no cascadeDelete volume, want 0", lists)
 	}
 
-	present := pvcNames(t, r.Client, cluster.Name)
 	for ordinal := 0; ordinal < 2; ordinal++ {
-		name := fmt.Sprintf("data-%s-%d", stsName, ordinal)
-		if !present[name] {
+		name := pvcReclaimPVCName(cluster.Name, "data", ordinal)
+		if !pvcExists(t, r.Client, name) {
 			t.Errorf("non-cascadeDelete PVC %s was deleted", name)
 		}
 	}
@@ -430,7 +647,6 @@ func TestReclaimOrphanedRackPVCs_NonCascadeVolumesIssueNoList(t *testing.T) {
 func TestReclaimOrphanedRackPVCs_Idempotent(t *testing.T) {
 	scheme := rollingRestartScheme(t)
 	cluster := pvcReclaimCluster(true)
-	stsName := utils.StatefulSetName(cluster.Name, pvcReclaimRackID)
 
 	recorder := record.NewFakeRecorder(8)
 	r := &AerospikeClusterReconciler{
@@ -443,17 +659,16 @@ func TestReclaimOrphanedRackPVCs_Idempotent(t *testing.T) {
 		Recorder: recorder,
 	}
 
-	replicas := int32(1)
+	sts := pvcReclaimSts(cluster.Name, int32Ptr(1), "data")
 	for pass := 1; pass <= 3; pass++ {
-		r.reclaimOrphanedRackPVCs(context.Background(), cluster,
-			pvcReclaimRackID, stsName, &replicas, cluster.Spec.Storage)
+		r.reclaimOrphanedRackPVCs(context.Background(), cluster, pvcReclaimRackID,
+			sts, cluster.Spec.Storage)
 	}
 
-	present := pvcNames(t, r.Client, cluster.Name)
-	if !present[fmt.Sprintf("data-%s-0", stsName)] {
+	if !pvcExists(t, r.Client, pvcReclaimPVCName(cluster.Name, "data", 0)) {
 		t.Error("in-use PVC at ordinal 0 was deleted")
 	}
-	if present[fmt.Sprintf("data-%s-1", stsName)] {
+	if pvcExists(t, r.Client, pvcReclaimPVCName(cluster.Name, "data", 1)) {
 		t.Error("orphaned PVC at ordinal 1 was not reclaimed")
 	}
 
@@ -485,8 +700,8 @@ func TestRackPodOrdinal(t *testing.T) {
 		{"my-cluster-2-3", 3, true},
 		// The ordinal is the segment after the LAST dash, so a leading '-' is
 		// always consumed as the separator and the parsed value can never be
-		// negative. Pinned here because the reclamation guard's lower bound
-		// depends on it.
+		// negative. Pinned because the reclamation guard's lower bound depends
+		// on it.
 		{"demo-0--1", 1, true},
 		// Fail closed: none of these may be read as ordinal 0.
 		{"demo-0-abc", 0, false},

--- a/internal/controller/reconciler_pvc_reclaim_test.go
+++ b/internal/controller/reconciler_pvc_reclaim_test.go
@@ -77,7 +77,7 @@ func pvcReclaimSts(clusterName string, replicas *int32, vctNames ...string) *app
 			ObjectMeta: metav1.ObjectMeta{Name: name},
 		})
 	}
-	return &appsv1.StatefulSet{
+	sts := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      utils.StatefulSetName(clusterName, pvcReclaimRackID),
 			Namespace: ctrlTestNamespace,
@@ -88,6 +88,23 @@ func pvcReclaimSts(clusterName string, replicas *int32, vctNames ...string) *app
 			VolumeClaimTemplates: vcts,
 		},
 	}
+	// A settled status: ObservedGeneration == Generation (both 0 here) and
+	// status.replicas == spec.replicas. This is what kube-controller-manager
+	// reports for a converged StatefulSet, and what the reclaim status gate
+	// requires. Tests that need an unsettled StatefulSet call withStatusReplicas.
+	if replicas != nil {
+		sts.Status.Replicas = *replicas
+	}
+	return sts
+}
+
+// withStatusReplicas overrides status.replicas so a test can model a
+// StatefulSet that still owns pods it has not released — the shape
+// kube-controller-manager reports while scaled-down pods are terminating, and
+// the one that must defer reclamation.
+func withStatusReplicas(sts *appsv1.StatefulSet, statusReplicas int32) *appsv1.StatefulSet {
+	sts.Status.Replicas = statusReplicas
+	return sts
 }
 
 func int32Ptr(v int32) *int32 { return &v }
@@ -252,7 +269,7 @@ func TestReclaimOrphanedRackPVCs_SelectsPVCWithNoOwnerReferences(t *testing.T) {
 
 	r := pvcReclaimReconciler(scheme, pvcReclaimPod(cluster.Name, 0), orphan)
 	r.reclaimOrphanedRackPVCs(context.Background(), cluster, pvcReclaimRackID,
-		pvcReclaimSts(cluster.Name, int32Ptr(1), "data"), cluster.Spec.Storage)
+		pvcReclaimSts(cluster.Name, int32Ptr(1), "data"), 1, cluster.Spec.Storage)
 
 	if pvcExists(t, r.Client, orphan.Name) {
 		t.Error("orphan with no ownerReferences was not reclaimed; the default " +
@@ -272,7 +289,7 @@ func TestReclaimOrphanedRackPVCs_SelectsPVCOwnedByThisStatefulSet(t *testing.T) 
 
 	r := pvcReclaimReconciler(scheme, pvcReclaimPod(cluster.Name, 0), orphan)
 	r.reclaimOrphanedRackPVCs(context.Background(), cluster, pvcReclaimRackID,
-		pvcReclaimSts(cluster.Name, int32Ptr(1), "data"), cluster.Spec.Storage)
+		pvcReclaimSts(cluster.Name, int32Ptr(1), "data"), 1, cluster.Spec.Storage)
 
 	if pvcExists(t, r.Client, orphan.Name) {
 		t.Error("orphan owned by this StatefulSet was not reclaimed")
@@ -351,7 +368,8 @@ func TestReclaimOrphanedRackPVCs_NeverSelectsInUsePVC(t *testing.T) {
 
 			r := pvcReclaimReconciler(scheme, objs...)
 			r.reclaimOrphanedRackPVCs(context.Background(), cluster, pvcReclaimRackID,
-				pvcReclaimSts(cluster.Name, int32Ptr(tc.specReplicas), "data"), cluster.Spec.Storage)
+				pvcReclaimSts(cluster.Name, int32Ptr(tc.specReplicas), "data"),
+				tc.specReplicas, cluster.Spec.Storage)
 
 			shouldBeGone := map[int]bool{}
 			for _, ordinal := range tc.wantDeleted {
@@ -397,7 +415,7 @@ func TestReclaimOrphanedRackPVCs_DefersWhenPodsMissingRackLabel(t *testing.T) {
 	// The StatefulSet is mid-scale-down: replicas already reads 1 while pods
 	// 1 and 2 are still running.
 	r.reclaimOrphanedRackPVCs(context.Background(), cluster, pvcReclaimRackID,
-		pvcReclaimSts(cluster.Name, int32Ptr(1), "data"), cluster.Spec.Storage)
+		pvcReclaimSts(cluster.Name, int32Ptr(1), "data"), 1, cluster.Spec.Storage)
 
 	for ordinal := range 3 {
 		name := pvcReclaimPVCName(cluster.Name, "data", ordinal)
@@ -420,7 +438,7 @@ func TestReclaimOrphanedRackPVCs_NeverSelectsForeignOwnedPVC(t *testing.T) {
 
 	r := pvcReclaimReconciler(scheme, pvcReclaimPod(cluster.Name, 0), foreign)
 	r.reclaimOrphanedRackPVCs(context.Background(), cluster, pvcReclaimRackID,
-		pvcReclaimSts(cluster.Name, int32Ptr(1), "data"), cluster.Spec.Storage)
+		pvcReclaimSts(cluster.Name, int32Ptr(1), "data"), 1, cluster.Spec.Storage)
 
 	if !pvcExists(t, r.Client, foreign.Name) {
 		t.Error("PVC owned by a foreign UID was reclaimed")
@@ -442,7 +460,7 @@ func TestReclaimOrphanedRackPVCs_NeverSelectsUnlabelledPVC(t *testing.T) {
 
 	r := pvcReclaimReconciler(scheme, pvcReclaimPod(cluster.Name, 0), unlabelled)
 	r.reclaimOrphanedRackPVCs(context.Background(), cluster, pvcReclaimRackID,
-		pvcReclaimSts(cluster.Name, int32Ptr(1), "data"), cluster.Spec.Storage)
+		pvcReclaimSts(cluster.Name, int32Ptr(1), "data"), 1, cluster.Spec.Storage)
 
 	if !pvcExists(t, r.Client, unlabelled.Name) {
 		t.Error("unlabelled PVC was reclaimed through a name-only ownership test")
@@ -478,7 +496,7 @@ func TestReclaimOrphanedRackPVCs_NeverSelectsVolumeNotInStatefulSet(t *testing.T
 
 	r := pvcReclaimReconciler(scheme, pvcReclaimPod(cluster.Name, 0), foreignVol)
 	r.reclaimOrphanedRackPVCs(context.Background(), cluster, pvcReclaimRackID,
-		pvcReclaimSts(cluster.Name, int32Ptr(1), "data"), cluster.Spec.Storage)
+		pvcReclaimSts(cluster.Name, int32Ptr(1), "data"), 1, cluster.Spec.Storage)
 
 	if !pvcExists(t, r.Client, foreignVol.Name) {
 		t.Error("PVC whose volume is not a VolumeClaimTemplate of this StatefulSet was reclaimed")
@@ -497,7 +515,7 @@ func TestReclaimOrphanedRackPVCs_NeverSelectsMalformedOrdinal(t *testing.T) {
 
 	r := pvcReclaimReconciler(scheme, pvcReclaimPod(cluster.Name, 0), malformed)
 	r.reclaimOrphanedRackPVCs(context.Background(), cluster, pvcReclaimRackID,
-		pvcReclaimSts(cluster.Name, int32Ptr(1), "data"), cluster.Spec.Storage)
+		pvcReclaimSts(cluster.Name, int32Ptr(1), "data"), 1, cluster.Spec.Storage)
 
 	if !pvcExists(t, r.Client, malformed.Name) {
 		t.Error("PVC with a malformed ordinal was reclaimed")
@@ -519,7 +537,7 @@ func TestReclaimOrphanedRackPVCs_DefersWhilePodAboveReplicaCountExists(t *testin
 	)
 
 	r.reclaimOrphanedRackPVCs(context.Background(), cluster, pvcReclaimRackID,
-		pvcReclaimSts(cluster.Name, int32Ptr(1), "data"), cluster.Spec.Storage)
+		pvcReclaimSts(cluster.Name, int32Ptr(1), "data"), 1, cluster.Spec.Storage)
 
 	for ordinal := range 2 {
 		name := pvcReclaimPVCName(cluster.Name, "data", ordinal)
@@ -545,7 +563,7 @@ func TestReclaimOrphanedRackPVCs_DefersOnUnparseablePodName(t *testing.T) {
 	)
 
 	r.reclaimOrphanedRackPVCs(context.Background(), cluster, pvcReclaimRackID,
-		pvcReclaimSts(cluster.Name, int32Ptr(1), "data"), cluster.Spec.Storage)
+		pvcReclaimSts(cluster.Name, int32Ptr(1), "data"), 1, cluster.Spec.Storage)
 
 	if !pvcExists(t, r.Client, pvcReclaimPVCName(cluster.Name, "data", 1)) {
 		t.Error("PVC was reclaimed despite a rack pod with an unparseable ordinal")
@@ -565,7 +583,7 @@ func TestReclaimOrphanedRackPVCs_SkipsWhenReplicaCountUnknown(t *testing.T) {
 	)
 
 	r.reclaimOrphanedRackPVCs(context.Background(), cluster, pvcReclaimRackID,
-		pvcReclaimSts(cluster.Name, nil, "data"), cluster.Spec.Storage)
+		pvcReclaimSts(cluster.Name, nil, "data"), 1, cluster.Spec.Storage)
 
 	for ordinal := range 2 {
 		name := pvcReclaimPVCName(cluster.Name, "data", ordinal)
@@ -589,7 +607,7 @@ func TestReclaimOrphanedRackPVCs_SkipsAtZeroReplicas(t *testing.T) {
 	)
 
 	r.reclaimOrphanedRackPVCs(context.Background(), cluster, pvcReclaimRackID,
-		pvcReclaimSts(cluster.Name, int32Ptr(0), "data"), cluster.Spec.Storage)
+		pvcReclaimSts(cluster.Name, int32Ptr(0), "data"), 0, cluster.Spec.Storage)
 
 	for ordinal := range 2 {
 		name := pvcReclaimPVCName(cluster.Name, "data", ordinal)
@@ -627,7 +645,7 @@ func TestReclaimOrphanedRackPVCs_NonCascadeVolumesIssueNoList(t *testing.T) {
 	}
 
 	r.reclaimOrphanedRackPVCs(context.Background(), cluster, pvcReclaimRackID,
-		pvcReclaimSts(cluster.Name, int32Ptr(1), "data"), cluster.Spec.Storage)
+		pvcReclaimSts(cluster.Name, int32Ptr(1), "data"), 1, cluster.Spec.Storage)
 
 	if lists != 0 {
 		t.Errorf("issued %d List call(s) for a cluster with no cascadeDelete volume, want 0", lists)
@@ -662,7 +680,7 @@ func TestReclaimOrphanedRackPVCs_Idempotent(t *testing.T) {
 	sts := pvcReclaimSts(cluster.Name, int32Ptr(1), "data")
 	for pass := 1; pass <= 3; pass++ {
 		r.reclaimOrphanedRackPVCs(context.Background(), cluster, pvcReclaimRackID,
-			sts, cluster.Spec.Storage)
+			sts, 1, cluster.Spec.Storage)
 	}
 
 	if !pvcExists(t, r.Client, pvcReclaimPVCName(cluster.Name, "data", 0)) {
@@ -720,5 +738,280 @@ func TestRackPodOrdinal(t *testing.T) {
 				t.Errorf("rackPodOrdinal(%q) = %d, want %d", tc.podName, got, tc.want)
 			}
 		})
+	}
+}
+
+// --- regressions ported from independent verification of this PR ---
+//
+// Both hazards below were introduced by moving reclamation to the top of
+// reconcileStatefulSet, and both were demonstrated by a reviewer with a failing
+// test before being fixed. They are kept here so the hazards cannot return
+// silently.
+
+// TestReconcileStatefulSet_DoesNotReclaimOnExternalScaleDown covers an external
+// write that lowered spec.replicas behind the operator's back — `kubectl scale
+// sts`, an HPA aimed at the StatefulSet instead of the CR, GitOps drift, a
+// backup restore.
+//
+// Reclamation sits above the scale-down branch, so isMigrationInProgress and the
+// quiesce path never run for this transition. Before the rackSize guard the
+// operator deleted the volumes of every ordinal above the externally-lowered
+// count and then, on the same pass, scaled the rack back up onto blank devices —
+// a destructive behaviour that did not exist before this PR, for a scale-down
+// the CR never asked for.
+func TestReconcileStatefulSet_DoesNotReclaimOnExternalScaleDown(t *testing.T) {
+	scheme := rollingRestartScheme(t)
+
+	cluster := pvcReclaimCluster(true)
+	cluster.Spec.Size = 3
+	rack := &ackov1alpha1.Rack{ID: pvcReclaimRackID}
+
+	const configHash = "cfg-SAME"
+	podSpecHash := computePodSpecHash(cluster, rack)
+
+	// Someone scaled the StatefulSet to 1. The removed pods have finished
+	// terminating, so the rack looks "converged" at 1 by every local signal.
+	sts := pvcReclaimSts(cluster.Name, int32Ptr(1), "data")
+	sts.Spec.Template = corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				utils.ConfigHashAnnotation:  configHash,
+				utils.PodSpecHashAnnotation: podSpecHash,
+			},
+		},
+	}
+
+	r := pvcReclaimReconciler(scheme,
+		sts,
+		pvcReclaimPod(cluster.Name, 0),
+		pvcReclaimPVC(cluster.Name, 0),
+		pvcReclaimPVC(cluster.Name, 1), // holds node 1's Aerospike data
+		pvcReclaimPVC(cluster.Name, 2), // holds node 2's Aerospike data
+	)
+
+	// rackSize = 3: the operator is about to scale the rack back up to the size
+	// the CR asks for.
+	if _, err := r.reconcileStatefulSet(
+		context.Background(), cluster, rack, nil, configHash, 3); err != nil {
+		t.Fatalf("reconcileStatefulSet() error = %v", err)
+	}
+
+	for _, ordinal := range []int{1, 2} {
+		name := pvcReclaimPVCName(cluster.Name, "data", ordinal)
+		if !pvcExists(t, r.Client, name) {
+			t.Errorf("PVC %s was destroyed on the pass that scales the rack back up; "+
+				"the CR never asked for a scale-down", name)
+		}
+	}
+
+	// And the rack really is scaled back up, so this is not passing by accident
+	// of the reconcile bailing out early.
+	after := &appsv1.StatefulSet{}
+	if err := r.Get(context.Background(),
+		types.NamespacedName{Name: sts.Name, Namespace: ctrlTestNamespace}, after); err != nil {
+		t.Fatalf("get sts: %v", err)
+	}
+	if after.Spec.Replicas == nil || *after.Spec.Replicas != 3 {
+		t.Errorf("expected the rack to be scaled back up to 3, got %v", after.Spec.Replicas)
+	}
+}
+
+// TestReconcileStatefulSet_DoesNotEatPreProvisionedScaleUpPVCs is the same guard
+// from the operator's other side: an admin pre-provisions PVCs at the ordinals a
+// scale-up will use (seeding nodes from restored PVs), then raises size.
+// Reclamation runs before the scale-up patch, so without the rackSize guard it
+// consumed exactly the claims the admin staged.
+func TestReconcileStatefulSet_DoesNotEatPreProvisionedScaleUpPVCs(t *testing.T) {
+	scheme := rollingRestartScheme(t)
+
+	cluster := pvcReclaimCluster(true)
+	cluster.Spec.Size = 3
+	rack := &ackov1alpha1.Rack{ID: pvcReclaimRackID}
+
+	const configHash = "cfg-SAME"
+	podSpecHash := computePodSpecHash(cluster, rack)
+
+	sts := pvcReclaimSts(cluster.Name, int32Ptr(1), "data")
+	sts.Spec.Template = corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				utils.ConfigHashAnnotation:  configHash,
+				utils.PodSpecHashAnnotation: podSpecHash,
+			},
+		},
+	}
+
+	r := pvcReclaimReconciler(scheme,
+		sts,
+		pvcReclaimPod(cluster.Name, 0),
+		pvcReclaimPVC(cluster.Name, 0),
+		// Hand-created, bound to restored PVs, labelled like the operator's own.
+		pvcReclaimPVC(cluster.Name, 1),
+		pvcReclaimPVC(cluster.Name, 2),
+	)
+
+	if _, err := r.reconcileStatefulSet(
+		context.Background(), cluster, rack, nil, configHash, 3); err != nil {
+		t.Fatalf("reconcileStatefulSet() error = %v", err)
+	}
+
+	for _, ordinal := range []int{1, 2} {
+		name := pvcReclaimPVCName(cluster.Name, "data", ordinal)
+		if !pvcExists(t, r.Client, name) {
+			t.Errorf("pre-provisioned PVC %s was destroyed by the pre-scale-up reclaim", name)
+		}
+	}
+}
+
+// TestReclaimOrphanedRackPVCs_DefersWhenLivePodsAreInvisibleToRackQuery covers
+// the pod-gate bypass. len(rackPods) == spec.replicas only catches a *wrong*
+// count, so hiding pods until the count comes out right defeats it.
+//
+// This is reachable without an attacker: the StatefulSet's Selector is
+// SelectorLabelsForCluster, which carries no rack label, so acko.io/rack is not
+// selector-enforced — and podutil.BuildPodTemplateSpec lets
+// spec.podSpec.metadata.labels overwrite it. A lagging pod informer produces the
+// same shape. The fix is to gate on the StatefulSet's own status, which
+// kube-controller-manager computes from the StatefulSet's selector and which
+// arrives on the same object read as spec.replicas.
+func TestReclaimOrphanedRackPVCs_DefersWhenLivePodsAreInvisibleToRackQuery(t *testing.T) {
+	stsName := utils.StatefulSetName("demo", pvcReclaimRackID)
+
+	tests := []struct {
+		name string
+		// pods are the objects that exist; hiddenFromList are removed from every
+		// List result to model either a mislabelled pod or a stale informer.
+		visiblePods []int
+		hiddenPods  []int
+	}{
+		{
+			// Pods 1 and 2 are live but carry no rack label, so listRackPods
+			// returns exactly one pod and the count check passes.
+			name:        "pods mislabelled so the visible count matches",
+			visiblePods: []int{0},
+			hiddenPods:  []int{1, 2},
+		},
+		{
+			// Same shape via a lagging pod informer.
+			name:        "pods hidden by a stale informer",
+			visiblePods: []int{0},
+			hiddenPods:  []int{1, 2},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			scheme := rollingRestartScheme(t)
+			cluster := pvcReclaimCluster(true)
+
+			objs := make([]client.Object, 0, len(tc.visiblePods)+len(tc.hiddenPods)+3)
+			for _, o := range tc.visiblePods {
+				objs = append(objs, pvcReclaimPod(cluster.Name, o))
+			}
+			for _, o := range tc.hiddenPods {
+				objs = append(objs, pvcReclaimPod(cluster.Name, o))
+			}
+			for ordinal := range 3 {
+				objs = append(objs, pvcReclaimPVC(cluster.Name, ordinal))
+			}
+
+			base := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+			hidden := map[string]bool{}
+			for _, o := range tc.hiddenPods {
+				hidden[fmt.Sprintf("%s-%d", stsName, o)] = true
+			}
+			cl := interceptor.NewClient(base, interceptor.Funcs{
+				List: func(ctx context.Context, c client.WithWatch,
+					list client.ObjectList, opts ...client.ListOption) error {
+					if err := c.List(ctx, list, opts...); err != nil {
+						return err
+					}
+					pl, ok := list.(*corev1.PodList)
+					if !ok {
+						return nil
+					}
+					kept := pl.Items[:0]
+					for i := range pl.Items {
+						if !hidden[pl.Items[i].Name] {
+							kept = append(kept, pl.Items[i])
+						}
+					}
+					pl.Items = kept
+					return nil
+				},
+			})
+
+			r := &AerospikeClusterReconciler{
+				Client: cl, Scheme: scheme, Recorder: record.NewFakeRecorder(8),
+			}
+
+			// spec.replicas is 1, but kube-controller-manager still counts all
+			// three pods via the StatefulSet's own selector, so status.replicas
+			// is 3. That mismatch is what defers the pass.
+			sts := withStatusReplicas(pvcReclaimSts(cluster.Name, int32Ptr(1), "data"), 3)
+
+			r.reclaimOrphanedRackPVCs(context.Background(), cluster, pvcReclaimRackID,
+				sts, 1, cluster.Spec.Storage)
+
+			for ordinal := range 3 {
+				name := pvcReclaimPVCName(cluster.Name, "data", ordinal)
+				if !pvcExists(t, r.Client, name) {
+					t.Errorf("PVC %s deleted while its pod is live but invisible to the rack query", name)
+				}
+			}
+		})
+	}
+}
+
+// TestReclaimOrphanedRackPVCs_DefersUntilStatusCatchesUp pins the
+// ObservedGeneration half of the status gate: immediately after the operator
+// patches spec.replicas the StatefulSet controller has not acted yet, so no
+// conclusion may be drawn from status.replicas.
+func TestReclaimOrphanedRackPVCs_DefersUntilStatusCatchesUp(t *testing.T) {
+	scheme := rollingRestartScheme(t)
+	cluster := pvcReclaimCluster(true)
+
+	r := pvcReclaimReconciler(scheme,
+		pvcReclaimPod(cluster.Name, 0),
+		pvcReclaimPVC(cluster.Name, 0),
+		pvcReclaimPVC(cluster.Name, 1),
+	)
+
+	sts := pvcReclaimSts(cluster.Name, int32Ptr(1), "data")
+	sts.Generation = 7
+	sts.Status.ObservedGeneration = 6 // controller has not caught up
+
+	r.reclaimOrphanedRackPVCs(context.Background(), cluster, pvcReclaimRackID,
+		sts, 1, cluster.Spec.Storage)
+
+	if !pvcExists(t, r.Client, pvcReclaimPVCName(cluster.Name, "data", 1)) {
+		t.Error("PVC reclaimed while the StatefulSet status had not caught up with its spec")
+	}
+}
+
+// TestReclaimOrphanedRackPVCs_NeverSelectsPVCMissingComponentLabels closes the
+// gap a reviewer found by constructing a PVC that satisfied every other guard:
+// correct name, correct ordinal, nil ownerReferences, and the two labels the
+// legacy getter checks. The reclaim listing now matches all four labels
+// LabelsForCluster stamps, so a claim carrying only name+instance is not ours.
+func TestReclaimOrphanedRackPVCs_NeverSelectsPVCMissingComponentLabels(t *testing.T) {
+	scheme := rollingRestartScheme(t)
+	cluster := pvcReclaimCluster(true)
+
+	foreign := pvcReclaimPVCNamed(cluster.Name,
+		pvcReclaimPVCName(cluster.Name, "data", 1), false)
+	foreign.Labels = map[string]string{
+		utils.AppLabel:      "aerospike-cluster",
+		utils.InstanceLabel: cluster.Name,
+		// no component, no managed-by
+	}
+
+	r := pvcReclaimReconciler(scheme, pvcReclaimPod(cluster.Name, 0), foreign)
+	r.reclaimOrphanedRackPVCs(context.Background(), cluster, pvcReclaimRackID,
+		pvcReclaimSts(cluster.Name, int32Ptr(1), "data"), 1, cluster.Spec.Storage)
+
+	if !pvcExists(t, r.Client, foreign.Name) {
+		t.Error("PVC carrying only app/instance labels was reclaimed; " +
+			"component and managed-by must also match")
 	}
 }

--- a/internal/controller/reconciler_pvc_reclaim_test.go
+++ b/internal/controller/reconciler_pvc_reclaim_test.go
@@ -341,7 +341,7 @@ func TestReclaimOrphanedRackPVCs_NeverSelectsInUsePVC(t *testing.T) {
 			scheme := rollingRestartScheme(t)
 			cluster := pvcReclaimCluster(true)
 
-			var objs []client.Object
+			objs := make([]client.Object, 0, len(tc.podOrdinals)+len(tc.pvcOrdinals))
 			for _, ordinal := range tc.podOrdinals {
 				objs = append(objs, pvcReclaimPod(cluster.Name, ordinal))
 			}
@@ -399,7 +399,7 @@ func TestReclaimOrphanedRackPVCs_DefersWhenPodsMissingRackLabel(t *testing.T) {
 	r.reclaimOrphanedRackPVCs(context.Background(), cluster, pvcReclaimRackID,
 		pvcReclaimSts(cluster.Name, int32Ptr(1), "data"), cluster.Spec.Storage)
 
-	for ordinal := 0; ordinal < 3; ordinal++ {
+	for ordinal := range 3 {
 		name := pvcReclaimPVCName(cluster.Name, "data", ordinal)
 		if !pvcExists(t, r.Client, name) {
 			t.Errorf("PVC %s was deleted while a live pod at that ordinal exists "+
@@ -521,7 +521,7 @@ func TestReclaimOrphanedRackPVCs_DefersWhilePodAboveReplicaCountExists(t *testin
 	r.reclaimOrphanedRackPVCs(context.Background(), cluster, pvcReclaimRackID,
 		pvcReclaimSts(cluster.Name, int32Ptr(1), "data"), cluster.Spec.Storage)
 
-	for ordinal := 0; ordinal < 2; ordinal++ {
+	for ordinal := range 2 {
 		name := pvcReclaimPVCName(cluster.Name, "data", ordinal)
 		if !pvcExists(t, r.Client, name) {
 			t.Errorf("PVC %s was deleted while a pod above the replica count is still terminating", name)
@@ -567,7 +567,7 @@ func TestReclaimOrphanedRackPVCs_SkipsWhenReplicaCountUnknown(t *testing.T) {
 	r.reclaimOrphanedRackPVCs(context.Background(), cluster, pvcReclaimRackID,
 		pvcReclaimSts(cluster.Name, nil, "data"), cluster.Spec.Storage)
 
-	for ordinal := 0; ordinal < 2; ordinal++ {
+	for ordinal := range 2 {
 		name := pvcReclaimPVCName(cluster.Name, "data", ordinal)
 		if !pvcExists(t, r.Client, name) {
 			t.Errorf("PVC %s was deleted with an unknown replica count", name)
@@ -591,7 +591,7 @@ func TestReclaimOrphanedRackPVCs_SkipsAtZeroReplicas(t *testing.T) {
 	r.reclaimOrphanedRackPVCs(context.Background(), cluster, pvcReclaimRackID,
 		pvcReclaimSts(cluster.Name, int32Ptr(0), "data"), cluster.Spec.Storage)
 
-	for ordinal := 0; ordinal < 2; ordinal++ {
+	for ordinal := range 2 {
 		name := pvcReclaimPVCName(cluster.Name, "data", ordinal)
 		if !pvcExists(t, r.Client, name) {
 			t.Errorf("PVC %s was deleted for a rack at zero replicas", name)
@@ -633,7 +633,7 @@ func TestReclaimOrphanedRackPVCs_NonCascadeVolumesIssueNoList(t *testing.T) {
 		t.Errorf("issued %d List call(s) for a cluster with no cascadeDelete volume, want 0", lists)
 	}
 
-	for ordinal := 0; ordinal < 2; ordinal++ {
+	for ordinal := range 2 {
 		name := pvcReclaimPVCName(cluster.Name, "data", ordinal)
 		if !pvcExists(t, r.Client, name) {
 			t.Errorf("non-cascadeDelete PVC %s was deleted", name)

--- a/internal/controller/reconciler_statefulset.go
+++ b/internal/controller/reconciler_statefulset.go
@@ -99,6 +99,14 @@ func (r *AerospikeClusterReconciler) reconcileStatefulSet(
 	if existing.Spec.Replicas != nil {
 		oldReplicas = *existing.Spec.Replicas
 	}
+
+	// Reclaim PVCs orphaned above the StatefulSet's *observed* replica count.
+	// Runs on every pass, before any of the mutation logic below, so it is
+	// reached whichever way this function returns — see reclaimOrphanedRackPVCs
+	// for why keying it on the replica delta of a single reconcile leaked every
+	// scale-down PVC permanently.
+	r.reclaimOrphanedRackPVCs(ctx, cluster, rack.ID, stsName, existing.Spec.Replicas, storageSpec)
+
 	needsUpdate := oldReplicas != rackSize
 	var existingHash, existingPodSpecHash string
 	if existing.Spec.Template.Annotations != nil {
@@ -187,11 +195,13 @@ func (r *AerospikeClusterReconciler) reconcileStatefulSet(
 			"Rack %d scaled from %d to %d replicas", rack.ID, oldReplicas, targetReplicas)
 	}
 
-	// Cleanup orphaned PVCs after scale-down.
-	if scaleDown {
-		r.cleanupOrphanedPVCsAfterScaleDown(ctx, cluster, rack.ID, stsName, targetReplicas, oldReplicas, storageSpec)
-	}
-
+	// PVC reclamation for the ordinals this patch just removed happens on the
+	// NEXT reconcile, from the call at the top of this function: the pods are
+	// still terminating right now (deletion is asynchronous and they carry a
+	// preStop sleep), so any attempt here would defer anyway. Patching
+	// spec.replicas bumps the StatefulSet generation, and the ReadyReplicas
+	// change as the pods go away is a second trigger, so the follow-up reconcile
+	// is guaranteed rather than left to the resync period.
 	return false, nil
 }
 
@@ -230,46 +240,137 @@ func (r *AerospikeClusterReconciler) checkScaleDownReadiness(
 	return false, nil
 }
 
-// cleanupOrphanedPVCsAfterScaleDown verifies pods have terminated and then deletes orphaned PVCs.
-// Pod termination is asynchronous — PVCs are only deleted once all scaled-down pods are gone.
-func (r *AerospikeClusterReconciler) cleanupOrphanedPVCsAfterScaleDown(
+// reclaimOrphanedRackPVCs deletes cascade-delete PVCs left above the rack's
+// current replica count. It is idempotent and safe to call on every reconcile.
+//
+// Keyed on OBSERVED state, not on the replica delta of one reconcile. The
+// previous call site sat inside the `needsUpdate` branch and so ran only on the
+// pass that performed the scale-down — the single pass on which it can never
+// succeed, because pod deletion is asynchronous and the pods carry a preStop
+// sleep, so it always hit the "still terminating" deferral. On the next
+// reconcile the StatefulSet already read the desired size, both hashes matched,
+// and reconcileStatefulSet returned before the cleanup was reachable. Since the
+// default getScaleDownBatchSize returns the whole delta, the deferred pass was
+// the ONLY pass, so every cascadeDelete PVC leaked permanently.
+//
+// The leak is not merely wasted storage. StatefulSet PVC names are
+// ordinal-derived, so a later scale-up remounts the exact device the removed
+// node wrote, and the init container only wipes volumes explicitly marked
+// dirty — an Aerospike node can rejoin the cluster carrying records the
+// operator was told to destroy.
+//
+// Safety, in the order the guards run:
+//
+//   - specReplicas is the StatefulSet's own spec.replicas, NEVER the desired
+//     rack size. During a batched scale-down the ordinals between the two still
+//     have live pods, and deleting their PVCs would pull the volume out from
+//     under a running Aerospike node. A nil or non-positive value means the
+//     observed replica count is unknown or the rack is being torn down
+//     entirely, and reclamation is skipped rather than guessed at.
+//   - Only PVCs at ordinal >= specReplicas are ever considered, and only ones
+//     the operator owns and marked cascadeDelete. Both bounds live in
+//     storage.DeleteOrphanedCascadeDeletePVCs; a PVC in use by a pod at an
+//     ordinal below specReplicas cannot be selected by construction.
+//   - A pod observed at or above specReplicas defers the whole pass: that pod
+//     is still terminating and still mounting its volume.
+//
+// Cost on the steady-state path: nothing at all for clusters with no
+// cascadeDelete PV volume (the common case — cascadeDelete defaults to false),
+// which is checked before either List is issued.
+func (r *AerospikeClusterReconciler) reclaimOrphanedRackPVCs(
 	ctx context.Context,
 	cluster *ackov1alpha1.AerospikeCluster,
 	rackID int,
 	stsName string,
-	targetReplicas, oldReplicas int32,
+	specReplicas *int32,
 	storageSpec *ackov1alpha1.AerospikeStorageSpec,
 ) {
 	log := logf.FromContext(ctx)
 
+	// Cheapest gate first: with no cascade-delete PV volume there is nothing to
+	// reclaim, so skip the pod List and the PVC List entirely.
+	if !storage.HasCascadeDeletePVCs(storageSpec) {
+		return
+	}
+
+	// Without an observed replica count there is no safe lower bound on which
+	// ordinals are orphaned. Treating nil as 0 would make every PVC in the rack
+	// a candidate.
+	if specReplicas == nil {
+		log.V(1).Info("Skipping PVC reclamation: StatefulSet has no observed replica count",
+			"statefulset", stsName)
+		return
+	}
+	currentReplicas := *specReplicas
+
+	// A rack at zero replicas is being torn down, not scaled down. Whole-rack
+	// PVC deletion belongs to the rack-removal / cluster-deletion path, which
+	// deletes by ownership rather than by ordinal; reclaiming from ordinal 0
+	// here would duplicate that decision without its guards.
+	if currentReplicas < 1 {
+		log.V(1).Info("Skipping PVC reclamation: rack is at zero replicas",
+			"statefulset", stsName)
+		return
+	}
+
 	rackPods, listErr := r.listRackPods(ctx, cluster, rackID)
 	if listErr != nil {
-		log.Error(listErr, "Failed to list rack pods for PVC cleanup check, deferring PVC cleanup",
+		log.Error(listErr, "Failed to list rack pods for PVC reclamation, deferring",
 			"statefulset", stsName)
 		return
 	}
 
 	for i := range rackPods {
-		if podOrdinal(rackPods[i].Name) >= int(targetReplicas) {
-			log.Info("Deferring PVC cleanup: scaled-down pods still terminating",
-				"statefulset", stsName, "targetReplicas", targetReplicas)
+		ordinal, ok := rackPodOrdinal(rackPods[i].Name)
+		if !ok || ordinal >= int(currentReplicas) {
+			// Fail closed on an unparseable name: a pod whose ordinal we cannot
+			// read must never be assumed to be below the replica count.
+			log.V(1).Info("Deferring PVC reclamation: a pod at or above the replica count is still present",
+				"statefulset", stsName, "pod", rackPods[i].Name, "replicas", currentReplicas)
 			return
 		}
 	}
 
-	log.Info("All scaled-down pods terminated, cleaning up orphaned cascade-delete PVCs",
-		"name", stsName, "old", oldReplicas, "new", targetReplicas)
+	log.V(1).Info("Checking for orphaned cascade-delete PVCs",
+		"statefulset", stsName, "replicas", currentReplicas)
 	deleted, err := storage.DeleteOrphanedCascadeDeletePVCs(
-		ctx, r.Client, cluster.Namespace, cluster.Name, stsName, targetReplicas, storageSpec)
+		ctx, r.Client, cluster.Namespace, cluster.Name, stsName, currentReplicas, storageSpec)
 	if err != nil {
 		log.Error(err, "Failed to delete orphaned cascade PVCs", "statefulset", stsName)
 		r.Recorder.Eventf(cluster, corev1.EventTypeWarning, EventPVCCleanupFailed,
 			"Failed to delete orphaned cascade PVCs for %s: %v", stsName, err)
 	} else if deleted > 0 {
-		log.Info("Deleted orphaned cascade-delete PVCs", "statefulset", stsName, "count", deleted)
+		log.Info("Deleted orphaned cascade-delete PVCs",
+			"statefulset", stsName, "count", deleted, "replicas", currentReplicas)
 		r.Recorder.Eventf(cluster, corev1.EventTypeNormal, EventPVCCleanedUp,
-			"Deleted %d orphaned PVC(s) for %s after scale-down", deleted, stsName)
+			"Deleted %d orphaned PVC(s) for %s above replica count %d", deleted, stsName, currentReplicas)
 	}
+}
+
+// rackPodOrdinal parses the StatefulSet ordinal from a pod name, reporting
+// whether the parse succeeded.
+//
+// podOrdinal returns 0 for a name it cannot parse, which is fine for restart
+// *ordering* but not for a destructive decision: "ordinal 0" would read as
+// "below the replica count, therefore not blocking PVC deletion". Reclamation
+// uses this instead and fails closed.
+func rackPodOrdinal(podName string) (int, bool) {
+	idx := strings.LastIndex(podName, "-")
+	if idx < 0 {
+		return 0, false
+	}
+	ordinal, err := strconv.Atoi(podName[idx+1:])
+	if err != nil {
+		return 0, false
+	}
+	// The ordinal is the segment after the last dash, so a leading '-' is always
+	// consumed as the separator and Atoi can never return a negative value here.
+	// The bound is asserted rather than assumed because the reclamation guard's
+	// "ordinal >= replicas" comparison depends on it.
+	if ordinal < 0 {
+		return 0, false
+	}
+	return ordinal, true
 }
 
 func (r *AerospikeClusterReconciler) buildStatefulSet(

--- a/internal/controller/reconciler_statefulset.go
+++ b/internal/controller/reconciler_statefulset.go
@@ -105,7 +105,12 @@ func (r *AerospikeClusterReconciler) reconcileStatefulSet(
 	// reached whichever way this function returns — see reclaimOrphanedRackPVCs
 	// for why keying it on the replica delta of a single reconcile leaked every
 	// scale-down PVC permanently.
-	r.reclaimOrphanedRackPVCs(ctx, cluster, rack.ID, stsName, existing.Spec.Replicas, storageSpec)
+	//
+	// Deliberately runs before a scale-up patch too. On 3->5 it reclaims any
+	// leftover PVCs at ordinals 3-4 and the StatefulSet then provisions fresh
+	// ones, which is the whole point: skipping reclamation here would hand the
+	// new pods the exact devices the removed nodes wrote.
+	r.reclaimOrphanedRackPVCs(ctx, cluster, rack.ID, existing, storageSpec)
 
 	needsUpdate := oldReplicas != rackSize
 	var existingHash, existingPodSpecHash string
@@ -261,18 +266,25 @@ func (r *AerospikeClusterReconciler) checkScaleDownReadiness(
 //
 // Safety, in the order the guards run:
 //
-//   - specReplicas is the StatefulSet's own spec.replicas, NEVER the desired
-//     rack size. During a batched scale-down the ordinals between the two still
-//     have live pods, and deleting their PVCs would pull the volume out from
-//     under a running Aerospike node. A nil or non-positive value means the
-//     observed replica count is unknown or the rack is being torn down
-//     entirely, and reclamation is skipped rather than guessed at.
-//   - Only PVCs at ordinal >= specReplicas are ever considered, and only ones
-//     the operator owns and marked cascadeDelete. Both bounds live in
-//     storage.DeleteOrphanedCascadeDeletePVCs; a PVC in use by a pod at an
-//     ordinal below specReplicas cannot be selected by construction.
-//   - A pod observed at or above specReplicas defers the whole pass: that pod
-//     is still terminating and still mounting its volume.
+//   - The bound is sts.Spec.Replicas — the count the StatefulSet is actually
+//     running — NEVER the desired rack size. During a batched scale-down the
+//     ordinals between the two still have live pods, and deleting their PVCs
+//     would pull the volume out from under a running Aerospike node. A nil or
+//     non-positive value means the observed replica count is unknown or the rack
+//     is being torn down entirely, and reclamation is skipped rather than
+//     guessed at.
+//   - The observed pod set must match the replica count exactly. This gate is
+//     LOAD-BEARING, not a second layer: the ordinal bound alone is not
+//     sufficient, because during a scale-down the StatefulSet's replica count
+//     drops before the removed pods finish terminating, so a PVC at an ordinal
+//     >= spec.replicas can still be mounted. Requiring len(pods) ==
+//     spec.replicas closes the case where the label query returns fewer pods
+//     than exist and the per-pod check would be vacuous.
+//   - Selection then requires ALL of: ordinal >= spec.replicas, the operator's
+//     cluster labels (with no unfiltered namespace-wide fallback), a volume name
+//     that is one of the StatefulSet's own VolumeClaimTemplates, no foreign
+//     ownerReference, and cascadeDelete on that volume. See
+//     storage.ownedOrphanCandidates.
 //
 // Cost on the steady-state path: nothing at all for clusters with no
 // cascadeDelete PV volume (the common case — cascadeDelete defaults to false),
@@ -281,8 +293,7 @@ func (r *AerospikeClusterReconciler) reclaimOrphanedRackPVCs(
 	ctx context.Context,
 	cluster *ackov1alpha1.AerospikeCluster,
 	rackID int,
-	stsName string,
-	specReplicas *int32,
+	sts *appsv1.StatefulSet,
 	storageSpec *ackov1alpha1.AerospikeStorageSpec,
 ) {
 	log := logf.FromContext(ctx)
@@ -293,15 +304,20 @@ func (r *AerospikeClusterReconciler) reclaimOrphanedRackPVCs(
 		return
 	}
 
+	if sts == nil {
+		return
+	}
+	stsName := sts.Name
+
 	// Without an observed replica count there is no safe lower bound on which
 	// ordinals are orphaned. Treating nil as 0 would make every PVC in the rack
 	// a candidate.
-	if specReplicas == nil {
+	if sts.Spec.Replicas == nil {
 		log.V(1).Info("Skipping PVC reclamation: StatefulSet has no observed replica count",
 			"statefulset", stsName)
 		return
 	}
-	currentReplicas := *specReplicas
+	currentReplicas := *sts.Spec.Replicas
 
 	// A rack at zero replicas is being torn down, not scaled down. Whole-rack
 	// PVC deletion belongs to the rack-removal / cluster-deletion path, which
@@ -320,6 +336,17 @@ func (r *AerospikeClusterReconciler) reclaimOrphanedRackPVCs(
 		return
 	}
 
+	// Fail closed unless the rack has converged to exactly the observed replica
+	// count. Fewer pods than replicas means either the rack is still coming up or
+	// the label query is not seeing every pod — in which case the per-pod ordinal
+	// check below would pass vacuously while live pods sit above the bound. More
+	// pods than replicas means a scale-down is still in flight.
+	if len(rackPods) != int(currentReplicas) {
+		log.V(1).Info("Deferring PVC reclamation: observed pod count does not match the replica count",
+			"statefulset", stsName, "pods", len(rackPods), "replicas", currentReplicas)
+		return
+	}
+
 	for i := range rackPods {
 		ordinal, ok := rackPodOrdinal(rackPods[i].Name)
 		if !ok || ordinal >= int(currentReplicas) {
@@ -334,7 +361,7 @@ func (r *AerospikeClusterReconciler) reclaimOrphanedRackPVCs(
 	log.V(1).Info("Checking for orphaned cascade-delete PVCs",
 		"statefulset", stsName, "replicas", currentReplicas)
 	deleted, err := storage.DeleteOrphanedCascadeDeletePVCs(
-		ctx, r.Client, cluster.Namespace, cluster.Name, stsName, currentReplicas, storageSpec)
+		ctx, r.Client, sts, cluster.Name, currentReplicas, storageSpec)
 	if err != nil {
 		log.Error(err, "Failed to delete orphaned cascade PVCs", "statefulset", stsName)
 		r.Recorder.Eventf(cluster, corev1.EventTypeWarning, EventPVCCleanupFailed,

--- a/internal/controller/reconciler_statefulset.go
+++ b/internal/controller/reconciler_statefulset.go
@@ -106,11 +106,10 @@ func (r *AerospikeClusterReconciler) reconcileStatefulSet(
 	// for why keying it on the replica delta of a single reconcile leaked every
 	// scale-down PVC permanently.
 	//
-	// Deliberately runs before a scale-up patch too. On 3->5 it reclaims any
-	// leftover PVCs at ordinals 3-4 and the StatefulSet then provisions fresh
-	// ones, which is the whole point: skipping reclamation here would hand the
-	// new pods the exact devices the removed nodes wrote.
-	r.reclaimOrphanedRackPVCs(ctx, cluster, rack.ID, existing, storageSpec)
+	// rackSize is passed so reclamation can tell an operator-driven scale-down
+	// from an external write that lowered spec.replicas behind the operator's
+	// back — see reclaimOrphanedRackPVCs.
+	r.reclaimOrphanedRackPVCs(ctx, cluster, rack.ID, existing, rackSize, storageSpec)
 
 	needsUpdate := oldReplicas != rackSize
 	var existingHash, existingPodSpecHash string
@@ -273,13 +272,18 @@ func (r *AerospikeClusterReconciler) checkScaleDownReadiness(
 //     non-positive value means the observed replica count is unknown or the rack
 //     is being torn down entirely, and reclamation is skipped rather than
 //     guessed at.
-//   - The observed pod set must match the replica count exactly. This gate is
-//     LOAD-BEARING, not a second layer: the ordinal bound alone is not
-//     sufficient, because during a scale-down the StatefulSet's replica count
-//     drops before the removed pods finish terminating, so a PVC at an ordinal
-//     >= spec.replicas can still be mounted. Requiring len(pods) ==
-//     spec.replicas closes the case where the label query returns fewer pods
-//     than exist and the per-pod check would be vacuous.
+//   - currentReplicas must not be below rackSize. Only an operator-driven
+//     scale-down may trigger reclamation; an external write that lowered
+//     spec.replicas must not.
+//   - The StatefulSet must report a settled status matching its spec
+//     (ObservedGeneration == Generation, Status.Replicas == Spec.Replicas).
+//     This is the LOAD-BEARING pod gate: the ordinal bound alone is not
+//     sufficient, because during a scale-down the replica count drops before
+//     the removed pods finish terminating, so a PVC at an ordinal >=
+//     spec.replicas can still be mounted. status.replicas comes from
+//     kube-controller-manager using the StatefulSet's own selector, so unlike a
+//     rack-label query it cannot be defeated by pod labels or a stale informer.
+//   - The rack-label pod list is kept as a secondary check.
 //   - Selection then requires ALL of: ordinal >= spec.replicas, the operator's
 //     cluster labels (with no unfiltered namespace-wide fallback), a volume name
 //     that is one of the StatefulSet's own VolumeClaimTemplates, no foreign
@@ -294,6 +298,7 @@ func (r *AerospikeClusterReconciler) reclaimOrphanedRackPVCs(
 	cluster *ackov1alpha1.AerospikeCluster,
 	rackID int,
 	sts *appsv1.StatefulSet,
+	rackSize int32,
 	storageSpec *ackov1alpha1.AerospikeStorageSpec,
 ) {
 	log := logf.FromContext(ctx)
@@ -329,6 +334,49 @@ func (r *AerospikeClusterReconciler) reclaimOrphanedRackPVCs(
 		return
 	}
 
+	// Only reclaim when the operator itself put the StatefulSet at this replica
+	// count. A count BELOW the rack size the operator wants did not come from an
+	// operator scale-down — `kubectl scale sts`, an HPA aimed at the StatefulSet
+	// instead of the CR, GitOps drift or a backup restore can all lower it — and
+	// this function sits above the scale-down branch, so isMigrationInProgress
+	// and the quiesce path never run for it. Reclaiming there would destroy the
+	// volumes of every ordinal the operator is about to bring back, on the same
+	// pass that scales the rack up onto blank devices.
+	//
+	// Skipping is safe because reclamation also runs on every converged pass: a
+	// stale volume left by a real scale-down is caught while the rack sits at the
+	// smaller size, not only on the way back up. The residual gap is a scale-down
+	// immediately followed by a scale-up with no reconcile converging in between,
+	// which is documented in the PR rather than papered over.
+	if currentReplicas < rackSize {
+		log.V(1).Info("Skipping PVC reclamation: StatefulSet is below the desired rack size",
+			"statefulset", stsName, "replicas", currentReplicas, "rackSize", rackSize)
+		return
+	}
+
+	// The StatefulSet's own status is the authoritative pod count, and it is the
+	// only one that cannot be defeated by labels. kube-controller-manager
+	// computes status.replicas from the StatefulSet's OWN selector
+	// (SelectorLabelsForCluster, which carries no rack label) and counts
+	// terminating pods, and it arrives on the same object read as spec.replicas,
+	// so there is no cross-informer skew.
+	//
+	// The label-scoped list below cannot do this job alone: the rack label is not
+	// selector-enforced, and podutil.BuildPodTemplateSpec lets
+	// spec.podSpec.metadata.labels overwrite acko.io/rack, so a pod can be live
+	// and invisible to listRackPods. A stale pod informer has the same effect.
+	if sts.Status.ObservedGeneration != sts.Generation {
+		log.V(1).Info("Deferring PVC reclamation: StatefulSet status has not caught up with its spec",
+			"statefulset", stsName, "generation", sts.Generation,
+			"observedGeneration", sts.Status.ObservedGeneration)
+		return
+	}
+	if sts.Status.Replicas != currentReplicas {
+		log.V(1).Info("Deferring PVC reclamation: StatefulSet still reports pods it has not released",
+			"statefulset", stsName, "statusReplicas", sts.Status.Replicas, "replicas", currentReplicas)
+		return
+	}
+
 	rackPods, listErr := r.listRackPods(ctx, cluster, rackID)
 	if listErr != nil {
 		log.Error(listErr, "Failed to list rack pods for PVC reclamation, deferring",
@@ -336,11 +384,9 @@ func (r *AerospikeClusterReconciler) reclaimOrphanedRackPVCs(
 		return
 	}
 
-	// Fail closed unless the rack has converged to exactly the observed replica
-	// count. Fewer pods than replicas means either the rack is still coming up or
-	// the label query is not seeing every pod — in which case the per-pod ordinal
-	// check below would pass vacuously while live pods sit above the bound. More
-	// pods than replicas means a scale-down is still in flight.
+	// Secondary check. Weaker than the status gate above — it can be defeated by
+	// label manipulation or a stale informer — but it costs nothing and catches
+	// the case where the rack label genuinely disagrees with the StatefulSet.
 	if len(rackPods) != int(currentReplicas) {
 		log.V(1).Info("Deferring PVC reclamation: observed pod count does not match the replica count",
 			"statefulset", stsName, "pods", len(rackPods), "replicas", currentReplicas)

--- a/internal/storage/pvc.go
+++ b/internal/storage/pvc.go
@@ -60,21 +60,14 @@ func GetPVCsForStatefulSet(ctx context.Context, c client.Client, namespace, clus
 	return matched, nil
 }
 
-// DeleteOrphanedCascadeDeletePVCs removes PVCs for pod ordinals >= desiredReplicas,
-// but only for volumes that have cascadeDelete enabled. Non-cascade PVCs are preserved.
-// This is the correct function to use during scale-down.
-func DeleteOrphanedCascadeDeletePVCs(
-	ctx context.Context,
-	c client.Client,
-	namespace, clusterName, stsName string,
-	desiredReplicas int32,
-	storageSpec *v1alpha1.AerospikeStorageSpec,
-) (int, error) {
+// cascadeDeleteVolumeNames returns the set of PV-backed volume names that have
+// cascadeDelete enabled. Volumes without a PersistentVolume source have no PVC
+// to reclaim, and cascadeDelete defaults to false, so the set is empty for any
+// cluster that has not opted in.
+func cascadeDeleteVolumeNames(storageSpec *v1alpha1.AerospikeStorageSpec) map[string]bool {
 	if storageSpec == nil {
-		return 0, nil
+		return nil
 	}
-
-	// Build a set of volume names that have cascadeDelete enabled
 	cascadeVolumes := make(map[string]bool)
 	for i := range storageSpec.Volumes {
 		vol := &storageSpec.Volumes[i]
@@ -82,7 +75,37 @@ func DeleteOrphanedCascadeDeletePVCs(
 			cascadeVolumes[vol.Name] = true
 		}
 	}
+	return cascadeVolumes
+}
 
+// HasCascadeDeletePVCs reports whether the spec declares any PV-backed volume
+// with cascadeDelete enabled — i.e. whether there is anything for
+// DeleteOrphanedCascadeDeletePVCs to reclaim at all.
+//
+// Callers use it as a cheap pre-gate so the steady-state reconcile path skips
+// the PVC List entirely for clusters that never opt into cascadeDelete. It
+// shares cascadeDeleteVolumeNames with the deleter deliberately: a gate that
+// could ever be looser than the deleter's own predicate would let a caller
+// believe it had reclaimed PVCs it never looked at.
+func HasCascadeDeletePVCs(storageSpec *v1alpha1.AerospikeStorageSpec) bool {
+	return len(cascadeDeleteVolumeNames(storageSpec)) > 0
+}
+
+// DeleteOrphanedCascadeDeletePVCs removes PVCs for pod ordinals >= desiredReplicas,
+// but only for volumes that have cascadeDelete enabled. Non-cascade PVCs are preserved.
+// This is the correct function to use during scale-down.
+//
+// desiredReplicas must be the replica count the StatefulSet is actually running
+// (its own spec.replicas), never a lower target the operator is still working
+// towards: ordinals between the two still have live pods holding their volumes.
+func DeleteOrphanedCascadeDeletePVCs(
+	ctx context.Context,
+	c client.Client,
+	namespace, clusterName, stsName string,
+	desiredReplicas int32,
+	storageSpec *v1alpha1.AerospikeStorageSpec,
+) (int, error) {
+	cascadeVolumes := cascadeDeleteVolumeNames(storageSpec)
 	if len(cascadeVolumes) == 0 {
 		return 0, nil
 	}
@@ -222,19 +245,7 @@ func DeleteCascadeDeletePVCs(
 	namespace, clusterName, stsName string,
 	storageSpec *v1alpha1.AerospikeStorageSpec,
 ) error {
-	if storageSpec == nil {
-		return nil
-	}
-
-	// Build a set of volume names that have cascadeDelete enabled
-	cascadeVolumes := make(map[string]bool)
-	for i := range storageSpec.Volumes {
-		vol := &storageSpec.Volumes[i]
-		if vol.Source.PersistentVolume != nil && ResolveCascadeDelete(vol, storageSpec) {
-			cascadeVolumes[vol.Name] = true
-		}
-	}
-
+	cascadeVolumes := cascadeDeleteVolumeNames(storageSpec)
 	if len(cascadeVolumes) == 0 {
 		return nil
 	}

--- a/internal/storage/pvc.go
+++ b/internal/storage/pvc.go
@@ -7,8 +7,10 @@ import (
 	"strconv"
 	"strings"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
@@ -91,26 +93,121 @@ func HasCascadeDeletePVCs(storageSpec *v1alpha1.AerospikeStorageSpec) bool {
 	return len(cascadeDeleteVolumeNames(storageSpec)) > 0
 }
 
-// DeleteOrphanedCascadeDeletePVCs removes PVCs for pod ordinals >= desiredReplicas,
-// but only for volumes that have cascadeDelete enabled. Non-cascade PVCs are preserved.
-// This is the correct function to use during scale-down.
+// ownedByStatefulSetUID reports whether pvc may be attributed to the given
+// StatefulSet UID.
+//
+// A PVC with NO ownerReferences passes, because that is the normal shape rather
+// than an anomaly: the StatefulSet controller only stamps an ownerReference onto
+// a volumeClaimTemplate PVC when persistentVolumeClaimRetentionPolicy is set to
+// Delete, and this operator never sets that field — it defaults to
+// Retain/Retain, documented upstream as "retained until manually deleted".
+// Requiring an ownerReference would reclaim nothing at all on a default install.
+//
+// What this check does buy is rejecting a PVC that names some *other* owner: a
+// sibling StatefulSet, a foreign cluster, or a hand-created claim that happens
+// to collide with the ordinal naming pattern.
+func ownedByStatefulSetUID(pvc *corev1.PersistentVolumeClaim, stsUID types.UID) bool {
+	refs := pvc.GetOwnerReferences()
+	if len(refs) == 0 {
+		return true
+	}
+	for i := range refs {
+		if refs[i].UID == stsUID {
+			return true
+		}
+	}
+	return false
+}
+
+// ownedOrphanCandidates returns the PVCs that belong to sts and sit at an
+// ordinal at or above desiredReplicas.
+//
+// Ownership is established against the StatefulSet object the caller just read,
+// and every available signal must agree:
+//
+//   - The operator's cluster labels must be present. Unlike
+//     GetPVCsForStatefulSet this deliberately does NOT fall back to an
+//     unfiltered namespace-wide List. That fallback exists so cluster
+//     *deletion* can still find legacy pre-label PVCs, and in that path a name
+//     substring is the only ownership signal. Reclamation runs on every
+//     reconcile of every rack, so it must not inherit a name-only test — an
+//     unlabelled foreign claim called data-<sts>-9 would be selected.
+//   - The PVC name must decompose as <volume>-<stsName>-<ordinal> where
+//     <volume> is one of the StatefulSet's own VolumeClaimTemplate names, taken
+//     from the live object rather than from the spec.
+//   - Any ownerReferences present must include this StatefulSet's UID.
 //
 // desiredReplicas must be the replica count the StatefulSet is actually running
 // (its own spec.replicas), never a lower target the operator is still working
 // towards: ordinals between the two still have live pods holding their volumes.
+func ownedOrphanCandidates(
+	ctx context.Context,
+	c client.Client,
+	sts *appsv1.StatefulSet,
+	clusterName string,
+	desiredReplicas int32,
+) ([]corev1.PersistentVolumeClaim, error) {
+	vctNames := make(map[string]bool, len(sts.Spec.VolumeClaimTemplates))
+	for i := range sts.Spec.VolumeClaimTemplates {
+		vctNames[sts.Spec.VolumeClaimTemplates[i].Name] = true
+	}
+	if len(vctNames) == 0 {
+		return nil, nil
+	}
+
+	pvcList := &corev1.PersistentVolumeClaimList{}
+	if err := c.List(ctx, pvcList,
+		client.InNamespace(sts.Namespace),
+		client.MatchingLabels{
+			"app.kubernetes.io/name":     "aerospike-cluster",
+			"app.kubernetes.io/instance": clusterName,
+		},
+	); err != nil {
+		return nil, fmt.Errorf("listing PVCs in namespace %s: %w", sts.Namespace, err)
+	}
+
+	var matched []corev1.PersistentVolumeClaim
+	for i := range pvcList.Items {
+		pvc := &pvcList.Items[i]
+
+		ordinal, ok := extractOrdinal(pvc.Name, sts.Name)
+		if !ok || ordinal < desiredReplicas {
+			continue
+		}
+		volName, ok := extractVolumeName(pvc.Name, sts.Name)
+		if !ok || !vctNames[volName] {
+			continue
+		}
+		if !ownedByStatefulSetUID(pvc, sts.UID) {
+			continue
+		}
+		matched = append(matched, *pvc)
+	}
+
+	return matched, nil
+}
+
+// DeleteOrphanedCascadeDeletePVCs removes PVCs for pod ordinals >= desiredReplicas,
+// but only for volumes that have cascadeDelete enabled. Non-cascade PVCs are preserved.
+// This is the correct function to use during scale-down.
+//
+// sts must be the live StatefulSet object; it supplies the namespace, the name
+// prefix, the VolumeClaimTemplate names and the UID that together establish
+// ownership. See ownedOrphanCandidates for the full predicate.
 func DeleteOrphanedCascadeDeletePVCs(
 	ctx context.Context,
 	c client.Client,
-	namespace, clusterName, stsName string,
+	sts *appsv1.StatefulSet,
+	clusterName string,
 	desiredReplicas int32,
 	storageSpec *v1alpha1.AerospikeStorageSpec,
 ) (int, error) {
 	cascadeVolumes := cascadeDeleteVolumeNames(storageSpec)
-	if len(cascadeVolumes) == 0 {
+	if len(cascadeVolumes) == 0 || sts == nil {
 		return 0, nil
 	}
 
-	pvcs, err := GetPVCsForStatefulSet(ctx, c, namespace, clusterName, stsName)
+	pvcs, err := ownedOrphanCandidates(ctx, c, sts, clusterName, desiredReplicas)
 	if err != nil {
 		return 0, err
 	}
@@ -119,21 +216,9 @@ func DeleteOrphanedCascadeDeletePVCs(
 	var deleteErrs []error
 	for i := range pvcs {
 		pvc := &pvcs[i]
-		ordinal, ok := extractOrdinal(pvc.Name, stsName)
-		if !ok {
-			continue
-		}
 
-		if ordinal < desiredReplicas {
-			continue
-		}
-
-		volName, ok := extractVolumeName(pvc.Name, stsName)
-		if !ok {
-			continue
-		}
-
-		if !cascadeVolumes[volName] {
+		volName, ok := extractVolumeName(pvc.Name, sts.Name)
+		if !ok || !cascadeVolumes[volName] {
 			continue
 		}
 

--- a/internal/storage/pvc.go
+++ b/internal/storage/pvc.go
@@ -12,8 +12,10 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	v1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/utils"
 )
 
 // GetPVCsForStatefulSet lists PVCs belonging to the given StatefulSet of the
@@ -119,6 +121,16 @@ func ownedByStatefulSetUID(pvc *corev1.PersistentVolumeClaim, stsUID types.UID) 
 	return false
 }
 
+// ownerRefSummary renders a PVC's ownerReferences compactly for a log field.
+func ownerRefSummary(pvc *corev1.PersistentVolumeClaim) string {
+	refs := pvc.GetOwnerReferences()
+	parts := make([]string, 0, len(refs))
+	for i := range refs {
+		parts = append(parts, fmt.Sprintf("%s/%s(%s)", refs[i].Kind, refs[i].Name, refs[i].UID))
+	}
+	return strings.Join(parts, ",")
+}
+
 // ownedOrphanCandidates returns the PVCs that belong to sts and sit at an
 // ordinal at or above desiredReplicas.
 //
@@ -155,13 +167,14 @@ func ownedOrphanCandidates(
 		return nil, nil
 	}
 
+	// All four labels LabelsForCluster stamps, not just the two the legacy
+	// getter checks. component and managed-by cost nothing to match and narrow
+	// the surface against hand-created or restored claims that happen to carry
+	// the name/instance pair.
 	pvcList := &corev1.PersistentVolumeClaimList{}
 	if err := c.List(ctx, pvcList,
 		client.InNamespace(sts.Namespace),
-		client.MatchingLabels{
-			"app.kubernetes.io/name":     "aerospike-cluster",
-			"app.kubernetes.io/instance": clusterName,
-		},
+		client.MatchingLabels(utils.LabelsForCluster(clusterName)),
 	); err != nil {
 		return nil, fmt.Errorf("listing PVCs in namespace %s: %w", sts.Namespace, err)
 	}
@@ -179,6 +192,16 @@ func ownedOrphanCandidates(
 			continue
 		}
 		if !ownedByStatefulSetUID(pvc, sts.UID) {
+			// Log rather than drop silently. Under
+			// persistentVolumeClaimRetentionPolicy.whenScaled=Delete the
+			// StatefulSet controller stamps the *Pod* as owner, which reads as
+			// foreign here — correct (kube-controller-manager reclaims those
+			// itself, so this path has nothing to do) but worth seeing, because
+			// otherwise reclamation appearing to do nothing is indistinguishable
+			// from reclamation being broken.
+			logf.FromContext(ctx).V(1).Info(
+				"Skipping PVC: ownerReferences name a different owner",
+				"pvc", pvc.Name, "statefulset", sts.Name, "owners", ownerRefSummary(pvc))
 			continue
 		}
 		matched = append(matched, *pvc)

--- a/internal/storage/pvc_cascade_test.go
+++ b/internal/storage/pvc_cascade_test.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"testing"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -95,6 +97,29 @@ func storageSpecMultiVolume(cascadeVol, nonCascadeVol string) *v1alpha1.Aerospik
 	}
 }
 
+// testStsUID is the UID PVC ownerReferences must match to be reclaimable.
+const testStsUID = types.UID("sts-uid-1")
+
+// newTestSts builds the StatefulSet the reclaim predicate is evaluated against.
+// It supplies the namespace, the name prefix, the UID and the
+// VolumeClaimTemplate names a PVC's volume must be one of.
+func newTestSts(vctNames ...string) *appsv1.StatefulSet {
+	vcts := make([]corev1.PersistentVolumeClaim, 0, len(vctNames))
+	for _, name := range vctNames {
+		vcts = append(vcts, corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+		})
+	}
+	return &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testStsName,
+			Namespace: testNamespace,
+			UID:       testStsUID,
+		},
+		Spec: appsv1.StatefulSetSpec{VolumeClaimTemplates: vcts},
+	}
+}
+
 // --- DeleteOrphanedCascadeDeletePVCs tests ---
 
 func TestDeleteOrphanedCascadeDeletePVCs_DeletesOnlyCascadeOrphans(t *testing.T) {
@@ -113,7 +138,7 @@ func TestDeleteOrphanedCascadeDeletePVCs_DeletesOnlyCascadeOrphans(t *testing.T)
 	)
 
 	ctx := context.Background()
-	deleted, err := DeleteOrphanedCascadeDeletePVCs(ctx, c, testNamespace, testClusterName, testStsName, 1, spec)
+	deleted, err := DeleteOrphanedCascadeDeletePVCs(ctx, c, newTestSts("data", "logs"), testClusterName, 1, spec)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -166,7 +191,7 @@ func TestDeleteOrphanedCascadeDeletePVCs_NoCascadeVolumes(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	deleted, err := DeleteOrphanedCascadeDeletePVCs(ctx, c, testNamespace, testClusterName, testStsName, 1, spec)
+	deleted, err := DeleteOrphanedCascadeDeletePVCs(ctx, c, newTestSts("data"), testClusterName, 1, spec)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -191,7 +216,7 @@ func TestDeleteOrphanedCascadeDeletePVCs_NilStorageSpec(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	deleted, err := DeleteOrphanedCascadeDeletePVCs(ctx, c, testNamespace, testClusterName, testStsName, 0, nil)
+	deleted, err := DeleteOrphanedCascadeDeletePVCs(ctx, c, newTestSts("data"), testClusterName, 0, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -211,7 +236,7 @@ func TestDeleteOrphanedCascadeDeletePVCs_AllCascadeAllOrphans(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	deleted, err := DeleteOrphanedCascadeDeletePVCs(ctx, c, testNamespace, testClusterName, testStsName, 0, spec)
+	deleted, err := DeleteOrphanedCascadeDeletePVCs(ctx, c, newTestSts("data"), testClusterName, 0, spec)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -238,7 +263,7 @@ func TestDeleteOrphanedCascadeDeletePVCs_NoOrphans(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	deleted, err := DeleteOrphanedCascadeDeletePVCs(ctx, c, testNamespace, testClusterName, testStsName, 2, spec)
+	deleted, err := DeleteOrphanedCascadeDeletePVCs(ctx, c, newTestSts("data"), testClusterName, 2, spec)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -273,7 +298,7 @@ func TestDeleteOrphanedCascadeDeletePVCs_PolicyFallback(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	deleted, err := DeleteOrphanedCascadeDeletePVCs(ctx, c, testNamespace, testClusterName, testStsName, 1, spec)
+	deleted, err := DeleteOrphanedCascadeDeletePVCs(ctx, c, newTestSts("data"), testClusterName, 1, spec)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/storage/pvc_cascade_test.go
+++ b/internal/storage/pvc_cascade_test.go
@@ -14,6 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	v1alpha1 "github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/api/v1alpha1"
+	"github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/internal/utils"
 )
 
 const (
@@ -33,10 +34,11 @@ func newPVCForCluster(name, clusterName string) *corev1.PersistentVolumeClaim {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: testNamespace,
-			Labels: map[string]string{
-				"app.kubernetes.io/name":     "aerospike-cluster",
-				"app.kubernetes.io/instance": clusterName,
-			},
+			// The full label set the operator stamps onto VolumeClaimTemplates,
+			// not just the two GetPVCsForStatefulSet happens to filter on — the
+			// reclaim path requires all four, so an under-specified fixture would
+			// silently stop matching.
+			Labels: utils.LabelsForCluster(clusterName),
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{
 			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},


### PR DESCRIPTION
## Problem

`internal/controller/reconciler_statefulset.go:102`:

```go
needsUpdate := oldReplicas != rackSize
```

gates the whole update block, and the PVC cleanup call sat **inside** it at `:191`:

```go
if scaleDown {
    r.cleanupOrphanedPVCsAfterScaleDown(ctx, cluster, rack.ID, stsName, targetReplicas, oldReplicas, storageSpec)
}
```

On the pass that performs the scale-down, the cleanup returns early because the removed pods are still terminating (`:253-257` — deletion is asynchronous and the pods carry a `preStop` sleep):

```go
for i := range rackPods {
    if podOrdinal(rackPods[i].Name) >= int(targetReplicas) {
        log.Info("Deferring PVC cleanup: scaled-down pods still terminating", ...)
        return
    }
}
```

On the next reconcile the StatefulSet already reads `rackSize`, both hashes match, and `:116` returns before the cleanup is reachable again. Since the default `getScaleDownBatchSize` returns the full delta (`:432`), the deferred pass is the **only** pass — so **every `cascadeDelete: true` PVC leaked permanently, on every scale-down.**

Beyond the storage cost this is a data-correctness risk. StatefulSet PVC names are ordinal-derived, so a later scale-up remounts the exact device the removed node wrote, and the init container only wipes volumes explicitly marked dirty — **an Aerospike node can rejoin the cluster carrying records the operator was told to destroy.**

## Fix

`reclaimOrphanedRackPVCs` replaces `cleanupOrphanedPVCsAfterScaleDown` and is called **once near the top of `reconcileStatefulSet`**, before any of the mutation logic, so it is reached on every pass whichever way the function returns — including the `!needsUpdate` early return where the retry used to die.

It is keyed on the StatefulSet's own **observed `spec.replicas`**, never on the replica delta and never on the desired `rackSize`. That distinction is the whole safety argument: during a batched scale-down, `rackSize <= targetReplicas <= spec.replicas`, and the ordinals between `rackSize` and `spec.replicas` still have **live pods holding their volumes**. Keying on `rackSize` would delete in-use PVCs.

Reclamation for the ordinals a patch just removed therefore happens on the *following* reconcile. That follow-up is guaranteed, not left to the 10-hour resync: patching `spec.replicas` bumps the StatefulSet generation, and the `ReadyReplicas` change as the pods go away is a second trigger — both are in the `Owns(&appsv1.StatefulSet{}, predicate.Or(GenerationChangedPredicate, statefulSetReadyReplicasPredicate))` watch. A batched scale-down reclaims incrementally: each pass reclaims the previous batch's ordinals at the top, then patches the next batch.

**Guards, cheapest first:**

| Guard | Why |
| --- | --- |
| No cascadeDelete PV-backed volume | Short-circuits before *either* List. `cascadeDelete` defaults to false, so this is the steady-state path for most clusters. New `storage.HasCascadeDeletePVCs` shares `cascadeDeleteVolumeNames` with the deleter, so the gate can never be looser than what the deleter actually selects. |
| `spec.replicas == nil` | Skips rather than treating nil as 0 — which would make **every** PVC in the rack an orphan candidate. |
| `spec.replicas < 1` | A rack at zero replicas is being torn down, not scaled down. Whole-rack PVC deletion belongs to the rack-removal / cluster-deletion path, which deletes by ownership rather than by ordinal. |
| Any observed pod at or above the replica count | That pod is still terminating and still mounting its volume. New `rackPodOrdinal` fails **closed** on an unparseable name — `podOrdinal` returns 0 there, which is fine for restart *ordering* but would read as "below the replica count, therefore not blocking deletion" in a destructive decision. |

Selection requires **all** of the following, and review of the first commit showed the original set was not sufficient:

| Requirement | Where |
| --- | --- |
| `ordinal >= sts.spec.replicas` | `ownedOrphanCandidates` |
| the operator's cluster labels, via a **strict** label-scoped List with no namespace-wide fallback | `ownedOrphanCandidates` |
| the volume name is one of the **live** StatefulSet's `VolumeClaimTemplates` | `ownedOrphanCandidates` |
| no **foreign** `ownerReference` — any refs present must include this StatefulSet's UID | `ownedByStatefulSetUID` |
| `cascadeDelete` resolves true for that volume | `DeleteOrphanedCascadeDeletePVCs` |
| `currentReplicas >= rackSize` — only a count the **operator** set may trigger reclamation | `reclaimOrphanedRackPVCs` |
| `sts.Status.ObservedGeneration == sts.Generation` and `sts.Status.Replicas == *sts.Spec.Replicas` | `reclaimOrphanedRackPVCs` |
| `len(rackPods) == sts.spec.replicas`, and every pod ordinal below it — secondary | `reclaimOrphanedRackPVCs` |

**Independent verification found two HIGH regressions in the first two commits; both are fixed and both are now regression-tested.**

**The placement made reclamation fire for scale-downs the operator never performed.** Because the call sits above the `needsUpdate`/scale-up logic, *any* external write that lowered `sts.spec.replicas` — `kubectl scale sts`, an HPA aimed at the StatefulSet instead of the CR, GitOps drift, a Velero restore — caused the operator to delete the volumes of every ordinal above that count and then scale the rack back up onto blank devices **on the same pass**. `isMigrationInProgress` never runs on this path because it sits under `if scaleDown`. Pre-PR the situation was self-healing. Reachability is raised by two separately-filed findings: `aerospikeclusters/scale` is missing from the webhook rules (#353) so `kubectl scale` bypasses admission, and #343 has the scale subresource publishing the ready-pod count as the replica count, which invites pointing an HPA at the wrong object.

Fixed by passing `rackSize` in and skipping when `currentReplicas < rackSize`. **This reverses an earlier position of mine.** I argued against skipping reclamation on scale-up because a rapid down-then-up would remount old devices. That premise is right but the conclusion was wrong: reclamation also runs on every *converged* pass, so the scale-up pass is not the only chance to catch a stale volume. The residual gap is a scale-down immediately followed by a scale-up with **no reconcile converging in between** — narrow, and strictly better than letting an external write destroy live data.

**The pod gate was bypassable.** `len(rackPods) != spec.replicas` only catches a *wrong* count, so hiding pods until the count comes out right defeats it. This needs no attacker: the StatefulSet's `Selector` is `SelectorLabelsForCluster`, which carries **no rack label**, so `acko.io/rack` is not selector-enforced — and `podutil/pod.go:93`'s `maps.Copy(labels, cluster.Spec.PodSpec.Metadata.Labels)` lets user-supplied pod labels overwrite it. A lagging pod informer produces the same shape.

The load-bearing gate is now the StatefulSet's **own status**: `ObservedGeneration == Generation` and `Status.Replicas == Spec.Replicas`. kube-controller-manager computes `status.replicas` from the StatefulSet's own selector, counts terminating pods, and it arrives on the same object read as `spec.replicas`, so there is no cross-informer skew. The rack-label list is kept as a secondary check.

**A PVC with no `ownerReferences` is deliberately still eligible.** That is the normal shape, not an anomaly: the StatefulSet controller only stamps an ownerReference onto a `volumeClaimTemplate` PVC when `persistentVolumeClaimRetentionPolicy` is set to `Delete`, and this operator never sets that field — it defaults to `Retain`/`Retain`, documented upstream as "retained until manually deleted". Requiring an ownerReference would reclaim nothing at all on a default install and silently disable the fix. What the UID check buys is rejecting a claim that names some *other* owner.

Also refactored the duplicated `cascadeVolumes` map construction out of `DeleteOrphanedCascadeDeletePVCs` and `DeleteCascadeDeletePVCs` into `cascadeDeleteVolumeNames`, so the new gate and both deleters share one predicate.

Log levels moved to `V(1)` for the per-reconcile "checking" and "deferring" lines, since this now runs every pass; the "Deleted N PVCs" line and its Event stay at `Info` and still only fire when something was actually reclaimed.

## Verification

**The regression test fails with the old call site and passes with the new one.** I restored the pre-fix placement (cleanup only inside `if scaleDown`, after the patch) and re-ran:

```
=== WITHOUT the fix (old call site restored) ===
--- FAIL: TestReconcileStatefulSet_ReclaimsOrphanedPVCsOnConvergedPass (0.04s)
FAIL  .../internal/controller  0.678s

=== fix restored ===
ok    .../internal/controller  0.525s
```

That test drives the real `reconcileStatefulSet` with matching hashes and `spec.replicas == rackSize`, so it exercises exactly the `!needsUpdate` early return where the bug lived.

### Safety tests — every way a PVC must be rejected

16 test functions in `internal/controller/reconciler_pvc_reclaim_test.go` (`grep -c '^func Test'` → **16**), 30 `=== RUN` lines including subtests. Two assert an orphan IS reclaimed; the rest assert non-selection.

**Each new guard was falsified by mutation** — one guard removed at a time, confirming the matching test fails rather than passing vacuously:

| Mutation | Tests that fail |
| --- | --- |
| remove the `len(rackPods) == spec.replicas` gate | `DefersWhenPodsMissingRackLabel`, `NeverSelectsInUsePVC/no_pods_observed_defers…`, `NeverSelectsInUsePVC/fewer_pods_than_replicas_defers` |
| remove the `ownedByStatefulSetUID` check | `NeverSelectsForeignOwnedPVC` |
| restore `GetPVCsForStatefulSet`'s namespace-wide fallback | `NeverSelectsUnlabelledPVC` |
| remove the `VolumeClaimTemplates` name check | `NeverSelectsVolumeNotInStatefulSet` |

```
--- FAIL: TestReclaimOrphanedRackPVCs_NeverSelectsInUsePVC (0.04s)
    --- FAIL: /no_pods_observed_defers_rather_than_reclaiming (0.00s)
    --- FAIL: /fewer_pods_than_replicas_defers (0.00s)
--- FAIL: TestReclaimOrphanedRackPVCs_DefersWhenPodsMissingRackLabel (0.00s)
--- FAIL: TestReclaimOrphanedRackPVCs_NeverSelectsForeignOwnedPVC (0.03s)
--- FAIL: TestReclaimOrphanedRackPVCs_NeverSelectsUnlabelledPVC (0.03s)
--- FAIL: TestReclaimOrphanedRackPVCs_NeverSelectsVolumeNotInStatefulSet (0.03s)
```

Being precise about what the other tests do and do not prove:

- `NeverSelectsMalformedOrdinal` **passes on unmutated pre-existing code too** — a PVC whose trailing segment does not parse can never clear the ordinal bound anyway. It documents the invariant; it does not isolate a new guard.
- `SkipsWhenReplicaCountUnknown` and `SkipsAtZeroReplicas` pin guards added in the first commit.
- `NonCascadeVolumesIssueNoList` uses an `interceptor` List counter to prove the steady-state path issues **zero** List calls.
- `Idempotent` runs three passes and asserts exactly one Event.

The case that previously read `no pods observed still preserves ordinals below the replica count` asserted that ordinal 3 was reclaimed with **no pods observed at all**. That encoded a weaker contract than the code can safely offer, and is now `no pods observed defers rather than reclaiming`.

| Command | Result |
| --- | --- |
| `go build ./...` | exit 0, no output |
| `go vet ./...` | exit 0, no output |
| `gofmt -l .` | empty |
| `go test ./internal/controller/...` | `ok ... 0.603s` |
| `go test ./internal/storage/...` | `ok ... 1.084s` |
| `go test ./...` | all packages `ok` / no test files; zero failures |

`golangci-lint` was not run — `.custom-gcl.yml` requires a custom build with a `logcheck` plugin that is not available here. No kind/kubectl/docker commands were run and the e2e suite was not executed.

### Fixes from independent verification

| Finding | Fix | Falsifying mutation |
| --- | --- | --- |
| HIGH: external scale-down destroys data, then scales back up | skip when `currentReplicas < rackSize` | remove the guard → `DoesNotReclaimOnExternalScaleDown` and `DoesNotEatPreProvisionedScaleUpPVCs` fail |
| HIGH: pod gate bypassed by hidden pods | gate on `sts.Status.Replicas` | remove it → both `DefersWhenLivePodsAreInvisibleToRackQuery` subtests fail |
| (same) status not yet settled | gate on `ObservedGeneration` | remove it → `DefersUntilStatusCatchesUp` fails |
| MEDIUM: listing filtered 2 of 4 cluster labels | match all of `LabelsForCluster` | revert to 2 labels → `NeverSelectsPVCMissingComponentLabels` fails |
| LOW: foreign-owner drop was silent | log it at V(1) | n/a — visibility only |

The storage test fixture was under-specified in the same way as the listing (2 labels where the operator stamps 4) and now uses `LabelsForCluster`.

**Limit of this verification, stated plainly:** the `status.replicas` *semantics* are not exercised anywhere in this repo's test suite. `internal/controller/suite_test.go` builds an `envtest.Environment`, which runs kube-apiserver and etcd only — **kube-controller-manager never runs**, so no StatefulSet controller populates `status.replicas`. The tests here set the field directly, which verifies my guard logic but not Kubernetes' behaviour behind it. Only a real cluster (the Kind e2e suite) would cover that, and it was not run. The claim that `status.replicas` counts terminating pods and derives from the StatefulSet's own selector rests on the upstream contract, not on a test in this PR.

Left alone deliberately: the pre-existing namespace-wide fallback in `GetPVCsForStatefulSet`. The reclaim path cannot reach it and the other callers are unchanged by this PR; it is worth its own issue alongside #353.

## Risk

This is the riskiest of the three fixes in this batch — a wrong predicate deletes a live PVC — so the notes below are deliberately explicit about what protects what.

- **`ordinal >= sts.spec.replicas` is necessary but NOT sufficient on its own.** A PVC at or above `spec.replicas` is *not* guaranteed to be unmounted: during a scale-down the replica count drops before the removed pods terminate. An earlier draft of this description claimed otherwise; a reviewer built the counterexample. The converged-pod-set gate is what makes the bound safe, which is why it is listed as a requirement rather than a nicety. Passing `rackSize` instead of `spec.replicas` would be the dangerous version and is explicitly avoided.
- **Behaviour change: reclamation now happens for pre-existing leaks.** On upgrade, the first reconcile of a cluster that has leaked PVCs from past scale-downs will delete them. That is the intended fix, but it means an operator who was relying on the leak to keep old data (e.g. planning to scale back up and reuse it) loses it. Anyone in that position should set `cascadeDelete: false` before upgrading. Worth a release note.
- **Steady-state cost for cascadeDelete clusters:** one cached pod List plus one cached PVC List per rack per reconcile. Both are label-scoped on the reclaim path specifically — `ownedOrphanCandidates` does not use `GetPVCsForStatefulSet`, whose zero-result fallback re-lists the whole namespace unfiltered. Both are served from the informer cache, and PVC list/watch is already granted and already used by the scale-down and cluster-delete paths. Clusters without cascadeDelete pay nothing (test-enforced). I considered a durable "cleanup pending" marker to avoid the List entirely, but every option — a new status field, a StatefulSet annotation, in-memory state — is either a larger change than this fix warrants or loses the pending state on operator restart. Called out here rather than hidden.
- **Not covered: the freshly-created StatefulSet path.** `reconcileStatefulSet` returns at `:83` after creating a new StatefulSet, before the reclamation call. A rack whose StatefulSet was deleted and recreated at a smaller size can still have PVCs above the new replica count. That overlaps the separate rack-removal finding (#342) and was left out to keep this change focused.
- **Not covered: a rack at zero replicas.** Deliberately skipped, per the guard table above. If a rack legitimately sits at 0 replicas with its StatefulSet still present, its PVCs are not reclaimed here.
- **Deferred: a rack that reaches zero replicas leaks permanently.** `getRackSize` is `Size/numRacks`, so shrinking a 3-rack cluster to `size: 1` drives racks 1-2 to 0 replicas, where the `< 1` guard skips reclamation forever. Reclaiming from ordinal 0 is the whole-rack teardown decision and belongs with the rack-removal path, so it is not folded in here. Related and worth filing separately: `config/webhook/manifests.yaml` and the chart's `validatingwebhookconfiguration.yaml` list only `resources: [aerospikeclusters]`, **not** `aerospikeclusters/scale`, while the CRD declares `+kubebuilder:subresource:scale` (`aerospikecluster_types.go:606`) — so `kubectl scale asc/demo --replicas=1` bypasses admission validation entirely.
- **Not covered: `GetPVCsForStatefulSet`'s namespace-wide fallback itself.** It is untouched, and still name-substring-only, for the cluster-deletion and local-PVC paths that rely on it to find legacy pre-label PVCs. This PR only stops the *reclaim* path from using it.
- **Not covered: e2e.** There is no Kind test asserting orphaned PVCs are actually gone after a scale-down — `test/e2e/e2e_cluster_test.go` has zero PVC assertions. That gap is what let this defect survive; closing it is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


