### PR TITLE
fix(docs): correct nonexistent PVC label selector in troubleshooting guide

### DIFF
--- a/docs/content/operations/troubleshooting.md
+++ b/docs/content/operations/troubleshooting.md
@@ -13,7 +13,7 @@ Start with the symptom table, then use the focused checks below to find and fix 
 |---------|--------------|--------------|------------|
 | Phase = `Error` | `kubectl get asc <name> -o jsonpath='{.status.lastReconcileError}'` | Invalid config, image pull failure, insufficient resources | Fix based on error message and re-apply |
 | Phase = `WaitingForMigration` | `kubectl exec <pod> -- asinfo -v 'statistics' \| grep migrate` | Data migration in progress | Wait for completion (automatic) |
-| Stuck at `InProgress` | `kubectl get pvc -n <ns> -l aerospike.io/cr-name=<name>` | PVC Pending, ImagePull failure, scheduling failure | Check StorageClass, image, and resources |
+| Stuck at `InProgress` | `kubectl get pvc -n <ns> -l app.kubernetes.io/instance=<name>` | PVC Pending, ImagePull failure, scheduling failure | Check StorageClass, image, and resources |
 | `CircuitBreakerActive` event | `kubectl get asc <name> -o jsonpath='{.status.failedReconcileCount}'` | 10+ consecutive failures | Check `lastReconcileError`, fix root cause |
 | Pod `CrashLoopBackOff` | `kubectl logs <pod> -c aerospike-server --previous` | Config parsing error, out of memory | Check server logs and fix config |
 | Webhook rejects CR | Check `kubectl apply` error message | CE constraint violation | See [Validation Error Patterns](#validation-error-patterns) |
@@ -40,7 +40,7 @@ The cluster remains in the `InProgress` phase instead of moving to `Completed`.
 kubectl -n aerospike get asc <name> -o jsonpath='{.status.phase}{"\t"}{.status.phaseReason}'
 
 # Check for pending PVCs
-kubectl -n aerospike get pvc -l aerospike.io/cr-name=<name>
+kubectl -n aerospike get pvc -l app.kubernetes.io/instance=<name>
 
 # Check pod events for scheduling or pull errors
 kubectl -n aerospike describe pod <pod-name>
@@ -359,7 +359,7 @@ PersistentVolumeClaims remain in `Pending` state.
 
 ```bash
 # Check PVC status
-kubectl -n aerospike get pvc -l aerospike.io/cr-name=<name>
+kubectl -n aerospike get pvc -l app.kubernetes.io/instance=<name>
 
 # Check PVC events for details
 kubectl -n aerospike describe pvc <pvc-name>

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/operations/troubleshooting.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/operations/troubleshooting.md
@@ -13,7 +13,7 @@ title: 트러블슈팅
 |------|----------|------------|----------|
 | Phase = `Error` | `kubectl get asc <name> -o jsonpath='{.status.lastReconcileError}'` | 잘못된 설정, 이미지 풀 실패, 리소스 부족 | 에러 메시지 기반으로 수정 후 재적용 |
 | Phase = `WaitingForMigration` | `kubectl exec <pod> -- asinfo -v 'statistics' \| grep migrate` | 데이터 마이그레이션 진행 중 | 완료 대기 (자동 재시도) |
-| `InProgress`에서 멈춤 | `kubectl get pvc -n <ns> -l aerospike.io/cr-name=<name>` | PVC Pending, 이미지 풀 실패, 스케줄링 실패 | StorageClass/이미지/리소스 확인 |
+| `InProgress`에서 멈춤 | `kubectl get pvc -n <ns> -l app.kubernetes.io/instance=<name>` | PVC Pending, 이미지 풀 실패, 스케줄링 실패 | StorageClass/이미지/리소스 확인 |
 | `CircuitBreakerActive` 이벤트 | `kubectl get asc <name> -o jsonpath='{.status.failedReconcileCount}'` | 10회 이상 연속 실패 | `lastReconcileError` 확인 후 근본 원인 수정 |
 | Pod `CrashLoopBackOff` | `kubectl logs <pod> -c aerospike-server --previous` | 설정 파싱 오류, 메모리 부족 | 서버 로그 확인 후 설정 수정 |
 | Webhook이 CR 거부 | `kubectl apply` 에러 메시지 확인 | CE 제약 위반 | [검증 에러 패턴](#검증-에러-패턴) 참조 |
@@ -40,7 +40,7 @@ title: 트러블슈팅
 kubectl -n aerospike get asc <name> -o jsonpath='{.status.phase}{"\t"}{.status.phaseReason}'
 
 # Pending 상태의 PVC 확인
-kubectl -n aerospike get pvc -l aerospike.io/cr-name=<name>
+kubectl -n aerospike get pvc -l app.kubernetes.io/instance=<name>
 
 # 파드 이벤트에서 스케줄링/풀 에러 확인
 kubectl -n aerospike describe pod <pod-name>
@@ -338,7 +338,7 @@ PersistentVolumeClaim이 `Pending` 상태에 머무르는 경우입니다.
 
 ```bash
 # PVC 상태 확인
-kubectl -n aerospike get pvc -l aerospike.io/cr-name=<name>
+kubectl -n aerospike get pvc -l app.kubernetes.io/instance=<name>
 
 # PVC 이벤트 상세 확인
 kubectl -n aerospike describe pvc <pvc-name>


### PR DESCRIPTION
## Problem

The troubleshooting guide tells operators to find a cluster's PVCs with a label that does not exist, and never has:

```bash
kubectl get pvc -n <ns> -l aerospike.io/cr-name=<name>
```

Both halves are wrong. This project's custom label domain is `acko.io/`, not `aerospike.io/`, and there is no `cr-name` key in either domain.

**Doc side** — 6 sites, 3 per locale:

| File | Lines |
|---|---|
| `docs/content/operations/troubleshooting.md` | 16, 43, 362 |
| `docs/i18n/ko/docusaurus-plugin-content-docs/current/operations/troubleshooting.md` | 16, 43, 341 |

**Source side** — the labels we actually apply, `internal/utils/labels.go:7-17`:

```go
AppLabel       = "app.kubernetes.io/name"
InstanceLabel  = "app.kubernetes.io/instance"
ComponentLabel = "app.kubernetes.io/component"
ManagedByLabel = "app.kubernetes.io/managed-by"
RackLabel      = "acko.io/rack"

appName     = "aerospike-cluster"
managerName = "aerospike-ce-kubernetes-operator"
```

`SelectorLabelsForCluster` (`internal/utils/labels.go:31-36`) is the canonical per-cluster selector and returns exactly `app.kubernetes.io/name=aerospike-cluster` + `app.kubernetes.io/instance=<clusterName>`. It is what builds our own StatefulSet pod selector (`internal/podutil/pod.go:326`), and our own PVC lookup uses the same pair (`internal/storage/pvc.go:35-40`):

```go
client.MatchingLabels{
    "app.kubernetes.io/name":     "aerospike-cluster",
    "app.kubernetes.io/instance": clusterName,
},
```

Greps confirming the documented label is absent from code:

```
$ grep -rn 'cr-name' --include='*.go' .          # 0 hits
$ grep -rn 'aerospike\.io/' --include='*.go' .   # 0 hits (the CRD group is acko.io/v1alpha1)
```

Before this PR the only six occurrences anywhere in the repo were these doc lines.

**Why this is worse than a typo:** a `kubectl` label selector that matches nothing still **exits 0** and prints `No resources found`. All three sites sit in incident-time diagnosis paths — the "Stuck at `InProgress`" triage row and the "PVC Not Binding" section — so an operator following our guide during an outage concludes there are no PVCs when there are, and rules out the actual cause. We are telling our own operators to run a query that cannot return anything, at the worst possible moment.

## Fix

All six sites switched to `-l app.kubernetes.io/instance=<name>`. The instance label alone is sufficient and unambiguous within a namespace.

This is also consistent with the operator-log commands already in the same file, which select by label rather than name (`-l control-plane=controller-manager`, `troubleshooting.md:50`).

**Korean kept in sync:** the command text is byte-identical in both locales — the files differ only in surrounding prose — so the same substitution applies to both, and the diff is symmetric (3 lines each). No translated prose needed changing, because none of it described the label itself.

## Verification

Zero occurrences remain anywhere in the repo:

```
$ grep -rn 'cr-name' . --exclude-dir=.git | wc -l
0
```

All six sites now carry the real selector:

```
$ grep -rn 'app.kubernetes.io/instance=<name>' docs/
docs/content/operations/troubleshooting.md:16:| Stuck at `InProgress` | `kubectl get pvc -n <ns> -l app.kubernetes.io/instance=<name>` | ...
docs/content/operations/troubleshooting.md:43:kubectl -n aerospike get pvc -l app.kubernetes.io/instance=<name>
docs/content/operations/troubleshooting.md:362:kubectl -n aerospike get pvc -l app.kubernetes.io/instance=<name>
docs/i18n/ko/.../operations/troubleshooting.md:16:| `InProgress`에서 멈춤 | `kubectl get pvc -n <ns> -l app.kubernetes.io/instance=<name>` | ...
docs/i18n/ko/.../operations/troubleshooting.md:43:kubectl -n aerospike get pvc -l app.kubernetes.io/instance=<name>
docs/i18n/ko/.../operations/troubleshooting.md:341:kubectl -n aerospike get pvc -l app.kubernetes.io/instance=<name>
```

Diff is exactly 6 lines, evenly split across locales:

```
$ git diff --stat
 docs/content/operations/troubleshooting.md                | 6 +++---
 .../current/operations/troubleshooting.md                 | 6 +++---
 2 files changed, 6 insertions(+), 6 deletions(-)
```

**Not verified:** I did not run these commands against a live cluster — that needs a running operator and a bound PVC. The correctness argument is that the new selector is the one the operator's own `GetPVCsForStatefulSet` uses to find the very same PVCs, read directly from source.

## Risk

None to runtime — documentation only, no Go code, manifests, or chart templates touched.

One thing worth a reviewer's eye: `internal/storage/pvc.go:44-49` documents a fallback where, if the label-scoped query returns nothing, the operator re-lists all PVCs in the namespace to catch volumes created before these labels existed. So on a cluster upgraded from a pre-label version, the new documented selector could still miss legacy PVCs that the operator itself would find. That is a pre-existing gap rather than something this PR introduces — the old selector missed *everything* — but if you want, a follow-up could add a sentence pointing operators at the unlabelled fallback listing for legacy clusters.

## Related

These docs are the traced origin of the same wrong selector in the Claude Code skills — 12 sites there, fixed in aerospike-ce-ecosystem/aerospike-ce-ecosystem-plugins#99 and tracked by aerospike-ce-ecosystem/aerospike-ce-ecosystem-plugins#91. Not using a closing keyword, since that issue covers the skill-side sites rather than these.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
